### PR TITLE
feat: add mugiwaras AGENTS read-only phase 12.2

### DIFF
--- a/.engram/2026-04-24-franky-handoff-agents-md-crew-core-readonly.md
+++ b/.engram/2026-04-24-franky-handoff-agents-md-crew-core-readonly.md
@@ -1,0 +1,34 @@
+# Franky -> Zoro handoff — crew-core AGENTS.md en panel Mugiwara
+
+Fecha: 2026-04-24
+Agente origen: Franky
+Agente destino: Zoro
+
+## Decisión de Pablo
+
+En el panel Mugiwara Hermes, la página de Mugiwara debe mostrar el `AGENTS.md` canónico de crew-core en modo solo lectura.
+
+Fuente canónica:
+
+```text
+/srv/crew-core/AGENTS.md
+```
+
+## Contexto operativo
+
+- `/home/agentops/.hermes/hermes-agent/AGENTS.md` ya no debe tratarse como documento independiente.
+- Esa ruta es ahora un symlink a `/srv/crew-core/AGENTS.md`.
+- El panel debe mostrar solo la fuente canónica de crew-core para evitar duplicidad/confusión.
+
+## Requisito para implementación
+
+En la página/sección de Mugiwara del `mugiwara-control-panel`:
+
+- Añadir acceso de lectura a `/srv/crew-core/AGENTS.md`.
+- Mostrarlo como documento canónico de reglas operativas Mugiwara.
+- Solo lectura: sin edición desde el panel en esta fase.
+- No listar por separado el symlink de Hermes Agent.
+
+## Riesgo a evitar
+
+No presentar `hermes-agent/AGENTS.md` y `crew-core/AGENTS.md` como dos fuentes distintas, porque ahora representan el mismo canon y una duplicidad en UI confundirá a humanos/agentes.

--- a/.engram/phase-12-2-closeout.md
+++ b/.engram/phase-12-2-closeout.md
@@ -14,7 +14,7 @@
 ## Verify ejecutado
 - RED: `PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py` falló antes de implementación por ausencia del módulo `mugiwaras`.
 - GREEN inicial: `PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py` → 3 passed.
-- Suite backend actual: `python -m py_compile apps/api/src/modules/mugiwaras/domain.py apps/api/src/modules/mugiwaras/service.py apps/api/src/modules/mugiwaras/router.py apps/api/src/main.py && PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py` → 10 passed.
+- Suite backend actual: `python -m py_compile apps/api/src/modules/mugiwaras/domain.py apps/api/src/modules/mugiwaras/service.py apps/api/src/modules/mugiwaras/router.py apps/api/src/main.py && PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py` → 11 passed.
 - Frontend typecheck: `npm --prefix apps/web run typecheck` → OK.
 - Frontend build: `npm --prefix apps/web run build` → OK.
 - Diff hygiene: `git diff --check` → OK.
@@ -23,4 +23,5 @@
 
 ## Riesgos abiertos
 - La lectura de `/srv/crew-core/AGENTS.md` es una lectura fija allowlisted; futuras lecturas de documentos no deben reutilizar este patrón como filesystem browser.
+- Si el API deja de estar limitado al control plane privado, servir markdown completo de AGENTS.md debe quedar detrás de auth/permisos explícitos.
 - La página queda dinámica para poder leer API en runtime cuando `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` está configurada.

--- a/.engram/phase-12-2-closeout.md
+++ b/.engram/phase-12-2-closeout.md
@@ -1,0 +1,26 @@
+# Phase 12.2 closeout — mugiwaras AGENTS read-only
+
+## Resultado
+- `/mugiwaras` pasa a ser el primer vertical read-only no-`skills` respaldado por API.
+- Se añade módulo backend `mugiwaras` con catálogo y perfil por slug.
+- El catálogo incluye `crew_rules_document`, leído únicamente desde `/srv/crew-core/AGENTS.md` y marcado como canónico/solo lectura.
+- La UI de `/mugiwaras` muestra el documento canónico cuando la API está configurada; si no, mantiene fixture saneado sin mostrar contenido AGENTS.
+
+## Decisión técnica
+- El requisito de AGENTS.md se implementa en Phase 12.2 porque pertenece a la sección Mugiwara y aprovecha la nueva frontera backend read-only.
+- No se crea endpoint genérico de documentos ni navegación filesystem.
+- No se lista `/home/agentops/.hermes/hermes-agent/AGENTS.md`; además el servicio rechaza fuentes symlink en tests para evitar duplicidad conceptual.
+
+## Verify ejecutado
+- RED: `PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py` falló antes de implementación por ausencia del módulo `mugiwaras`.
+- GREEN inicial: `PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py` → 3 passed.
+- Suite backend actual: `python -m py_compile apps/api/src/modules/mugiwaras/domain.py apps/api/src/modules/mugiwaras/service.py apps/api/src/modules/mugiwaras/router.py apps/api/src/main.py && PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py` → 10 passed.
+- Frontend typecheck: `npm --prefix apps/web run typecheck` → OK.
+- Frontend build: `npm --prefix apps/web run build` → OK.
+- Diff hygiene: `git diff --check` → OK.
+- Smoke API: `/api/v1/mugiwaras` devolvió `mugiwaras.catalog`, 10 items y `crew_rules_document.display_path == /srv/crew-core/AGENTS.md`.
+- Smoke web: `/mugiwaras` renderizó `AGENTS.md — reglas operativas Mugiwara`, incluyó `/srv/crew-core/AGENTS.md` y no incluyó `/home/agentops/.hermes/hermes-agent/AGENTS.md`.
+
+## Riesgos abiertos
+- La lectura de `/srv/crew-core/AGENTS.md` es una lectura fija allowlisted; futuras lecturas de documentos no deben reutilizar este patrón como filesystem browser.
+- La página queda dinámica para poder leer API en runtime cuando `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` está configurada.

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -1,9 +1,11 @@
 from fastapi import FastAPI
 
 from .modules.skills.router import router as skills_router
+from .modules.mugiwaras.router import router as mugiwaras_router
 
 app = FastAPI(title='Mugiwara Control Panel API')
 app.include_router(skills_router)
+app.include_router(mugiwaras_router)
 
 
 @app.get('/health')

--- a/apps/api/src/modules/mugiwaras/AGENTS.md
+++ b/apps/api/src/modules/mugiwaras/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md — apps/api/src/modules/mugiwaras
+
+## Rol
+Módulo backend read-only de la sección Mugiwara.
+
+## Reglas
+- Exponer solo metadatos saneados y allowlisted de la tripulación.
+- Mostrar el canon operativo desde `/srv/crew-core/AGENTS.md` como documento de solo lectura.
+- No listar ni resolver por separado `/home/agentops/.hermes/hermes-agent/AGENTS.md`, porque es symlink al canon.
+- No aceptar paths desde cliente ni abrir navegación arbitraria de filesystem.
+- Mantener errores semánticos sin filtrar rutas reales no permitidas.

--- a/apps/api/src/modules/mugiwaras/domain.py
+++ b/apps/api/src/modules/mugiwaras/domain.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SafeLink:
+    label: str
+    href: str
+
+
+@dataclass(frozen=True)
+class MugiwaraCard:
+    slug: str
+    name: str
+    status: str
+    skills: list[str]
+    memory_badge: str
+    links: list[SafeLink]
+
+
+@dataclass(frozen=True)
+class MugiwaraIdentity:
+    name: str
+    role: str
+    crest_src: str
+    accent_color: str
+
+
+@dataclass(frozen=True)
+class MugiwaraProfile:
+    slug: str
+    identity: MugiwaraIdentity
+    status: str
+    allowed_metadata: dict[str, str | int | bool | None]
+    linked_skills: list[str]
+    memory_summary: str
+
+
+@dataclass(frozen=True)
+class CrewRulesDocument:
+    document_id: str
+    title: str
+    display_path: str
+    source_label: str
+    read_only: bool
+    canonical: bool
+    markdown: str

