### PR TITLE
feat: add memory read-only api foundation

### DIFF
--- a/.engram/phase-12-3a-memory-api-closeout.md
+++ b/.engram/phase-12-3a-memory-api-closeout.md
@@ -1,0 +1,21 @@
+# Phase 12.3a closeout — memory API foundation
+
+## Resultado
+- Añadido módulo backend `memory` read-only.
+- Añadidos endpoints `GET /api/v1/memory` y `GET /api/v1/memory/{slug}`.
+- La API devuelve solo resúmenes, contadores, badges, frescura y facts Honcho saneados.
+- No se leen stores reales ni se exponen prompts, IDs internos, sesiones, observaciones crudas ni secretos.
+
+## Decisión técnica
+Phase 12.3 se divide en microfases. Primero backend API foundation con frontera de fuga testeada; después vendrá integración frontend `/memory` contra API. Esto reduce riesgo porque la superficie Memory es más sensible que `mugiwaras`.
+
+## Verify ejecutado
+- RED inicial: `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py` falló por ausencia del módulo.
+- GREEN: `python -m py_compile apps/api/src/modules/memory/domain.py apps/api/src/modules/memory/service.py apps/api/src/modules/memory/router.py apps/api/src/main.py && PYTHONPATH=. pytest apps/api/tests/test_memory_api.py` → 4 passed.
+- Regression backend: `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py` → 15 passed.
+- `git diff --check` → OK.
+
+## Riesgos abiertos
+- Los datos son backend-owned/saneados, no conexión a stores reales. La integración con memoria real debe ser otra fase con revisión de Chopper.
+- Frontend `/memory` sigue fixture-backed hasta la siguiente microfase.
+- Chopper debe revisar esta PR por ser frontera de exposición de memoria.

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -2,10 +2,12 @@ from fastapi import FastAPI
 
 from .modules.skills.router import router as skills_router
 from .modules.mugiwaras.router import router as mugiwaras_router
+from .modules.memory.router import router as memory_router
 
 app = FastAPI(title='Mugiwara Control Panel API')
 app.include_router(skills_router)
 app.include_router(mugiwaras_router)
+app.include_router(memory_router)
 
 
 @app.get('/health')

--- a/apps/api/src/modules/memory/AGENTS.md
+++ b/apps/api/src/modules/memory/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md — apps/api/src/modules/memory
+
+## Rol
+Módulo backend read-only para la superficie Memory.
+
+## Reglas
+- Exponer solo resúmenes saneados, contadores, badges, frescura y links allowlisted.
+- No exponer dumps crudos de memoria, prompts, IDs internos, observaciones completas, sesiones ni secretos.
+- Mantener separadas las fuentes `built-in` y `honcho`; Engram no se mezcla silenciosamente en esta superficie.
+- No leer bases reales de memoria desde paths arbitrarios en esta microfase; usar catálogo seguro backend-owned hasta que exista conector auditado.
+- Los errores deben ser semánticos y no filtrar rutas del host ni detalles internos.

--- a/apps/api/src/modules/memory/domain.py
+++ b/apps/api/src/modules/memory/domain.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SafeLink:
+    label: str
+    href: str
+
+
+@dataclass(frozen=True)
+class Freshness:
+    status: str
+    updated_at: str | None
+    source_label: str
+
+
+@dataclass(frozen=True)
+class MemoryAgentSummary:
+    mugiwara_slug: str
+    summary: str
+    fact_count: int
+    last_updated: str | None
+    badges: list[str]
+
+
+@dataclass(frozen=True)
+class MemoryAgentDetail:
+    mugiwara_slug: str
+    built_in_summary: str
+    honcho_facts: list[str]
+    freshness: Freshness
+    links: list[SafeLink]
+
+
+@dataclass(frozen=True)
+class MemoryRecord:
+    slug: str
+    summary: str
+    fact_count: int
+    last_updated: str | None
+    badges: tuple[str, ...]
+    built_in_summary: str
+    honcho_facts: tuple[str, ...]
+    freshness_status: str

