### PR TITLE
feat: add phase 12.1 read-only contracts

### DIFF
--- a/.engram/phase-12-1-closeout.md
+++ b/.engram/phase-12-1-closeout.md
@@ -1,0 +1,25 @@
+# Phase 12.1 closeout — read-only contracts foundation
+
+## Resultado
+- Se añadieron contratos TypeScript compartidos para las superficies read-only de Phase 12: `dashboard/system`, `mugiwaras`, `memory`, `vault` y `healthcheck`.
+- Se expuso `RESOURCE_STATUSES` en `packages/contracts/src/resource.ts` y se deriva `ResourceStatus` de esa constante.
+- Se endureció `apps/api/src/shared/contracts.py::resource_response` para rechazar statuses no permitidos.
+- Se añadieron tests backend mínimos para el contrato de envelope/status.
+
+## Decisión técnica
+- Phase 12.1 queda estrictamente como foundation de contratos: no endpoints, no adapters reales, no lecturas de vault/memoria/host.
+- La validación de status se sitúa en el helper compartido backend para fallar temprano si un módulo futuro emite un envelope inválido.
+- Los contratos TypeScript mantienen snake_case para alinearse con el payload API/backend existente.
+
+## Verify ejecutado
+- RED: `PYTHONPATH=. pytest apps/api/tests/test_shared_contracts.py` falló antes de implementación por ausencia de `ALLOWED_RESOURCE_STATUSES`.
+- GREEN parcial: `PYTHONPATH=. pytest apps/api/tests/test_shared_contracts.py` pasó tras implementación.
+- Suite backend completa: `python -m py_compile apps/api/src/shared/contracts.py apps/api/tests/test_shared_contracts.py && PYTHONPATH=. pytest apps/api/tests` → 7 passed.
+- TypeScript contracts direct compile: `npx --prefix apps/web tsc --noEmit --strict --moduleResolution bundler --module esnext --target es2017 packages/contracts/src/resource.ts packages/contracts/src/read-models.ts` → OK.
+- Frontend typecheck: `npm --prefix apps/web run typecheck` → OK.
+- Frontend build: `npm --prefix apps/web run build` → OK.
+- Diff hygiene: `git diff --check` → OK.
+
+## Riesgos abiertos
+- Los contratos aún no están consumidos por endpoints no-`skills`; 12.2 debe elegir un primer vertical real sin ampliar superficie de escritura.
+- `ResourceStatus` backend sigue siendo un set manual paralelo al TypeScript; mantenerlos sincronizados si se añaden estados.

--- a/apps/api/src/shared/contracts.py
+++ b/apps/api/src/shared/contracts.py
@@ -1,9 +1,24 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Final
+
+ALLOWED_RESOURCE_STATUSES: Final[frozenset[str]] = frozenset(
+    {
+        'ready',
+        'empty',
+        'error',
+        'stale',
+        'forbidden',
+        'not_configured',
+        'validation_error',
+        'source_unavailable',
+    }
+)
 
 
 def resource_response(*, resource: str, status: str, data: Any, meta: dict[str, Any] | None = None) -> dict[str, Any]:
+    if status not in ALLOWED_RESOURCE_STATUSES:
+        raise ValueError(f'Unsupported resource status: {status}')
     return {
         'resource': resource,
         'status': status,

--- a/apps/api/tests/test_shared_contracts.py
+++ b/apps/api/tests/test_shared_contracts.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from apps.api.src.shared.contracts import ALLOWED_RESOURCE_STATUSES, resource_response
+
+
+def test_resource_response_accepts_allowed_statuses() -> None:
+    payload = resource_response(
+        resource='mugiwaras.catalog',
+        status='ready',
+        data={'items': []},
+        meta={'count': 0},
+    )
+
+    assert payload == {
+        'resource': 'mugiwaras.catalog',
+        'status': 'ready',
+        'data': {'items': []},
+        'meta': {'count': 0},
+    }
+    assert 'source_unavailable' in ALLOWED_RESOURCE_STATUSES
+
+
+def test_resource_response_rejects_unknown_status() -> None:
+    with pytest.raises(ValueError, match='Unsupported resource status'):
+        resource_response(resource='dashboard.summary', status='loading', data={}, meta={})

--- a/openspec/phase-12-1-readonly-contracts-foundation.md
+++ b/openspec/phase-12-1-readonly-contracts-foundation.md
@@ -1,0 +1,35 @@
+# Phase 12.1 — read-only contracts foundation
+
+## Scope
+Establish the shared contract foundation for the Phase 12 read-only backend integration block without introducing module endpoints or host/filesystem access.
+
+## SDD summary
+### Explore
+- Existing shared TypeScript contracts live in `packages/contracts/src`, currently only `resource.ts` and `skills.ts`.
+- Backend responses already use `apps/api/src/shared/contracts.py::resource_response` but the helper did not expose or validate the allowed status set.
+- `docs/read-models.md` already defines conceptual read models for `dashboard.summary`, `healthcheck.summary[]`, `memory.agent_summary`, `memory.agent_detail`, `vault.index`, `vault.document`, `mugiwara.card` and `mugiwara.profile`.
+
+### Decision
+- Keep Phase 12.1 contract-only: no new module routers and no filesystem/host adapters.
+- Add a single TypeScript contract module, `packages/contracts/src/read-models.ts`, for the non-`skills` read-only MVP surfaces.
+- Export `RESOURCE_STATUSES` from `resource.ts` so runtime/client code can share the same allowed status vocabulary as the type.
+- Add backend validation to `resource_response` so unknown backend statuses fail early instead of silently creating invalid envelopes.
+
+### Tasks
+- [x] Add tests for backend envelope status conventions.
+- [x] Add allowed status validation to backend shared contracts.
+- [x] Add read-only TypeScript contracts for dashboard/system, mugiwaras, memory, vault and healthcheck.
+- [x] Keep implementation endpoint-free and filesystem-free.
+- [x] Record verify evidence and closeout artifacts.
+
+## Definition of done
+- Contract types exist for all Phase 12 read-only MVP surface families.
+- Backend helper validates the same resource status vocabulary used by TypeScript contracts.
+- No real endpoints, filesystem reads, vault reads or host checks are introduced.
+- `docs/read-models.md` remains compatible with the implemented contract names and fields.
+
+## Files changed
+- `packages/contracts/src/resource.ts` — exported `RESOURCE_STATUSES` and derived `ResourceStatus` from the constant.
+- `packages/contracts/src/read-models.ts` — added read-only MVP contracts and response envelope aliases.
+- `apps/api/src/shared/contracts.py` — added allowed status set and validation in `resource_response`.
+- `apps/api/tests/test_shared_contracts.py` — added tests for accepted/rejected envelope statuses.

--- a/openspec/phase-12-1-verify-checklist.md
+++ b/openspec/phase-12-1-verify-checklist.md
@@ -1,0 +1,13 @@
+# Phase 12.1 verify checklist
+
+- [x] SDD attempted through OpenCode with `sdd-orchestrator-zoro`.
+- [x] OpenCode headless stalled during lightweight init/explore with no worktree changes; phase recovered inline using local SDD skills and TDD discipline.
+- [x] RED observed: `PYTHONPATH=. pytest apps/api/tests/test_shared_contracts.py` failed before implementation because `ALLOWED_RESOURCE_STATUSES` did not exist.
+- [x] GREEN observed: `PYTHONPATH=. pytest apps/api/tests/test_shared_contracts.py` passed after implementation.
+- [x] No new API endpoints introduced.
+- [x] No filesystem/vault/host access introduced.
+- [x] Full backend test suite: `python -m py_compile apps/api/src/shared/contracts.py apps/api/tests/test_shared_contracts.py && PYTHONPATH=. pytest apps/api/tests`.
+- [x] TypeScript contracts compile directly: `npx --prefix apps/web tsc --noEmit --strict --moduleResolution bundler --module esnext --target es2017 packages/contracts/src/resource.ts packages/contracts/src/read-models.ts`.
+- [x] `npm --prefix apps/web run typecheck`.
+- [x] `npm --prefix apps/web run build`.
+- [x] `git diff --check`.

--- a/packages/contracts/src/read-models.ts
+++ b/packages/contracts/src/read-models.ts
@@ -1,0 +1,116 @@
+import type { ResourceEnvelope } from './resource'
+
+export type Freshness = {
+  status: 'fresh' | 'stale' | 'unknown'
+  updated_at: string | null
+  source_label?: string
+}
+
+export type SafeLink = {
+  label: string
+  href: string
+}
+
+export type Severity = 'operativo' | 'revision' | 'incidencia' | 'stale' | 'sin-datos'
+
+export type DashboardSection = {
+  section_id: string
+  label: string
+  status: Severity
+  summary: string
+  href?: string
+}
+
+export type DashboardSummary = {
+  sections: DashboardSection[]
+  highest_severity: Severity
+  freshness: Freshness
+  counts: Record<string, number>
+  links: SafeLink[]
+}
+
+export type MugiwaraCard = {
+  slug: string
+  name: string
+  status: Severity
+  skills: string[]
+  memory_badge: string
+  links: SafeLink[]
+}
+
+export type MugiwaraProfile = {
+  slug: string
+  identity: {
+    name: string
+    role: string
+    crest_src: string
+    accent_color: string
+  }
+  status: Severity
+  allowed_metadata: Record<string, string | number | boolean | null>
+  linked_skills: string[]
+  memory_summary: string
+}
+
+export type MemoryAgentSummary = {
+  mugiwara_slug: string
+  summary: string
+  fact_count: number
+  last_updated: string | null
+  badges: string[]
+}
+
+export type MemoryAgentDetail = {
+  mugiwara_slug: string
+  built_in_summary: string
+  honcho_facts: string[]
+  freshness: Freshness
+  links: SafeLink[]
+}
+
+export type VaultIndex = {
+  path: string
+  entries: Array<{
+    name: string
+    path: string
+    kind: 'directory' | 'document'
+  }>
+  breadcrumbs: SafeLink[]
+  freshness: Freshness
+}
+
+export type VaultDocument = {
+  path: string
+  title: string
+  markdown: string
+  updated_at: string | null
+  breadcrumbs: SafeLink[]
+}
+
+export type HealthcheckSummary = {
+  check_id: string
+  label: string
+  severity: Severity
+  status: string
+  freshness: Freshness
+  warning_text: string | null
+  source_label: string
+}
+
+export type SystemSignal = {
+  signal_id: string
+  label: string
+  status: Severity
+  summary: string
+  freshness: Freshness
+}
+
+export type DashboardSummaryResponse = ResourceEnvelope<DashboardSummary, { links_count: number }>
+export type MugiwarasCatalogResponse = ResourceEnvelope<{ items: MugiwaraCard[] }, { count: number }>
+export type MugiwaraProfileResponse = ResourceEnvelope<MugiwaraProfile, { slug: string }>
+export type MemorySummaryResponse = ResourceEnvelope<{ items: MemoryAgentSummary[] }, { count: number; sources: string[] }>
+export type MemoryDetailResponse = ResourceEnvelope<MemoryAgentDetail, { mugiwara_slug: string; read_only: true }>
+export type VaultIndexResponse = ResourceEnvelope<VaultIndex, { safe_root: string }>
+export type VaultDocumentResponse = ResourceEnvelope<VaultDocument, { path: string; markdown_only: true }>
+export type HealthcheckSummaryResponse = ResourceEnvelope<{ items: HealthcheckSummary[] }, { count: number }>
+export type SystemSignalsResponse = ResourceEnvelope<{ items: SystemSignal[] }, { count: number }>

--- a/packages/contracts/src/resource.ts
+++ b/packages/contracts/src/resource.ts
@@ -1,4 +1,15 @@
-export type ResourceStatus = 'ready' | 'empty' | 'error' | 'stale' | 'forbidden' | 'not_configured' | 'validation_error' | 'source_unavailable'
+export const RESOURCE_STATUSES = [
+  'ready',
+  'empty',
+  'error',
+  'stale',
+  'forbidden',
+  'not_configured',
+  'validation_error',
+  'source_unavailable',
+] as const
+
+export type ResourceStatus = typeof RESOURCE_STATUSES[number]
 
 export type ResourceEnvelope<TData, TMeta = Record<string, unknown>> = {
   resource: string


### PR DESCRIPTION
## Summary
- Add shared TypeScript read-only contracts for Phase 12 surfaces: dashboard/system, mugiwaras, memory, vault and healthcheck.
- Export canonical resource statuses from TypeScript contracts.
- Add backend envelope status validation and tests.
- Record Phase 12.1 SDD/verify closeout artifacts.

## Verification
- python -m py_compile apps/api/src/shared/contracts.py apps/api/tests/test_shared_contracts.py
- PYTHONPATH=. pytest apps/api/tests
- npx --prefix apps/web tsc --noEmit --strict --moduleResolution bundler --module esnext --target es2017 packages/contracts/src/resource.ts packages/contracts/src/read-models.ts
- npm --prefix apps/web run typecheck
- npm --prefix apps/web run build
- git diff --check

## Review note
Opened by Zoro for self-review under shared Mugiwara GitHub account. Formal approval may be unavailable because the same GitHub actor opened the PR.