--- a/apps/api/src/modules/mugiwaras/router.py
+++ b/apps/api/src/modules/mugiwaras/router.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from fastapi import APIRouter, Depends
+
+from ...shared.contracts import resource_response
+from .service import CANONICAL_CREW_RULES_DISPLAY_PATH, MugiwaraService
+
+router = APIRouter(prefix='/api/v1/mugiwaras', tags=['mugiwaras'])
+_service = MugiwaraService()
+
+
+def get_mugiwaras_service() -> MugiwaraService:
+    return _service
+
+
+@router.get('')
+def list_mugiwaras(service: MugiwaraService = Depends(get_mugiwaras_service)) -> dict:
+    catalog = service.list_catalog()
+    items = catalog['items']
+    return resource_response(
+        resource='mugiwaras.catalog',
+        status='ready',
+        data=catalog,
+        meta={
+            'count': len(items),
+            'crew_rules_document': CANONICAL_CREW_RULES_DISPLAY_PATH,
+            'read_only': True,
+        },
+    )
+
+
+@router.get('/{slug}')
+def get_mugiwara_profile(slug: str, service: MugiwaraService = Depends(get_mugiwaras_service)) -> dict:
+    profile = service.get_profile(slug)
+    return resource_response(
+        resource='mugiwaras.profile',
+        status='ready',
+        data=asdict(profile),
+        meta={'slug': slug, 'read_only': True},
+    )