--- a/apps/api/src/modules/memory/router.py
+++ b/apps/api/src/modules/memory/router.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from fastapi import APIRouter, Depends
+
+from ...shared.contracts import resource_response
+from .service import MemoryService
+
+router = APIRouter(prefix='/api/v1/memory', tags=['memory'])
+_service = MemoryService()
+
+
+def get_memory_service() -> MemoryService:
+    return _service
+
+
+@router.get('')
+def list_memory(service: MemoryService = Depends(get_memory_service)) -> dict:
+    items = service.list_summary()
+    return resource_response(
+        resource='memory.summary',
+        status=service.catalog_status(),
+        data={'items': items},
+        meta={'count': len(items), 'sources': ['built-in', 'honcho'], 'read_only': True, 'sanitized': True},
+    )
+
+
+@router.get('/{slug}')
+def get_memory_detail(slug: str, service: MemoryService = Depends(get_memory_service)) -> dict:
+    detail = service.get_detail(slug)
+    return resource_response(
+        resource='memory.agent_detail',
+        status='ready',
+        data=asdict(detail),
+        meta={'mugiwara_slug': slug, 'read_only': True, 'sanitized': True},
+    )

--- a/apps/api/src/modules/memory/service.py
+++ b/apps/api/src/modules/memory/service.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from fastapi import HTTPException, status
+
+from .domain import Freshness, MemoryAgentDetail, MemoryAgentSummary, MemoryRecord, SafeLink
+
+SAFE_MEMORY_RECORDS: tuple[MemoryRecord, ...] = (
+    MemoryRecord('luffy', 'Coordina briefs, prioridades y delegación diaria entre especialistas.', 6, '2026-04-24T07:20:00Z', ('orquestación', 'briefs', 'prioridades'), 'Resumen operativo de delegaciones, prioridades activas y criterios de coordinación.', ('Coordina tono y foco entre especialistas.', 'Recoge hábitos de colaboración transversales.', 'No sustituye memoria viva de proyecto.'), 'fresh'),
+    MemoryRecord('zoro', 'Mantiene continuidad técnica, verify y decisiones recientes de software.', 6, '2026-04-24T07:25:00Z', ('arquitectura', 'verify', 'software'), 'Continuidad saneada de arquitectura, decisiones técnicas y cierres verificables de software.', ('Pablo prefiere español de España.', 'Prefiere recomendaciones firmes con plan breve.', 'La coordinación general sigue pasando por Luffy.'), 'fresh'),
+    MemoryRecord('franky', 'Conserva topología operativa, automatizaciones y continuidad de infraestructura.', 5, '2026-04-24T07:03:00Z', ('infra', 'backups', 'automatización'), 'Resumen de runtime, backups, automatizaciones y decisiones de infraestructura.', ('Coordina temas operativos con Luffy.', 'Comparte señales transversales de mantenimiento.', 'Requiere refresco tras incidencias nocturnas.'), 'stale'),
+    MemoryRecord('nami', 'Resume presupuestos, previsiones y señales de prioridad financiera.', 5, '2026-04-24T06:55:00Z', ('finanzas', 'presupuesto', 'prioridades'), 'Resumen financiero operativo sin libros contables ni datos sensibles.', ('Resume dependencias de decisiones presupuestarias.', 'Conecta impacto económico con prioridades.', 'Sirve como contexto relacional, no como ledger.'), 'fresh'),
+    MemoryRecord('usopp', 'Agrupa handoffs, decisiones de UI y material editorial del frontend.', 5, '2026-04-24T07:10:00Z', ('docs', 'handoff', 'ui'), 'Resumen de handoffs, decisiones visuales y material editorial vigente.', ('Sostiene copy y posicionamiento.', 'Ajusta tono externo según contexto.', 'No sustituye documentación de producto.'), 'fresh'),
+    MemoryRecord('robin', 'Conserva investigaciones estructuradas y fuentes contrastadas.', 4, '2026-04-24T06:48:00Z', ('research', 'fuentes', 'síntesis'), 'Resumen de investigaciones, fuentes contrastadas y síntesis estructurada.', ('Relaciona hallazgos con necesidades de la tripulación.', 'Reduce duplicación de research.', 'No sustituye canon del vault.'), 'fresh'),
+    MemoryRecord('jinbe', 'Mantiene criterios legales, contratos y trámites públicos relevantes.', 4, '2026-04-24T06:36:00Z', ('legal', 'contratos', 'boe'), 'Resumen legal de alto nivel sin documentos privados ni datos personales.', ('Pendiente de primeras interacciones relacionales.', 'La ausencia de Honcho no bloquea la lectura built-in.'), 'unknown'),
+    MemoryRecord('sanji', 'Recoge logística física, reservas y comparativas operativas del mundo real.', 4, '2026-04-24T06:26:00Z', ('logística', 'reservas', 'ofertas'), 'Resumen logístico saneado sin reservas, ubicaciones ni datos personales.', ('Conviene refrescar tras nuevos viajes o compras.', 'El contexto base sigue siendo útil.'), 'stale'),
+    MemoryRecord('chopper', 'Agrupa hallazgos de seguridad, postura defensiva y auditorías técnicas.', 4, '2026-04-24T06:18:00Z', ('ciberseguridad', 'auditoría', 'riesgo'), 'Resumen defensivo sin vulnerabilidades explotables, secretos ni outputs crudos.', ('La memoria built-in sigue disponible.', 'Conviene reintentar la generación de resumen.'), 'unknown'),
+    MemoryRecord('brook', 'Conserva continuidad de datos, bases relacionales y análisis de patrones.', 4, '2026-04-24T06:12:00Z', ('datos', 'postgres', 'análisis'), 'Resumen de continuidad de datos sin datasets ni credenciales.', ('Aporta contexto de consumo de datos por otras áreas.', 'Sirve para continuidad transversal de análisis.', 'No reemplaza datasets ni notebooks.'), 'fresh'),
+)
+
+
+class MemoryService:
+    def __init__(self, *, records: tuple[MemoryRecord, ...] = SAFE_MEMORY_RECORDS) -> None:
+        self._records = {record.slug: record for record in records}
+
+    def catalog_status(self) -> str:
+        return 'ready' if self._records else 'not_configured'
+
+    def list_summary(self) -> list[dict]:
+        return [asdict(self._to_summary(record)) for record in self._records.values()]
+
+    def get_detail(self, slug: str) -> MemoryAgentDetail:
+        record = self._records.get(slug)
+        if record is None:
+            raise self._reject(status.HTTP_404_NOT_FOUND, 'not_found', 'Memoria no configurada para el agente solicitado.')
+        return MemoryAgentDetail(
+            mugiwara_slug=record.slug,
+            built_in_summary=record.built_in_summary,
+            honcho_facts=list(record.honcho_facts[:3]),
+            freshness=Freshness(status=record.freshness_status, updated_at=record.last_updated, source_label='built-in + honcho summaries'),
+            links=[SafeLink(label='Ver Mugiwara', href='/mugiwaras')],
+        )
+
+    def _to_summary(self, record: MemoryRecord) -> MemoryAgentSummary:
+        return MemoryAgentSummary(
+            mugiwara_slug=record.slug,
+            summary=record.summary,
+            fact_count=record.fact_count,
+            last_updated=record.last_updated,
+            badges=list(record.badges),
+        )
+
+    def _reject(self, http_status: int, code: str, message: str) -> HTTPException:
+        return HTTPException(status_code=http_status, detail={'code': code, 'message': message})

