### PR TITLE
fix: polish mugiwaras agents viewer followups

### DIFF
--- a/.engram/phase-12-2-followups-closeout.md
+++ b/.engram/phase-12-2-followups-closeout.md
@@ -1,0 +1,23 @@
+# Phase 12.2 followups closeout — pending verify
+
+## Resultado esperado
+- Cerrar followups menores aceptados tras PR #3 antes de Phase 12.3.
+- Mejorar foco visible del visor AGENTS.
+- Reforzar affordance de scroll interno.
+- Sustituir `Crests activos` por `Emblemas activos`.
+
+## Decisión técnica
+La siguiente unidad no será Phase 12.3 todavía. Primero se cierra esta microfase pequeña porque reduce deuda visual/accesibilidad y no toca la frontera backend ni seguridad.
+
+## Riesgos
+- Bajo: CSS global de foco se amplía a elementos focusables por `tabindex`, excluyendo `tabindex="-1"` para no afectar el skip target programático del shell.
+- La scrollbar estilizada es puramente visual; no cambia datos ni contrato.
+
+## Verify ejecutado
+- `npm --prefix apps/web run typecheck` → OK.
+- `npm --prefix apps/web run build` → OK.
+- `git diff --check` → OK.
+
+## Verify pendiente
+- `git status --short --branch` antes de commit.
+- PR con revisión de Usopp.

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -144,6 +144,27 @@ button {
   word-break: break-word;
 }
 
+.canonical-document-viewer {
+  scrollbar-width: thin;
+  scrollbar-color: #5a9ddb rgba(90, 157, 219, 0.14);
+}
+
+.canonical-document-viewer::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+
+.canonical-document-viewer::-webkit-scrollbar-track {
+  background: rgba(90, 157, 219, 0.12);
+  border-radius: 999px;
+}
+
+.canonical-document-viewer::-webkit-scrollbar-thumb {
+  background: #5a9ddb;
+  border: 3px solid rgba(24, 36, 61, 0.92);
+  border-radius: 999px;
+}
+
 .topbar__brand {
   display: flex;
   align-items: center;
@@ -294,7 +315,7 @@ button {
   top: 16px;
 }
 
-:where(a, button, input, textarea, select, [role='button'], [role='tab']):focus-visible {
+:where(a, button, input, textarea, select, [role='button'], [role='tab'], [tabindex]:not([tabindex='-1'])):focus-visible {
   outline: 3px solid #5a9ddb;
   outline-offset: 2px;
 }

--- a/apps/web/src/app/mugiwaras/page.tsx
+++ b/apps/web/src/app/mugiwaras/page.tsx
@@ -93,7 +93,7 @@ export default async function MugiwarasPage() {
         title="Tripulación"
         subtitle="Vista de solo lectura de identidad, estado, skills enlazadas, señales de memoria y canon operativo Mugiwara."
         mugiwaraSlug="luffy"
-        detailPills={['Índice de tripulación', 'Crests activos', 'Documento canónico read-only']}
+        detailPills={['Índice de tripulación', 'Emblemas activos', 'Documento canónico read-only']}
       />
 
       <SurfaceCard title="Superficie de lectura" eyebrow="Roster" accent="gold">
@@ -146,6 +146,7 @@ export default async function MugiwarasPage() {
               </div>
 
               <pre
+                className="canonical-document-viewer"
                 aria-describedby="crew-rules-scroll-hint"
                 aria-label="Contenido de AGENTS.md canónico de crew-core"
                 tabIndex={0}

--- a/openspec/phase-12-2-followups-verify-checklist.md
+++ b/openspec/phase-12-2-followups-verify-checklist.md
@@ -1,0 +1,17 @@
+# Phase 12.2 followups verify checklist
+
+## Scope guard
+- [x] Diff is limited to frontend visual/copy polish plus openspec/Engram continuity.
+- [x] No backend, filesystem, auth, dependency or runtime configuration changes.
+
+## Frontend verify
+- [x] `npm --prefix apps/web run typecheck`
+- [x] `npm --prefix apps/web run build`
+
+## Hygiene
+- [x] `git diff --check`
+- [ ] `git status --short --branch`
+
+## Review
+- [ ] Open PR against `main`.
+- [ ] Ask Usopp for UI/UX review because the change is visible.

--- a/openspec/phase-12-2-followups.md
+++ b/openspec/phase-12-2-followups.md
@@ -1,0 +1,28 @@
+# Phase 12.2 followups — AGENTS viewer polish
+
+## Scope
+Close the low-risk followups accepted during PR #3 review before starting Phase 12.3.
+
+## Decision: polish before Phase 12.3
+Phase 12.3 targets the more sensitive `memory` vertical. The safer sequence is to first close the small UI/accessibility/copy followups from Phase 12.2 while the context is fresh, then enter the next backend vertical with a clean baseline.
+
+## Tasks
+- [x] Align the AGENTS `<pre>` focus state with the global 3px blue focus ring.
+- [x] Add a visible/styled scrollbar affordance to the canonical document viewer.
+- [x] Replace the mixed-language `Crests activos` pill with `Emblemas activos`.
+- [x] Keep the change frontend-only and avoid changing backend/security behavior.
+
+## Out of scope
+- No Phase 12.3 `memory` backend implementation.
+- No auth/perimeter changes.
+- No changes to the AGENTS filesystem read contract.
+
+## Definition of done
+- Keyboard focus on the AGENTS viewer is visually consistent with global focus states.
+- The scrollable document region has a visible scrollbar affordance.
+- Header copy is fully Spanish for the active emblem pill.
+- Typecheck/build pass.
+- `git diff --check` passes.
+
+## Reviewer routing
+This is a small visible frontend followup. Usopp review is appropriate. Franky/Chopper are not required unless the diff expands beyond CSS/copy.


### PR DESCRIPTION
## Qué he hecho
- Cierro followups menores aceptados tras PR #3 antes de entrar en Phase 12.3.
- Añado clase `canonical-document-viewer` al visor AGENTS.md.
- Amplío el foco global para elementos focusables por `tabindex` excluyendo `tabindex="-1"`, de modo que el `<pre>` tenga el mismo outline azul de 3px.
- Estilizo scrollbar del visor canónico para reforzar la affordance de scroll.
- Cambio el pill `Crests activos` por `Emblemas activos`.
- Dejo openspec/checklist/Engram de continuidad de esta microfase.

## Por qué existe este cambio
- Usopp y Chopper dejaron la PR #3 mergeable con followups menores.
- Antes de entrar en el vertical sensible Phase 12.3 `memory`, conviene cerrar este pulido pequeño mientras el contexto está fresco.

## Superficie afectada
- Frontend visible `/mugiwaras`.
- CSS global de foco para elementos focusables con `tabindex`.
- Documentación viva de fase en `openspec/` y `.engram/`.

## Verificación hecha por Zoro
- `npm --prefix apps/web run typecheck` → OK.
- `npm --prefix apps/web run build` → OK.
- `git diff --check` → OK.
- `git status --short --branch` → limpio en rama tras commit/push.

## Riesgos que veo
- Bajo. Cambio frontend/CSS/copy sin backend, filesystem, auth, dependencias ni runtime.
- La ampliación de foco excluye `tabindex="-1"` para no afectar targets programáticos del shell.

## Reviewer solicitado
- Usopp: revisar UI/UX, foco visible, affordance de scroll y copy `Emblemas activos`.

## Regla de merge
Si Usopp aprueba o declara `mergeable_with_minor_followups`, Zoro puede mergear. No requiere Franky/Chopper salvo que Usopp detecte riesgo fuera de UI/UX.