--- a/apps/api/src/modules/mugiwaras/service.py
+++ b/apps/api/src/modules/mugiwaras/service.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+
+from fastapi import HTTPException, status
+
+from .domain import CrewRulesDocument, MugiwaraCard, MugiwaraIdentity, MugiwaraProfile, SafeLink
+
+MAX_CREW_RULES_BYTES = 200_000
+DEFAULT_CREW_RULES_PATH = Path('/srv/crew-core/AGENTS.md')
+CANONICAL_CREW_RULES_DISPLAY_PATH = '/srv/crew-core/AGENTS.md'
+
+CREW_CARDS: tuple[MugiwaraCard, ...] = (
+    MugiwaraCard('luffy', 'Luffy', 'operativo', ['delegation-contract', 'crew-orchestration'], 'Capitán operativo', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
+    MugiwaraCard('zoro', 'Zoro', 'operativo', ['sdd-orchestrator-zoro', 'zoro-pr-review-handoff'], 'Continuidad fuerte', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
+    MugiwaraCard('franky', 'Franky', 'operativo', ['franky-pr-ops-review', 'vault-sync-ops'], 'Runtime vigilado', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
+    MugiwaraCard('chopper', 'Chopper', 'operativo', ['chopper-pr-security-review', 'security-hardening'], 'Riesgo controlado', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
+    MugiwaraCard('usopp', 'Usopp', 'revision', ['usopp-pr-design-review', 'frontend-spec-usopp'], 'Diseño activo', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
+    MugiwaraCard('nami', 'Nami', 'operativo', ['finance-ops', 'google-sheets-control'], 'Señales estables', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
+    MugiwaraCard('robin', 'Robin', 'operativo', ['research-synthesis', 'vault-canon'], 'Canon consultable', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
+    MugiwaraCard('brook', 'Brook', 'revision', ['data-analysis', 'analytics-standby'], 'Datos en standby', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
+    MugiwaraCard('jinbe', 'Jinbe', 'sin-datos', ['legal-context'], 'Definido en canon', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
+    MugiwaraCard('sanji', 'Sanji', 'sin-datos', ['physical-ops'], 'Definido en canon', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
+)
+
+PROFILE_META: dict[str, dict[str, str]] = {
+    'luffy': {'role': 'CEO y orquestador principal', 'accent_color': '#dc2626'},
+    'zoro': {'role': 'CTO e ingeniero de software', 'accent_color': '#16a34a'},
+    'franky': {'role': 'DevOps e ingeniero de sistemas', 'accent_color': '#0284c7'},
+    'chopper': {'role': 'CISO y experto en ciberseguridad', 'accent_color': '#db2777'},
+    'usopp': {'role': 'CMO y director de marketing/diseño', 'accent_color': '#ca8a04'},
+    'nami': {'role': 'CFO y directora financiera', 'accent_color': '#f97316'},
+    'robin': {'role': 'Directora de research e inteligencia', 'accent_color': '#7c3aed'},
+    'brook': {'role': 'CDO y data scientist', 'accent_color': '#64748b'},
+    'jinbe': {'role': 'CLO y asesor legal', 'accent_color': '#2563eb'},
+    'sanji': {'role': 'COO físico y concierge personal', 'accent_color': '#eab308'},
+}
+
+
+class MugiwaraService:
+    def __init__(self, *, crew_rules_path: Path = DEFAULT_CREW_RULES_PATH) -> None:
+        self._crew_rules_path = crew_rules_path
+        self._cards = {card.slug: card for card in CREW_CARDS}
+
+    def list_catalog(self) -> dict:
+        document = self.get_crew_rules_document()
+        return {
+            'items': [asdict(card) for card in self._cards.values()],
+            'crew_rules_document': asdict(document),
+        }
+
+    def get_profile(self, slug: str) -> MugiwaraProfile:
+        card = self._cards.get(slug)
+        if card is None:
+            raise self._reject(status.HTTP_404_NOT_FOUND, 'not_found', 'Mugiwara no configurado en catálogo read-only.')
+
+        meta = PROFILE_META.get(slug, {'role': 'Mugiwara', 'accent_color': '#94a3b8'})
+        return MugiwaraProfile(
+            slug=card.slug,
+            identity=MugiwaraIdentity(
+                name=card.name,
+                role=meta['role'],
+                crest_src=f'/assets/mugiwaras/crests/{card.slug}.svg',
+                accent_color=meta['accent_color'],
+            ),
+            status=card.status,
+            allowed_metadata={
+                'read_only': True,
+                'source': 'backend_static_allowlist',
+                'skills_count': len(card.skills),
+            },
+            linked_skills=card.skills,
+            memory_summary=card.memory_badge,
+        )
+
+    def get_crew_rules_document(self) -> CrewRulesDocument:
+        content = self._read_canonical_crew_rules()
+        return CrewRulesDocument(
+            document_id='crew-core-agents',
+            title='AGENTS.md — reglas operativas Mugiwara',
+            display_path=CANONICAL_CREW_RULES_DISPLAY_PATH,
+            source_label='crew-core canonical AGENTS.md',
+            read_only=True,
+            canonical=True,
+            markdown=content,
+        )
+
+    def _read_canonical_crew_rules(self) -> str:
+        if self._crew_rules_path.is_symlink():
+            raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'source_unavailable', 'La fuente canónica debe leerse directamente, no vía symlink.')
+
+        resolved = self._crew_rules_path.expanduser().resolve()
+        canonical = DEFAULT_CREW_RULES_PATH.resolve()
+        if self._crew_rules_path == DEFAULT_CREW_RULES_PATH and resolved != canonical:
+            raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'source_unavailable', 'AGENTS.md canónico no disponible.')
+
+        if not resolved.exists() or not resolved.is_file():
+            raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'source_unavailable', 'AGENTS.md canónico no disponible.')
+
+        content = resolved.read_text(encoding='utf-8')
+        if len(content.encode('utf-8')) > MAX_CREW_RULES_BYTES:
+            raise self._reject(status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, 'validation_error', 'AGENTS.md supera el tamaño máximo permitido.')
+        return content
+
+    def _reject(self, http_status: int, code: str, message: str) -> HTTPException:
+        return HTTPException(status_code=http_status, detail={'code': code, 'message': message})

--- a/apps/api/src/modules/mugiwaras/service.py
+++ b/apps/api/src/modules/mugiwaras/service.py
@@ -12,16 +12,16 @@ DEFAULT_CREW_RULES_PATH = Path('/srv/crew-core/AGENTS.md')
 CANONICAL_CREW_RULES_DISPLAY_PATH = '/srv/crew-core/AGENTS.md'
 
 CREW_CARDS: tuple[MugiwaraCard, ...] = (
-    MugiwaraCard('luffy', 'Luffy', 'operativo', ['delegation-contract', 'crew-orchestration'], 'Capitán operativo', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
-    MugiwaraCard('zoro', 'Zoro', 'operativo', ['sdd-orchestrator-zoro', 'zoro-pr-review-handoff'], 'Continuidad fuerte', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
-    MugiwaraCard('franky', 'Franky', 'operativo', ['franky-pr-ops-review', 'vault-sync-ops'], 'Runtime vigilado', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
-    MugiwaraCard('chopper', 'Chopper', 'operativo', ['chopper-pr-security-review', 'security-hardening'], 'Riesgo controlado', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
-    MugiwaraCard('usopp', 'Usopp', 'revision', ['usopp-pr-design-review', 'frontend-spec-usopp'], 'Diseño activo', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
-    MugiwaraCard('nami', 'Nami', 'operativo', ['finance-ops', 'google-sheets-control'], 'Señales estables', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
-    MugiwaraCard('robin', 'Robin', 'operativo', ['research-synthesis', 'vault-canon'], 'Canon consultable', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
-    MugiwaraCard('brook', 'Brook', 'revision', ['data-analysis', 'analytics-standby'], 'Datos en standby', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
-    MugiwaraCard('jinbe', 'Jinbe', 'sin-datos', ['legal-context'], 'Definido en canon', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
-    MugiwaraCard('sanji', 'Sanji', 'sin-datos', ['physical-ops'], 'Definido en canon', [SafeLink('Abrir Memory', '/memory'), SafeLink('Abrir Skills', '/skills')]),
+    MugiwaraCard('luffy', 'Luffy', 'operativo', ['delegation-contract', 'crew-orchestration'], 'Capitán operativo', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
+    MugiwaraCard('zoro', 'Zoro', 'operativo', ['sdd-orchestrator-zoro', 'zoro-pr-review-handoff'], 'Continuidad fuerte', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
+    MugiwaraCard('franky', 'Franky', 'operativo', ['franky-pr-ops-review', 'vault-sync-ops'], 'Runtime vigilado', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
+    MugiwaraCard('chopper', 'Chopper', 'operativo', ['chopper-pr-security-review', 'security-hardening'], 'Riesgo controlado', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
+    MugiwaraCard('usopp', 'Usopp', 'revision', ['usopp-pr-design-review', 'frontend-spec-usopp'], 'Diseño activo', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
+    MugiwaraCard('nami', 'Nami', 'operativo', ['finance-ops', 'google-sheets-control'], 'Señales estables', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
+    MugiwaraCard('robin', 'Robin', 'operativo', ['research-synthesis', 'vault-canon'], 'Canon consultable', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
+    MugiwaraCard('brook', 'Brook', 'revision', ['data-analysis', 'analytics-standby'], 'Datos en standby', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
+    MugiwaraCard('jinbe', 'Jinbe', 'sin-datos', ['legal-context'], 'Definido en canon', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
+    MugiwaraCard('sanji', 'Sanji', 'sin-datos', ['physical-ops'], 'Definido en canon', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
 )
 
 PROFILE_META: dict[str, dict[str, str]] = {
@@ -87,14 +87,9 @@ class MugiwaraService:
         )
 
     def _read_canonical_crew_rules(self) -> str:
-        if self._crew_rules_path.is_symlink():
-            raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'source_unavailable', 'La fuente canónica debe leerse directamente, no vía symlink.')
+        self._ensure_no_symlink_component(self._crew_rules_path)
 
         resolved = self._crew_rules_path.expanduser().resolve()
-        canonical = DEFAULT_CREW_RULES_PATH.resolve()
-        if self._crew_rules_path == DEFAULT_CREW_RULES_PATH and resolved != canonical:
-            raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'source_unavailable', 'AGENTS.md canónico no disponible.')
-
         if not resolved.exists() or not resolved.is_file():
             raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'source_unavailable', 'AGENTS.md canónico no disponible.')
 
@@ -102,6 +97,18 @@ class MugiwaraService:
         if len(content.encode('utf-8')) > MAX_CREW_RULES_BYTES:
             raise self._reject(status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, 'validation_error', 'AGENTS.md supera el tamaño máximo permitido.')
         return content
+
+    def _ensure_no_symlink_component(self, path: Path) -> None:
+        expanded = path.expanduser()
+        candidates = [expanded, *expanded.parents]
+        for candidate in candidates:
+            if candidate == candidate.parent:
+                continue
+            try:
+                if candidate.is_symlink():
+                    raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'source_unavailable', 'La fuente canónica debe leerse directamente, no vía symlink.')
+            except OSError:
+                raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'source_unavailable', 'AGENTS.md canónico no disponible.')
 
     def _reject(self, http_status: int, code: str, message: str) -> HTTPException:
         return HTTPException(status_code=http_status, detail={'code': code, 'message': message})

--- a/apps/api/tests/test_mugiwaras_api.py
+++ b/apps/api/tests/test_mugiwaras_api.py
@@ -84,3 +84,25 @@ def test_mugiwaras_catalog_does_not_follow_hermes_agents_symlink(tmp_path: Path)
     assert str(hermes_agents) not in response.text
 
     app.dependency_overrides.clear()
+
+
+def test_mugiwaras_catalog_rejects_parent_directory_symlink(tmp_path: Path) -> None:
+    real_root = tmp_path / 'real-crew-core'
+    real_root.mkdir()
+    (real_root / 'AGENTS.md').write_text('canonical through parent symlink', encoding='utf-8')
+
+    symlink_root = tmp_path / 'crew-core-link'
+    symlink_root.symlink_to(real_root, target_is_directory=True)
+
+    service = MugiwaraService(crew_rules_path=symlink_root / 'AGENTS.md')
+    app.dependency_overrides[get_mugiwaras_service] = lambda: service
+    client = TestClient(app)
+
+    response = client.get('/api/v1/mugiwaras')
+
+    assert response.status_code == 503
+    assert response.json()['detail']['code'] == 'source_unavailable'
+    assert str(symlink_root) not in response.text
+    assert str(real_root) not in response.text
+
+    app.dependency_overrides.clear()

--- a/apps/api/tests/test_mugiwaras_api.py
+++ b/apps/api/tests/test_mugiwaras_api.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from apps.api.src.main import app
+from apps.api.src.modules.mugiwaras.router import get_mugiwaras_service
+from apps.api.src.modules.mugiwaras.service import MugiwaraService
+
+
+def build_service(tmp_path: Path) -> MugiwaraService:
+    crew_rules_path = tmp_path / 'crew-core' / 'AGENTS.md'
+    crew_rules_path.parent.mkdir(parents=True)
+    crew_rules_path.write_text('# AGENTS.md\n\nCanon Mugiwara saneado.\n', encoding='utf-8')
+    return MugiwaraService(crew_rules_path=crew_rules_path)
+
+
+def test_mugiwaras_catalog_returns_safe_cards_and_canonical_agents_document(tmp_path: Path) -> None:
+    service = build_service(tmp_path)
+    app.dependency_overrides[get_mugiwaras_service] = lambda: service
+    client = TestClient(app)
+
+    response = client.get('/api/v1/mugiwaras')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'mugiwaras.catalog'
+    assert payload['status'] == 'ready'
+    assert payload['meta']['count'] >= 4
+    assert payload['meta']['crew_rules_document'] == '/srv/crew-core/AGENTS.md'
+    assert {item['slug'] for item in payload['data']['items']} >= {'luffy', 'zoro', 'usopp', 'chopper'}
+    assert payload['data']['crew_rules_document'] == {
+        'document_id': 'crew-core-agents',
+        'title': 'AGENTS.md — reglas operativas Mugiwara',
+        'display_path': '/srv/crew-core/AGENTS.md',
+        'source_label': 'crew-core canonical AGENTS.md',
+        'read_only': True,
+        'canonical': True,
+        'markdown': '# AGENTS.md\n\nCanon Mugiwara saneado.\n',
+    }
+
+    app.dependency_overrides.clear()
+
+
+def test_mugiwara_detail_returns_profile_and_rejects_unknown_slug(tmp_path: Path) -> None:
+    service = build_service(tmp_path)
+    app.dependency_overrides[get_mugiwaras_service] = lambda: service
+    client = TestClient(app)
+
+    detail = client.get('/api/v1/mugiwaras/zoro')
+    assert detail.status_code == 200
+    payload = detail.json()
+    assert payload['resource'] == 'mugiwaras.profile'
+    assert payload['data']['slug'] == 'zoro'
+    assert payload['data']['identity']['name'] == 'Zoro'
+    assert payload['data']['identity']['crest_src'].startswith('/assets/mugiwaras/crests/')
+
+    unknown = client.get('/api/v1/mugiwaras/unknown')
+    assert unknown.status_code == 404
+    assert unknown.json()['detail']['code'] == 'not_found'
+    assert '/srv/crew-core' not in unknown.text
+
+    app.dependency_overrides.clear()
+
+
+def test_mugiwaras_catalog_does_not_follow_hermes_agents_symlink(tmp_path: Path) -> None:
+    canonical = tmp_path / 'crew-core' / 'AGENTS.md'
+    canonical.parent.mkdir(parents=True)
+    canonical.write_text('canonical', encoding='utf-8')
+
+    hermes_agents = tmp_path / '.hermes' / 'hermes-agent' / 'AGENTS.md'
+    hermes_agents.parent.mkdir(parents=True)
+    hermes_agents.symlink_to(canonical)
+
+    service = MugiwaraService(crew_rules_path=hermes_agents)
+    app.dependency_overrides[get_mugiwaras_service] = lambda: service
+    client = TestClient(app)
+
+    response = client.get('/api/v1/mugiwaras')
+
+    assert response.status_code == 503
+    assert response.json()['detail']['code'] == 'source_unavailable'
+    assert str(hermes_agents) not in response.text
+
+    app.dependency_overrides.clear()

--- a/apps/web/src/app/mugiwaras/page.tsx
+++ b/apps/web/src/app/mugiwaras/page.tsx
@@ -1,48 +1,171 @@
 import Link from 'next/link'
 
+import type { CrewRulesDocument, MugiwaraCard } from '@contracts/read-models'
+
 import {
   getMugiwaraStatusLabel,
   mapMugiwaraStatusToBadgeStatus,
 } from '@/modules/mugiwaras/view-models/mugiwara-card.mappers'
+import { fetchMugiwarasCatalog, getMugiwarasApiBaseUrl, MugiwarasApiError } from '@/modules/mugiwaras/api/mugiwaras-http'
 import { mugiwaraCardFixture } from '@/modules/mugiwaras/view-models/mugiwara-card.fixture'
-import { getMugiwaraProfile } from '@/shared/mugiwara/crest-map'
+import { getMugiwaraProfile, isMugiwaraSlug } from '@/shared/mugiwara/crest-map'
 import { MugiwaraCrest } from '@/shared/mugiwara/MugiwaraCrest'
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
+import { StatePanel } from '@/shared/ui/state/StatePanel'
 import { StatusBadge } from '@/shared/ui/status/StatusBadge'
-import { appTheme } from '@/shared/theme/tokens'
+import { appTheme, type AppStatus } from '@/shared/theme/tokens'
 
-export default function MugiwarasPage() {
+export const dynamic = 'force-dynamic'
+
+type MugiwarasViewState = 'ready' | 'fallback' | 'error' | 'not_configured'
+
+type MugiwarasViewModel = {
+  state: MugiwarasViewState
+  cards: MugiwaraCard[]
+  crewRulesDocument: CrewRulesDocument | null
+  notice: {
+    status: AppStatus
+    title: string
+    description: string
+    detail: string | null
+  } | null
+}
+
+async function getMugiwarasViewModel(): Promise<MugiwarasViewModel> {
+  const apiBaseUrl = getMugiwarasApiBaseUrl()
+
+  if (!apiBaseUrl) {
+    return {
+      state: 'not_configured',
+      cards: mugiwaraCardFixture,
+      crewRulesDocument: null,
+      notice: {
+        status: 'sin-datos',
+        title: 'Backend de Mugiwara no configurado',
+        description:
+          'La página mantiene el fixture saneado, pero la lectura canónica de /srv/crew-core/AGENTS.md requiere NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL.',
+        detail: 'Variable ausente en el runtime actual.',
+      },
+    }
+  }
+
+  try {
+    const response = await fetchMugiwarasCatalog()
+    return {
+      state: 'ready',
+      cards: response.data.items,
+      crewRulesDocument: response.data.crew_rules_document,
+      notice: null,
+    }
+  } catch (error) {
+    const detail = error instanceof MugiwarasApiError ? `${error.code}: ${error.message}` : error instanceof Error ? error.message : 'Error desconocido'
+    return {
+      state: 'error',
+      cards: mugiwaraCardFixture,
+      crewRulesDocument: null,
+      notice: {
+        status: 'incidencia',
+        title: 'No se pudo cargar la API read-only de Mugiwara',
+        description:
+          'La UI cae al fixture saneado para no romper el shell. No se muestra AGENTS.md si la fuente backend no está disponible.',
+        detail,
+      },
+    }
+  }
+}
+
+function getSafeProfile(card: MugiwaraCard) {
+  return isMugiwaraSlug(card.slug) ? getMugiwaraProfile(card.slug) : null
+}
+
+function formatLineCount(markdown: string) {
+  return markdown.length === 0 ? 0 : markdown.split('\n').length
+}
+
+export default async function MugiwarasPage() {
+  const viewModel = await getMugiwarasViewModel()
+
   return (
     <>
       <PageHeader
         eyebrow="Mugiwaras"
         title="Tripulación"
-        subtitle="Vista de solo lectura de identidad, estado, skills enlazadas y señales de memoria por Mugiwara."
+        subtitle="Vista de solo lectura de identidad, estado, skills enlazadas, señales de memoria y canon operativo Mugiwara."
         mugiwaraSlug="luffy"
-        detailPills={['Crew index', 'Crests activos', 'Identidad visible']}
+        detailPills={['Crew index', 'Crests activos', 'AGENTS.md solo lectura']}
       />
 
       <SurfaceCard title="Superficie de lectura" eyebrow="Roster" accent="gold">
         <p style={{ marginTop: 0, marginBottom: '10px', color: appTheme.colors.textSecondary }}>
-          Esta vista agrega solo resúmenes saneados por agente. No abre detalle por ruta ni expone controles de edición.
+          Esta vista agrega solo resúmenes saneados por agente. No abre controles de edición y solo muestra el AGENTS.md canónico de crew-core cuando llega desde la API allowlisted.
         </p>
-        <StatusBadge status="operativo" />
+        <StatusBadge status={viewModel.state === 'ready' ? 'operativo' : 'sin-datos'} />
       </SurfaceCard>
 
+      {viewModel.notice ? (
+        <section className="section-block">
+          <StatePanel
+            status={viewModel.notice.status}
+            title={viewModel.notice.title}
+            description={viewModel.notice.description}
+            detail={viewModel.notice.detail}
+            eyebrow="Estado de fuente"
+          />
+        </section>
+      ) : null}
+
+      {viewModel.crewRulesDocument ? (
+        <section className="section-block">
+          <SurfaceCard title={viewModel.crewRulesDocument.title} eyebrow="Canon operativo" accent="sky" elevated>
+            <div style={{ display: 'grid', gap: '12px' }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
+                <div style={{ display: 'grid', gap: '4px' }}>
+                  <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{viewModel.crewRulesDocument.display_path}</span>
+                  <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>
+                    {viewModel.crewRulesDocument.source_label} · {formatLineCount(viewModel.crewRulesDocument.markdown)} líneas · solo lectura
+                  </span>
+                </div>
+                <StatusBadge status={viewModel.crewRulesDocument.read_only ? 'operativo' : 'revision'} />
+              </div>
+
+              <pre
+                aria-label="Contenido de AGENTS.md canónico de crew-core"
+                style={{
+                  margin: 0,
+                  maxHeight: '420px',
+                  overflow: 'auto',
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                  border: `1px solid ${appTheme.colors.borderSubtle}`,
+                  borderRadius: appTheme.radius.md,
+                  background: appTheme.colors.bgSurface1,
+                  color: appTheme.colors.textSecondary,
+                  padding: '14px',
+                  fontSize: '12px',
+                  lineHeight: 1.5,
+                }}
+              >
+                {viewModel.crewRulesDocument.markdown}
+              </pre>
+            </div>
+          </SurfaceCard>
+        </section>
+      ) : null}
+
       <section className="section-block layout-grid layout-grid--cards-280">
-        {mugiwaraCardFixture.map((mugiwara) => {
-          const profile = getMugiwaraProfile(mugiwara.slug)
+        {viewModel.cards.map((mugiwara) => {
+          const profile = getSafeProfile(mugiwara)
 
           return (
             <SurfaceCard key={mugiwara.slug} title={mugiwara.name} elevated eyebrow="Agente" accent="sky">
               <div style={{ display: 'grid', gap: '12px' }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
                   <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-                    <MugiwaraCrest slug={mugiwara.slug} size="md" accent />
+                    {profile ? <MugiwaraCrest slug={profile.slug} size="md" accent /> : null}
                     <div style={{ display: 'grid', gap: '2px' }}>
                       <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>slug: {mugiwara.slug}</span>
-                      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>{profile.role}</span>
+                      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>{profile?.role ?? 'Mugiwara'}</span>
                     </div>
                   </div>
                   <StatusBadge status={mapMugiwaraStatusToBadgeStatus(mugiwara.status)} />

--- a/apps/web/src/app/mugiwaras/page.tsx
+++ b/apps/web/src/app/mugiwaras/page.tsx
@@ -93,7 +93,7 @@ export default async function MugiwarasPage() {
         title="Tripulación"
         subtitle="Vista de solo lectura de identidad, estado, skills enlazadas, señales de memoria y canon operativo Mugiwara."
         mugiwaraSlug="luffy"
-        detailPills={['Crew index', 'Crests activos', 'AGENTS.md solo lectura']}
+        detailPills={['Índice de tripulación', 'Crests activos', 'Documento canónico read-only']}
       />
 
       <SurfaceCard title="Superficie de lectura" eyebrow="Roster" accent="gold">
@@ -121,16 +121,34 @@ export default async function MugiwarasPage() {
             <div style={{ display: 'grid', gap: '12px' }}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
                 <div style={{ display: 'grid', gap: '4px' }}>
-                  <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{viewModel.crewRulesDocument.display_path}</span>
-                  <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>
-                    {viewModel.crewRulesDocument.source_label} · {formatLineCount(viewModel.crewRulesDocument.markdown)} líneas · solo lectura
+                  <span style={{ color: appTheme.colors.textSecondary, fontSize: '14px', fontWeight: 700 }}>{viewModel.crewRulesDocument.display_path}</span>
+                  <span id="crew-rules-scroll-hint" style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
+                    {viewModel.crewRulesDocument.source_label} · {formatLineCount(viewModel.crewRulesDocument.markdown)} líneas · contenido desplazable
                   </span>
                 </div>
-                <StatusBadge status={viewModel.crewRulesDocument.read_only ? 'operativo' : 'revision'} />
+                <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
+                  <span
+                    aria-label="Documento en modo solo lectura"
+                    style={{
+                      border: `1px solid ${appTheme.colors.borderSubtle}`,
+                      borderRadius: '999px',
+                      padding: '4px 10px',
+                      color: appTheme.colors.textSecondary,
+                      background: appTheme.colors.bgSurface1,
+                      fontSize: '12px',
+                      fontWeight: 700,
+                    }}
+                  >
+                    🔒 Solo lectura
+                  </span>
+                  <StatusBadge status={viewModel.crewRulesDocument.read_only ? 'operativo' : 'revision'} />
+                </div>
               </div>
 
               <pre
+                aria-describedby="crew-rules-scroll-hint"
                 aria-label="Contenido de AGENTS.md canónico de crew-core"
+                tabIndex={0}
                 style={{
                   margin: 0,
                   maxHeight: '420px',
@@ -140,14 +158,18 @@ export default async function MugiwarasPage() {
                   border: `1px solid ${appTheme.colors.borderSubtle}`,
                   borderRadius: appTheme.radius.md,
                   background: appTheme.colors.bgSurface1,
-                  color: appTheme.colors.textSecondary,
-                  padding: '14px',
-                  fontSize: '12px',
-                  lineHeight: 1.5,
+                  color: appTheme.colors.textPrimary,
+                  padding: '16px',
+                  fontSize: '13px',
+                  lineHeight: 1.65,
+                  boxShadow: `inset 0 -18px 24px ${appTheme.colors.bgSurface2}`,
                 }}
               >
                 {viewModel.crewRulesDocument.markdown}
               </pre>
+              <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
+                Fin de ventana visible: usa scroll dentro del documento para leer el canon completo. Sin edición desde el panel.
+              </span>
             </div>
           </SurfaceCard>
         </section>

--- a/apps/web/src/modules/mugiwaras/api/mugiwaras-http.ts
+++ b/apps/web/src/modules/mugiwaras/api/mugiwaras-http.ts
@@ -1,0 +1,61 @@
+import type { MugiwarasCatalogResponse } from '@contracts/read-models'
+
+export class MugiwarasApiError extends Error {
+  status: number
+  code: string
+
+  constructor(message: string, options: { status: number; code: string }) {
+    super(message)
+    this.name = 'MugiwarasApiError'
+    this.status = options.status
+    this.code = options.code
+  }
+}
+
+type ApiErrorPayload = {
+  detail?: {
+    code?: string
+    message?: string
+  }
+}
+
+function trimTrailingSlash(value: string) {
+  return value.replace(/\/$/, '')
+}
+
+export function getMugiwarasApiBaseUrl() {
+  const value = process.env.NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL
+  return value ? trimTrailingSlash(value) : null
+}
+
+export async function fetchMugiwarasCatalog(): Promise<MugiwarasCatalogResponse> {
+  const baseUrl = getMugiwarasApiBaseUrl()
+
+  if (!baseUrl) {
+    throw new MugiwarasApiError('not_configured', { status: 0, code: 'not_configured' })
+  }
+
+  const response = await fetch(`${baseUrl}/api/v1/mugiwaras`, {
+    cache: 'no-store',
+    headers: {
+      Accept: 'application/json',
+    },
+  })
+
+  if (!response.ok) {
+    let payload: ApiErrorPayload | null = null
+
+    try {
+      payload = (await response.json()) as ApiErrorPayload
+    } catch {
+      payload = null
+    }
+
+    throw new MugiwarasApiError(payload?.detail?.message ?? `http_${response.status}`, {
+      status: response.status,
+      code: payload?.detail?.code ?? `http_${response.status}`,
+    })
+  }
+
+  return (await response.json()) as MugiwarasCatalogResponse
+}

--- a/apps/web/src/modules/mugiwaras/view-models/mugiwara-card.fixture.ts
+++ b/apps/web/src/modules/mugiwaras/view-models/mugiwara-card.fixture.ts
@@ -1,28 +1,45 @@
-import type { MugiwaraSlug } from '@/shared/mugiwara/crest-map'
-
-export type MugiwaraCardStatus = 'healthy' | 'warning' | 'degraded'
-
-export type MugiwaraCardLink = {
-  label: string
-  href: '/memory' | '/skills'
-}
-
-export type MugiwaraCard = {
-  slug: MugiwaraSlug
-  name: string
-  status: MugiwaraCardStatus
-  skills: string[]
-  memory_badge: string
-  links: MugiwaraCardLink[]
-}
+import type { MugiwaraCard } from '@contracts/read-models'
 
 export const mugiwaraCardFixture: MugiwaraCard[] = [
   {
+    slug: 'luffy',
+    name: 'Luffy',
+    status: 'operativo',
+    skills: ['delegation-contract', 'crew-orchestration'],
+    memory_badge: 'Capitán operativo',
+    links: [
+      { label: 'Abrir Memory', href: '/memory' },
+      { label: 'Abrir Skills', href: '/skills' },
+    ],
+  },
+  {
     slug: 'zoro',
     name: 'Zoro',
-    status: 'healthy',
-    skills: ['sdd-orchestrator-zoro', 'sdd-design-zoro'],
+    status: 'operativo',
+    skills: ['sdd-orchestrator-zoro', 'zoro-pr-review-handoff'],
     memory_badge: 'Continuidad fuerte',
+    links: [
+      { label: 'Abrir Memory', href: '/memory' },
+      { label: 'Abrir Skills', href: '/skills' },
+    ],
+  },
+  {
+    slug: 'franky',
+    name: 'Franky',
+    status: 'operativo',
+    skills: ['franky-pr-ops-review', 'vault-sync-ops'],
+    memory_badge: 'Runtime vigilado',
+    links: [
+      { label: 'Abrir Memory', href: '/memory' },
+      { label: 'Abrir Skills', href: '/skills' },
+    ],
+  },
+  {
+    slug: 'chopper',
+    name: 'Chopper',
+    status: 'operativo',
+    skills: ['chopper-pr-security-review', 'security-hardening'],
+    memory_badge: 'Riesgo controlado',
     links: [
       { label: 'Abrir Memory', href: '/memory' },
       { label: 'Abrir Skills', href: '/skills' },
@@ -31,9 +48,9 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
   {
     slug: 'usopp',
     name: 'Usopp',
-    status: 'warning',
-    skills: ['frontend-spec-usopp', 'ui-handoff-usopp'],
-    memory_badge: 'Docs recientes',
+    status: 'revision',
+    skills: ['usopp-pr-design-review', 'frontend-spec-usopp'],
+    memory_badge: 'Diseño activo',
     links: [
       { label: 'Abrir Memory', href: '/memory' },
       { label: 'Abrir Skills', href: '/skills' },
@@ -42,9 +59,42 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
   {
     slug: 'nami',
     name: 'Nami',
-    status: 'healthy',
-    skills: ['routing-nami', 'observability-nami'],
+    status: 'operativo',
+    skills: ['finance-ops', 'google-sheets-control'],
     memory_badge: 'Señales estables',
+    links: [
+      { label: 'Abrir Memory', href: '/memory' },
+      { label: 'Abrir Skills', href: '/skills' },
+    ],
+  },
+  {
+    slug: 'robin',
+    name: 'Robin',
+    status: 'operativo',
+    skills: ['research-synthesis', 'vault-canon'],
+    memory_badge: 'Canon consultable',
+    links: [
+      { label: 'Abrir Memory', href: '/memory' },
+      { label: 'Abrir Skills', href: '/skills' },
+    ],
+  },
+  {
+    slug: 'brook',
+    name: 'Brook',
+    status: 'revision',
+    skills: ['data-analysis', 'analytics-standby'],
+    memory_badge: 'Datos en standby',
+    links: [
+      { label: 'Abrir Memory', href: '/memory' },
+      { label: 'Abrir Skills', href: '/skills' },
+    ],
+  },
+  {
+    slug: 'jinbe',
+    name: 'Jinbe',
+    status: 'sin-datos',
+    skills: ['legal-context'],
+    memory_badge: 'Definido en canon',
     links: [
       { label: 'Abrir Memory', href: '/memory' },
       { label: 'Abrir Skills', href: '/skills' },
@@ -53,9 +103,9 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
   {
     slug: 'sanji',
     name: 'Sanji',
-    status: 'degraded',
-    skills: ['ops-surface-sanji'],
-    memory_badge: 'Requiere revisión',
+    status: 'sin-datos',
+    skills: ['physical-ops'],
+    memory_badge: 'Definido en canon',
     links: [
       { label: 'Abrir Memory', href: '/memory' },
       { label: 'Abrir Skills', href: '/skills' },

--- a/apps/web/src/modules/mugiwaras/view-models/mugiwara-card.fixture.ts
+++ b/apps/web/src/modules/mugiwaras/view-models/mugiwara-card.fixture.ts
@@ -8,8 +8,8 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
     skills: ['delegation-contract', 'crew-orchestration'],
     memory_badge: 'Capitán operativo',
     links: [
-      { label: 'Abrir Memory', href: '/memory' },
-      { label: 'Abrir Skills', href: '/skills' },
+      { label: 'Ver Memory', href: '/memory' },
+      { label: 'Ver Skills', href: '/skills' },
     ],
   },
   {
@@ -19,8 +19,8 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
     skills: ['sdd-orchestrator-zoro', 'zoro-pr-review-handoff'],
     memory_badge: 'Continuidad fuerte',
     links: [
-      { label: 'Abrir Memory', href: '/memory' },
-      { label: 'Abrir Skills', href: '/skills' },
+      { label: 'Ver Memory', href: '/memory' },
+      { label: 'Ver Skills', href: '/skills' },
     ],
   },
   {
@@ -30,8 +30,8 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
     skills: ['franky-pr-ops-review', 'vault-sync-ops'],
     memory_badge: 'Runtime vigilado',
     links: [
-      { label: 'Abrir Memory', href: '/memory' },
-      { label: 'Abrir Skills', href: '/skills' },
+      { label: 'Ver Memory', href: '/memory' },
+      { label: 'Ver Skills', href: '/skills' },
     ],
   },
   {
@@ -41,8 +41,8 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
     skills: ['chopper-pr-security-review', 'security-hardening'],
     memory_badge: 'Riesgo controlado',
     links: [
-      { label: 'Abrir Memory', href: '/memory' },
-      { label: 'Abrir Skills', href: '/skills' },
+      { label: 'Ver Memory', href: '/memory' },
+      { label: 'Ver Skills', href: '/skills' },
     ],
   },
   {
@@ -52,8 +52,8 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
     skills: ['usopp-pr-design-review', 'frontend-spec-usopp'],
     memory_badge: 'Diseño activo',
     links: [
-      { label: 'Abrir Memory', href: '/memory' },
-      { label: 'Abrir Skills', href: '/skills' },
+      { label: 'Ver Memory', href: '/memory' },
+      { label: 'Ver Skills', href: '/skills' },
     ],
   },
   {
@@ -63,8 +63,8 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
     skills: ['finance-ops', 'google-sheets-control'],
     memory_badge: 'Señales estables',
     links: [
-      { label: 'Abrir Memory', href: '/memory' },
-      { label: 'Abrir Skills', href: '/skills' },
+      { label: 'Ver Memory', href: '/memory' },
+      { label: 'Ver Skills', href: '/skills' },
     ],
   },
   {
@@ -74,8 +74,8 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
     skills: ['research-synthesis', 'vault-canon'],
     memory_badge: 'Canon consultable',
     links: [
-      { label: 'Abrir Memory', href: '/memory' },
-      { label: 'Abrir Skills', href: '/skills' },
+      { label: 'Ver Memory', href: '/memory' },
+      { label: 'Ver Skills', href: '/skills' },
     ],
   },
   {
@@ -85,8 +85,8 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
     skills: ['data-analysis', 'analytics-standby'],
     memory_badge: 'Datos en standby',
     links: [
-      { label: 'Abrir Memory', href: '/memory' },
-      { label: 'Abrir Skills', href: '/skills' },
+      { label: 'Ver Memory', href: '/memory' },
+      { label: 'Ver Skills', href: '/skills' },
     ],
   },
   {
@@ -96,8 +96,8 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
     skills: ['legal-context'],
     memory_badge: 'Definido en canon',
     links: [
-      { label: 'Abrir Memory', href: '/memory' },
-      { label: 'Abrir Skills', href: '/skills' },
+      { label: 'Ver Memory', href: '/memory' },
+      { label: 'Ver Skills', href: '/skills' },
     ],
   },
   {
@@ -107,8 +107,8 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
     skills: ['physical-ops'],
     memory_badge: 'Definido en canon',
     links: [
-      { label: 'Abrir Memory', href: '/memory' },
-      { label: 'Abrir Skills', href: '/skills' },
+      { label: 'Ver Memory', href: '/memory' },
+      { label: 'Ver Skills', href: '/skills' },
     ],
   },
 ]

--- a/apps/web/src/modules/mugiwaras/view-models/mugiwara-card.mappers.ts
+++ b/apps/web/src/modules/mugiwaras/view-models/mugiwara-card.mappers.ts
@@ -1,22 +1,26 @@
+import type { Severity } from '@contracts/read-models'
+
 import type { AppStatus } from '@/shared/theme/tokens'
 
-import type { MugiwaraCardStatus } from './mugiwara-card.fixture'
-
-export function mapMugiwaraStatusToBadgeStatus(status: MugiwaraCardStatus): AppStatus {
-  const map: Record<MugiwaraCardStatus, AppStatus> = {
-    healthy: 'operativo',
-    warning: 'revision',
-    degraded: 'incidencia',
+export function mapMugiwaraStatusToBadgeStatus(status: Severity): AppStatus {
+  const map: Record<Severity, AppStatus> = {
+    operativo: 'operativo',
+    revision: 'revision',
+    incidencia: 'incidencia',
+    stale: 'stale',
+    'sin-datos': 'sin-datos',
   }
 
   return map[status]
 }
 
-export function getMugiwaraStatusLabel(status: MugiwaraCardStatus): string {
-  const map: Record<MugiwaraCardStatus, string> = {
-    healthy: 'Estable',
-    warning: 'Atención',
-    degraded: 'Degradado',
+export function getMugiwaraStatusLabel(status: Severity): string {
+  const map: Record<Severity, string> = {
+    operativo: 'Operativo',
+    revision: 'En revisión',
+    incidencia: 'Incidencia',
+    stale: 'Stale',
+    'sin-datos': 'Sin datos',
   }
 
   return map[status]

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -19,7 +19,7 @@
 - componer ficha por agente
 - agregar estado, identidad, built-in memory resumida y skills relacionadas
 - exponer `GET /api/v1/mugiwaras` y `GET /api/v1/mugiwaras/{slug}` como superficies read-only
-- mostrar `/srv/crew-core/AGENTS.md` como documento canónico de reglas operativas en la sección Mugiwara
+- mostrar `/srv/crew-core/AGENTS.md` como documento canónico de reglas operativas en la sección Mugiwara; esta lectura pertenece al control plane privado y no debe exponerse fuera de la frontera operativa/autenticada del despliegue
 - no listar ni resolver por separado `/home/agentops/.hermes/hermes-agent/AGENTS.md`, porque es symlink al canon
 - no escribir sobre perfiles
 

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -18,6 +18,9 @@
 ### `mugiwaras`
 - componer ficha por agente
 - agregar estado, identidad, built-in memory resumida y skills relacionadas
+- exponer `GET /api/v1/mugiwaras` y `GET /api/v1/mugiwaras/{slug}` como superficies read-only
+- mostrar `/srv/crew-core/AGENTS.md` como documento canónico de reglas operativas en la sección Mugiwara
+- no listar ni resolver por separado `/home/agentops/.hermes/hermes-agent/AGENTS.md`, porque es symlink al canon
 - no escribir sobre perfiles
 
 ### `memory`

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -83,6 +83,20 @@ Campos esperados:
 - `memory_badge`
 - `links`
 
+### `mugiwara.crew_rules_document`
+Campos esperados:
+- `document_id`
+- `title`
+- `display_path`
+- `source_label`
+- `read_only`
+- `canonical`
+- `markdown`
+
+Uso:
+- mostrar en la sección Mugiwara el `/srv/crew-core/AGENTS.md` canónico en modo solo lectura
+- no listar `/home/agentops/.hermes/hermes-agent/AGENTS.md` como fuente distinta, porque es symlink al canon
+
 ### `mugiwara.profile`
 Campos esperados:
 - `slug`

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -95,6 +95,7 @@ Campos esperados:
 
 Uso:
 - mostrar en la sección Mugiwara el `/srv/crew-core/AGENTS.md` canónico en modo solo lectura
+- tratar esta lectura como superficie del control plane privado; si el API se expone fuera del perímetro operativo, debe ir detrás de auth/permisos antes de servir markdown completo
 - no listar `/home/agentops/.hermes/hermes-agent/AGENTS.md` como fuente distinta, porque es symlink al canon
 
 ### `mugiwara.profile`

--- a/openspec/phase-12-2-mugiwaras-agents-readonly.md
+++ b/openspec/phase-12-2-mugiwaras-agents-readonly.md
@@ -1,0 +1,57 @@
+# Phase 12.2 — mugiwaras API vertical + canonical AGENTS.md
+
+## Scope
+Make `/mugiwaras` the first non-`skills` API-backed read-only vertical and include the canonical Mugiwara operating rules document in that same section.
+
+## Decision: include AGENTS.md now
+The AGENTS.md requirement belongs in Phase 12.2, not later, because:
+- the requested page/section is Mugiwara, which maps to the existing `/mugiwaras` surface;
+- Phase 12.2 already creates the backend-owned boundary for this surface;
+- reading `/srv/crew-core/AGENTS.md` must be allowlisted server-side, not implemented as a frontend-only shortcut;
+- delaying it would leave the Mugiwara section API-backed but missing its canonical operating document.
+
+## SDD summary
+### Explore
+- Phase 12.1 already added shared read-only contracts and backend envelope validation.
+- `/mugiwaras` was still frontend fixture-backed.
+- Franky's handoff states that only `/srv/crew-core/AGENTS.md` should be shown, read-only, and `/home/agentops/.hermes/hermes-agent/AGENTS.md` must not be listed separately because it is now a symlink to the canonical file.
+
+### Design
+- Add backend module `apps/api/src/modules/mugiwaras` with:
+  - `GET /api/v1/mugiwaras`
+  - `GET /api/v1/mugiwaras/{slug}`
+- Keep data static and allowlisted for this microphase.
+- Read exactly the canonical crew rules document from `/srv/crew-core/AGENTS.md`.
+- Reject symlink-backed AGENTS reads in service tests to prevent treating the Hermes Agent symlink as an independent source.
+- Extend shared TypeScript contracts with `CrewRulesDocument`.
+- Update `/mugiwaras` to prefer backend data when `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` is configured, with a sane fixture fallback and no AGENTS content when backend is unavailable.
+
+## Tasks
+- [x] Add backend tests for mugiwaras catalog, detail, unknown slug and symlink rejection.
+- [x] Add `mugiwaras` backend module and include router in FastAPI app.
+- [x] Extend contracts and docs for the canonical crew rules document.
+- [x] Add frontend read-only API adapter and update `/mugiwaras` page.
+- [x] Preserve no-write scope and public repo hygiene.
+
+## Definition of done
+- `/api/v1/mugiwaras` returns crew cards plus `crew_rules_document` for `/srv/crew-core/AGENTS.md`.
+- `/api/v1/mugiwaras/{slug}` returns a safe profile for known slugs.
+- Unknown slugs return semantic 404 without leaking host paths.
+- Symlink AGENTS source is rejected in tests.
+- `/mugiwaras` can render API-backed data and shows the AGENTS.md content only when backend data is available.
+
+## Files changed
+- `apps/api/src/modules/mugiwaras/*` — new backend read-only module.
+- `apps/api/src/main.py` — includes mugiwaras router.
+- `apps/api/tests/test_mugiwaras_api.py` — endpoint/security tests.
+- `packages/contracts/src/read-models.ts` — `CrewRulesDocument` and updated mugiwaras response contracts.
+- `apps/web/src/modules/mugiwaras/api/mugiwaras-http.ts` — frontend API adapter.
+- `apps/web/src/modules/mugiwaras/view-models/*` — fixture/status alignment with shared severity.
+- `apps/web/src/app/mugiwaras/page.tsx` — API-backed read-only page with canonical AGENTS panel.
+- `docs/api-modules.md` and `docs/read-models.md` — updated module/read-model docs.
+
+## Reviewer routing
+This PR should request mixed review:
+- Chopper: fixed filesystem read, symlink rejection, no arbitrary path access.
+- Usopp: visible UI/UX change on `/mugiwaras` showing AGENTS.md.
+- Franky: optional/secondary because the document is operational canon, but no runtime/deploy scripts are changed.

--- a/openspec/phase-12-2-mugiwaras-agents-readonly.md
+++ b/openspec/phase-12-2-mugiwaras-agents-readonly.md
@@ -22,7 +22,8 @@ The AGENTS.md requirement belongs in Phase 12.2, not later, because:
   - `GET /api/v1/mugiwaras/{slug}`
 - Keep data static and allowlisted for this microphase.
 - Read exactly the canonical crew rules document from `/srv/crew-core/AGENTS.md`.
-- Reject symlink-backed AGENTS reads in service tests to prevent treating the Hermes Agent symlink as an independent source.
+- Reject symlink-backed AGENTS reads at file and parent-component level in service tests to prevent treating the Hermes Agent symlink as an independent source.
+- Document that full AGENTS markdown belongs behind the private control-plane boundary/auth perimeter if the API is ever exposed beyond trusted operation.
 - Extend shared TypeScript contracts with `CrewRulesDocument`.
 - Update `/mugiwaras` to prefer backend data when `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` is configured, with a sane fixture fallback and no AGENTS content when backend is unavailable.
 
@@ -37,7 +38,8 @@ The AGENTS.md requirement belongs in Phase 12.2, not later, because:
 - `/api/v1/mugiwaras` returns crew cards plus `crew_rules_document` for `/srv/crew-core/AGENTS.md`.
 - `/api/v1/mugiwaras/{slug}` returns a safe profile for known slugs.
 - Unknown slugs return semantic 404 without leaking host paths.
-- Symlink AGENTS source is rejected in tests.
+- Symlink AGENTS source is rejected in tests, including parent-directory symlink components.
+- `/mugiwaras` improves document legibility with a local read-only badge, keyboard-focusable scroll region and explicit scroll hint.
 - `/mugiwaras` can render API-backed data and shows the AGENTS.md content only when backend data is available.
 
 ## Files changed

--- a/openspec/phase-12-2-verify-checklist.md
+++ b/openspec/phase-12-2-verify-checklist.md
@@ -1,0 +1,22 @@
+# Phase 12.2 verify checklist — mugiwaras AGENTS read-only
+
+## TDD evidence
+- [x] RED: `PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py` failed before implementation with `ModuleNotFoundError: No module named 'apps.api.src.modules.mugiwaras'`.
+- [x] GREEN: `PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py` passed after implementation.
+
+## Backend verify
+- [x] `python -m py_compile apps/api/src/modules/mugiwaras/domain.py apps/api/src/modules/mugiwaras/service.py apps/api/src/modules/mugiwaras/router.py apps/api/src/main.py`
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py`
+
+## Frontend/contracts verify
+- [x] `npm --prefix apps/web run typecheck`
+- [x] `npm --prefix apps/web run build`
+
+## Integration/manual smoke
+- [x] Start API and web with `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` configured.
+- [x] Check `/api/v1/mugiwaras` returns `crew_rules_document.display_path == /srv/crew-core/AGENTS.md`.
+- [x] Check `/mugiwaras` renders the canonical AGENTS.md panel and does not list Hermes Agent AGENTS separately.
+
+## Hygiene
+- [x] `git diff --check`
+- [x] `git status --short --branch`

--- a/packages/contracts/src/read-models.ts
+++ b/packages/contracts/src/read-models.ts
@@ -38,6 +38,16 @@ export type MugiwaraCard = {
   links: SafeLink[]
 }
 
+export type CrewRulesDocument = {
+  document_id: string
+  title: string
+  display_path: string
+  source_label: string
+  read_only: true
+  canonical: true
+  markdown: string
+}
+
 export type MugiwaraProfile = {
   slug: string
   identity: {
@@ -106,8 +116,8 @@ export type SystemSignal = {
 }
 
 export type DashboardSummaryResponse = ResourceEnvelope<DashboardSummary, { links_count: number }>
-export type MugiwarasCatalogResponse = ResourceEnvelope<{ items: MugiwaraCard[] }, { count: number }>
-export type MugiwaraProfileResponse = ResourceEnvelope<MugiwaraProfile, { slug: string }>
+export type MugiwarasCatalogResponse = ResourceEnvelope<{ items: MugiwaraCard[]; crew_rules_document: CrewRulesDocument }, { count: number; crew_rules_document: string; read_only: true }>
+export type MugiwaraProfileResponse = ResourceEnvelope<MugiwaraProfile, { slug: string; read_only: true }>
 export type MemorySummaryResponse = ResourceEnvelope<{ items: MemoryAgentSummary[] }, { count: number; sources: string[] }>
 export type MemoryDetailResponse = ResourceEnvelope<MemoryAgentDetail, { mugiwara_slug: string; read_only: true }>
 export type VaultIndexResponse = ResourceEnvelope<VaultIndex, { safe_root: string }>


### PR DESCRIPTION
## Qué he hecho
- Implemento Phase 12.2: primer vertical read-only no-`skills` respaldado por API.
- Añado backend `mugiwaras` con `GET /api/v1/mugiwaras` y `GET /api/v1/mugiwaras/{slug}`.
- Incluyo `crew_rules_document` leyendo solo `/srv/crew-core/AGENTS.md` como AGENTS canónico de Mugiwara, en modo read-only.
- Actualizo `/mugiwaras` para usar backend cuando `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` está configurada y mantener fallback saneado si no lo está.
- No listo `/home/agentops/.hermes/hermes-agent/AGENTS.md`; además hay test de rechazo de fuente symlink.

## Por qué existe este cambio
- Phase 12 debe mover superficies MVP no-`skills` desde fixtures frontend hacia frontera backend segura.
- Pablo/Franky dejaron handoff explícito: la sección Mugiwara debe mostrar solo `/srv/crew-core/AGENTS.md` y no tratar el symlink de Hermes Agent como fuente separada.

## Superficie afectada
- Backend FastAPI: nuevo módulo read-only `mugiwaras`.
- Frontend Next.js: página visible `/mugiwaras` con panel AGENTS.md canónico.
- Contratos compartidos: `CrewRulesDocument` y respuesta de catálogo mugiwaras.
- Docs/openspec/Engram de Phase 12.2.

## Verificación hecha por Zoro
- RED: `PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py` falló antes de implementación por ausencia del módulo `mugiwaras`.
- GREEN: `PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py` → 3 passed.
- Backend suite: `python -m py_compile apps/api/src/modules/mugiwaras/domain.py apps/api/src/modules/mugiwaras/service.py apps/api/src/modules/mugiwaras/router.py apps/api/src/main.py && PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py` → 10 passed.
- Frontend: `npm --prefix apps/web run typecheck` → OK.
- Build: `npm --prefix apps/web run build` → OK.
- Smoke API: `/api/v1/mugiwaras` devuelve `crew_rules_document.display_path == /srv/crew-core/AGENTS.md` y no incluye Hermes Agent symlink.
- Smoke web: `/mugiwaras` renderiza el panel AGENTS canónico, incluye `/srv/crew-core/AGENTS.md` y no incluye `/home/agentops/.hermes/hermes-agent/AGENTS.md`.
- Hygiene: `git diff --check` → OK.

## Riesgos que veo
- Hay lectura de filesystem, pero fija y allowlisted; no hay path de cliente ni navegador genérico de documentos.
- Cambio visible en UI de `/mugiwaras`, requiere revisión visual/UX.
- La página queda dinámica para poder leer API en runtime.

## Reviewers solicitados
- Chopper: revisar filesystem read fija, symlink rejection, ausencia de path traversal / host leakage.
- Usopp: revisar UI/UX de la sección Mugiwara y el panel AGENTS.md.
- Franky: revisión operativa ligera por documento canónico operativo y ruta fija en runtime.

## Regla de merge
No mergear hasta que los reviewers solicitados aprueben o indiquen explícitamente que su perímetro no aplica.