--- a/apps/api/tests/test_memory_api.py
+++ b/apps/api/tests/test_memory_api.py
@@ -1,0 +1,76 @@
+from fastapi.testclient import TestClient
+
+from apps.api.src.main import app
+from apps.api.src.modules.memory.service import MemoryService
+
+client = TestClient(app)
+
+
+def _assert_no_sensitive_keys(value):
+    forbidden = {'prompt', 'prompts', 'raw', 'raw_memory', 'internal_id', 'observation_id', 'session_id', 'token', 'secret'}
+    if isinstance(value, dict):
+        lowered = {str(key).lower() for key in value.keys()}
+        assert forbidden.isdisjoint(lowered)
+        for item in value.values():
+            _assert_no_sensitive_keys(item)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_no_sensitive_keys(item)
+
+
+def test_memory_summary_returns_safe_allowlisted_items():
+    response = client.get('/api/v1/memory')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'memory.summary'
+    assert payload['status'] == 'ready'
+    assert payload['meta']['read_only'] is True
+    assert payload['meta']['sources'] == ['built-in', 'honcho']
+    assert payload['meta']['sanitized'] is True
+    assert payload['meta']['count'] >= 8
+
+    item = next(entry for entry in payload['data']['items'] if entry['mugiwara_slug'] == 'zoro')
+    assert set(item.keys()) == {'mugiwara_slug', 'summary', 'fact_count', 'last_updated', 'badges'}
+    assert item['fact_count'] >= 1
+    assert item['badges']
+    _assert_no_sensitive_keys(payload)
+
+
+def test_memory_detail_returns_summary_without_raw_memory_dump():
+    response = client.get('/api/v1/memory/zoro')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'memory.agent_detail'
+    assert payload['status'] == 'ready'
+    assert payload['meta'] == {'mugiwara_slug': 'zoro', 'read_only': True, 'sanitized': True}
+
+    data = payload['data']
+    assert data['mugiwara_slug'] == 'zoro'
+    assert isinstance(data['built_in_summary'], str)
+    assert data['built_in_summary']
+    assert isinstance(data['honcho_facts'], list)
+    assert 1 <= len(data['honcho_facts']) <= 3
+    assert data['freshness']['status'] in {'fresh', 'stale', 'unknown'}
+    assert data['links'] == [{'label': 'Ver Mugiwara', 'href': '/mugiwaras'}]
+    _assert_no_sensitive_keys(payload)
+
+
+def test_memory_unknown_slug_returns_semantic_404_without_paths():
+    response = client.get('/api/v1/memory/unknown')
+
+    assert response.status_code == 404
+    detail = response.json()['detail']
+    assert detail['code'] == 'not_found'
+    assert 'unknown' not in detail['message'].lower()
+    assert '/srv/' not in detail['message']
+    assert '/home/' not in detail['message']
+
+
+def test_memory_service_empty_source_is_not_configured():
+    service = MemoryService(records=())
+
+    assert service.list_summary() == []
+    status = service.catalog_status()
+    assert status == 'not_configured'

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -24,9 +24,12 @@
 - no escribir sobre perfiles
 
 ### `memory`
-- exponer built-in memory en lectura
-- exponer Honcho solo como estado + facts resumidos
+- exponer `GET /api/v1/memory` como catálogo read-only de resúmenes saneados por agente
+- exponer `GET /api/v1/memory/{slug}` como detalle read-only acotado
+- exponer built-in memory solo como resumen allowlisted, nunca como dump crudo
+- exponer Honcho solo como facts resumidos y estado de frescura
 - dejar Engram modelado por proyecto en una fase posterior
+- no exponer prompts, IDs internos, sesiones, observaciones completas, tokens ni secretos
 
 ### `vault`
 - navegación, árbol, índices y lectura de markdown

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -55,6 +55,8 @@ Campos esperados:
 
 Uso:
 - visión resumida y detalle acotado de memoria por agente
+- mantener visible la distinción built-in/Honcho sin mezclar Engram
+- no exponer prompts, dumps crudos, IDs internos, sesiones ni observaciones completas
 
 ### `vault.index`
 Campos esperados:

--- a/openspec/phase-12-3a-memory-api-foundation.md
+++ b/openspec/phase-12-3a-memory-api-foundation.md
@@ -1,0 +1,44 @@
+# Phase 12.3a — memory read-only API foundation
+
+## Scope
+Create the backend-owned, sanitized read-only Memory API before wiring `/memory` to live backend data.
+
+## Why split 12.3
+The `memory` vertical has higher leak risk than `mugiwaras`: raw memory stores, prompts, internal IDs and relational context must not escape. This microphase introduces only a small backend-owned safe catalog and tests the leak boundary before frontend integration.
+
+## Design
+- Add backend module `apps/api/src/modules/memory`.
+- Expose:
+  - `GET /api/v1/memory` → sanitized agent summaries.
+  - `GET /api/v1/memory/{slug}` → sanitized detail for one Mugiwara.
+- Return only allowlisted fields already present in shared contracts:
+  - `mugiwara_slug`, `summary`, `fact_count`, `last_updated`, `badges`.
+  - `built_in_summary`, `honcho_facts`, `freshness`, `links`.
+- Keep built-in and Honcho visible as distinct sources in meta and detail text.
+- Do not expose Engram in this surface yet.
+- Do not read live memory stores, DB files, prompts, sessions or observations in this microphase.
+
+## Tasks
+- [x] Add RED backend tests for memory summary/detail/unknown slug and empty source state.
+- [x] Add `memory` domain/service/router.
+- [x] Register memory router in FastAPI app.
+- [x] Update backend docs for the module.
+- [x] Record verify evidence and continuity artifacts.
+
+## Out of scope
+- Frontend `/memory` adapter/integration.
+- Live Honcho/builtin memory connector.
+- Engram project memory surface.
+- Any write endpoint.
+
+## Definition of done
+- `/api/v1/memory` returns a read-only `memory.summary` envelope with `sources`, `sanitized`, and `read_only` meta.
+- `/api/v1/memory/{slug}` returns a read-only `memory.agent_detail` envelope without raw memory dumps.
+- Unknown slug returns semantic 404 without host paths.
+- Empty source can represent `not_configured` state.
+- Backend tests and py_compile pass.
+
+## Reviewer routing
+- Chopper: required, because this phase defines the leak boundary for memory data.
+- Franky: not required unless runtime/deploy changes appear.
+- Usopp: not required until frontend `/memory` integration changes.

--- a/openspec/phase-12-3a-memory-api-verify-checklist.md
+++ b/openspec/phase-12-3a-memory-api-verify-checklist.md
@@ -1,0 +1,21 @@
+# Phase 12.3a verify checklist — memory API foundation
+
+## TDD evidence
+- [x] RED: `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py` failed with `ModuleNotFoundError: No module named 'apps.api.src.modules.memory'` before implementation.
+- [x] GREEN: `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py` passed after implementation.
+
+## Backend verify
+- [x] `python -m py_compile apps/api/src/modules/memory/domain.py apps/api/src/modules/memory/service.py apps/api/src/modules/memory/router.py apps/api/src/main.py`
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py`
+- [x] shared backend regression suite: `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py` → 15 passed.
+
+## Frontend/contracts verify
+- [x] Not required: frontend/contracts not touched in this microphase.
+
+## Hygiene
+- [x] `git diff --check`
+- [x] `git status --short --branch`
+
+## Review
+- [ ] Open PR against `main`.
+- [ ] Ask Chopper for security/leak review.


### PR DESCRIPTION
## Qué he hecho
- Inicio Phase 12.3 como microfase 12.3a: foundation backend read-only para Memory.
- Añado módulo backend `apps/api/src/modules/memory` con `domain.py`, `service.py`, `router.py` y `AGENTS.md` local.
- Expongo endpoints:
  - `GET /api/v1/memory`
  - `GET /api/v1/memory/{slug}`
- Devuelve solo resúmenes saneados, contadores, badges, frescura, links y facts Honcho allowlisted.
- No lee stores reales, prompts, sesiones, observaciones completas, IDs internos ni secretos.
- Registro router en `apps/api/src/main.py`.
- Añado tests de leak boundary y docs/openspec/Engram.

## Por qué existe este cambio
- Phase 12.3 debe mover `/memory` hacia backend read-only sin exponer memoria cruda.
- La superficie Memory es sensible; he separado backend foundation antes de integración frontend para revisar la frontera de fuga con Chopper.

## Superficie afectada
- Backend FastAPI: nuevo módulo read-only `memory`.
- Tests backend: `apps/api/tests/test_memory_api.py`.
- Docs: `docs/api-modules.md`, `docs/read-models.md`.
- No toca frontend, contratos TS, auth, filesystem, dependencias, runtime ni CI.

## Verificación hecha por Zoro
- RED: `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py` falló antes de implementación por ausencia de `apps.api.src.modules.memory`.
- GREEN: `python -m py_compile apps/api/src/modules/memory/domain.py apps/api/src/modules/memory/service.py apps/api/src/modules/memory/router.py apps/api/src/main.py && PYTHONPATH=. pytest apps/api/tests/test_memory_api.py` → 4 passed.
- Regression backend: `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py` → 15 passed.
- `git diff --check` → OK.

## Riesgos que veo
- Riesgo principal: exposición accidental de memoria cruda. Mitigado con catálogo backend-owned/saneado y tests que rechazan claves sensibles (`prompt`, `raw`, `internal_id`, `session_id`, etc.).
- No conecta todavía con memoria real; eso queda para fase posterior con revisión de Chopper.
- Frontend `/memory` sigue fixture-backed hasta la siguiente microfase.

## Reviewer solicitado
- Chopper: revisar seguridad/leak boundary de la API Memory y que no se expongan prompts, raw stores, IDs internos, sesiones, observaciones ni secretos.

## Regla de merge
No mergear hasta que Chopper deje `approve` o `mergeable_with_minor_followups`.
