### PR TITLE
feat: integrate memory page with read-only api

### DIFF
--- a/.engram/phase-12-3b-memory-frontend-closeout.md
+++ b/.engram/phase-12-3b-memory-frontend-closeout.md
@@ -1,0 +1,22 @@
+# Phase 12.3b closeout — memory frontend API integration
+
+## Resultado
+- `/memory` se integra con la API read-only de Phase 12.3a.
+- La ruta se divide en loader server-side (`page.tsx`) y componente cliente (`MemoryClient.tsx`).
+- La UI mantiene selección interactiva por Mugiwara y tabs Built-in/Honcho sin hacer fetch directo desde navegador.
+- Si falta o falla la API, la página cae a fixture saneado y muestra aviso explícito.
+
+## Decisión técnica
+El fetch de Memory queda server-side para evitar CORS en browser y mantener la frontera de datos más controlada. El cliente recibe solo datos saneados ya cargados o fallback local.
+
+## Verify ejecutado
+- `npm --prefix apps/web run typecheck` → OK.
+- `npm --prefix apps/web run build` → OK.
+- Backend regression: `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py` → 15 passed.
+- Smoke local API + web: `/memory` renderiza `API solo lectura`; Built-in y Honcho para Zoro muestran contenido API-backed; consola del navegador sin errores tras carga e interacción.
+- Tras review de Usopp: se corrigió wrapping de `StatusBadge`, semántica de tabs y copy `API solo lectura`.
+
+## Riesgos abiertos
+- La integración sigue usando catálogo saneado backend-owned; conectar stores reales queda fuera de alcance y requerirá nueva revisión de Chopper.
+- El server loader pide detalle para todos los Mugiwara conocidos; aceptable para catálogo pequeño, pero si crece convendrá endpoint agregado o lazy server action/proxy.
+- PR requiere Chopper + Usopp por mezclar frontera de datos y UI visible.

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -133,8 +133,7 @@ button {
   align-items: center;
   max-width: 100%;
   text-align: center;
-  white-space: normal;
-  overflow-wrap: anywhere;
+  white-space: nowrap;
 }
 
 .responsive-code {

--- a/apps/web/src/app/memory/MemoryClient.tsx
+++ b/apps/web/src/app/memory/MemoryClient.tsx
@@ -1,0 +1,381 @@
+'use client'
+
+import { useState } from 'react'
+
+import type { MemoryAgentDetail as ApiMemoryAgentDetail, MemoryAgentSummary as ApiMemoryAgentSummary } from '@contracts/read-models'
+import { memoryAgentDetailFixture, type MemoryAgentDetail, type MemorySourceKey, type MemorySourceSnapshot, type MemorySourceState } from '@/modules/memory/view-models/memory-agent-detail.fixture'
+import { memoryAgentSummaryFixture } from '@/modules/memory/view-models/memory-agent-summary.fixture'
+import { getMugiwaraProfile, MUGIWARA_SLUGS, type MugiwaraSlug } from '@/shared/mugiwara/crest-map'
+import { MugiwaraCrest } from '@/shared/mugiwara/MugiwaraCrest'
+import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
+import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
+import { StatePanel } from '@/shared/ui/state/StatePanel'
+import { StatusBadge } from '@/shared/ui/status/StatusBadge'
+import { appTheme, type AppStatus } from '@/shared/theme/tokens'
+
+const sourceLabelMap: Record<MemorySourceKey, string> = {
+  'built-in': 'Built-in',
+  honcho: 'Honcho',
+}
+
+function formatTimestamp(value: string | null) {
+  if (!value) {
+    return 'sin fecha'
+  }
+
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return new Intl.DateTimeFormat('es-ES', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(date)
+}
+
+function mapSourceStateToStatus(state: MemorySourceState): AppStatus {
+  switch (state) {
+    case 'initialized':
+      return 'operativo'
+    case 'stale':
+      return 'stale'
+    case 'error':
+      return 'incidencia'
+    case 'unavailable':
+    default:
+      return 'sin-datos'
+  }
+}
+
+function mapFreshnessToSourceState(status: ApiMemoryAgentDetail['freshness']['status']): MemorySourceState {
+  switch (status) {
+    case 'fresh':
+      return 'initialized'
+    case 'stale':
+      return 'stale'
+    case 'unknown':
+    default:
+      return 'unavailable'
+  }
+}
+
+function mapApiDetailToViewModel(detail: ApiMemoryAgentDetail): MemoryAgentDetail {
+  const sourceState = mapFreshnessToSourceState(detail.freshness.status)
+  const updatedAt = detail.freshness.updated_at ?? new Date(0).toISOString()
+
+  return {
+    mugiwara_slug: detail.mugiwara_slug as MugiwaraSlug,
+    built_in: {
+      state: sourceState,
+      updated_at: updatedAt,
+      summary: detail.built_in_summary,
+      availability: detail.freshness.source_label ?? 'Resumen built-in saneado desde API.',
+      facts: detail.built_in_summary ? [detail.built_in_summary] : [],
+    },
+    honcho: {
+      state: detail.honcho_facts.length > 0 ? sourceState : 'unavailable',
+      updated_at: updatedAt,
+      summary: detail.honcho_facts.length > 0 ? 'Facts Honcho resumidos y allowlisted desde API.' : 'Sin facts Honcho resumidos disponibles.',
+      availability: detail.honcho_facts.length > 0 ? 'Resumen Honcho saneado desde API.' : 'Honcho no configurado para esta vista saneada.',
+      facts: detail.honcho_facts,
+    },
+  }
+}
+
+function getMemoryStateNotice(snapshot: MemorySourceSnapshot, sourceLabel: string, mugiwaraName: string) {
+  switch (snapshot.state) {
+    case 'stale':
+      return {
+        status: 'stale' as const,
+        title: `${sourceLabel} disponible pero desactualizada`,
+        description: `La fuente sigue siendo legible para ${mugiwaraName}, pero conviene refrescarla antes de usarla como referencia operativa fuerte.`,
+        detail: snapshot.availability,
+      }
+    case 'error':
+      return {
+        status: 'incidencia' as const,
+        title: `${sourceLabel} con incidencia activa`,
+        description: `La última sincronización de ${sourceLabel} falló para ${mugiwaraName}. La lectura actual no debe tomarse como síntesis fiable hasta reintentar la generación.`,
+        detail: snapshot.availability,
+      }
+    case 'unavailable':
+      return {
+        status: 'sin-datos' as const,
+        title: `${sourceLabel} todavía no inicializada`,
+        description: `No hay contexto suficiente para mostrar una vista completa de ${sourceLabel} en ${mugiwaraName}. El resto del workspace debe seguir siendo navegable sin romper la superficie.`,
+        detail: snapshot.availability,
+      }
+    case 'initialized':
+    default:
+      return null
+  }
+}
+
+export type MemoryPageNotice = { status: AppStatus; title: string; description: string; detail?: string }
+
+type MemoryClientProps = {
+  apiSummaries: ApiMemoryAgentSummary[] | null
+  apiDetails: Partial<Record<MugiwaraSlug, ApiMemoryAgentDetail>>
+  apiState: 'ready' | 'fallback'
+  apiNotice: MemoryPageNotice | null
+}
+
+export function MemoryClient({ apiSummaries, apiDetails, apiState, apiNotice }: MemoryClientProps) {
+  const [selectedMugiwara, setSelectedMugiwara] = useState<MugiwaraSlug>('zoro')
+  const [selectedSource, setSelectedSource] = useState<MemorySourceKey>('built-in')
+
+  const summaries = apiSummaries ?? memoryAgentSummaryFixture
+  const selectedApiDetail = apiDetails[selectedMugiwara]
+  const selectedDetail = selectedApiDetail
+    ? mapApiDetailToViewModel(selectedApiDetail)
+    : memoryAgentDetailFixture.find((item) => item.mugiwara_slug === selectedMugiwara) ?? memoryAgentDetailFixture[0]
+
+  const selectedSnapshot = selectedSource === 'built-in' ? selectedDetail.built_in : selectedDetail.honcho
+  const selectedProfile = getMugiwaraProfile(selectedMugiwara)
+  const selectedSummary = summaries.find((item) => item.mugiwara_slug === selectedMugiwara)
+  const selectedBadges = selectedSummary?.badges ?? []
+  const sourceNotice = getMemoryStateNotice(selectedSnapshot, sourceLabelMap[selectedSource], selectedProfile.name)
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="Memory"
+        title="Memoria operativa"
+        subtitle="Selector por Mugiwara, tabs Built-in/Honcho y lectura resumida de fuente, manteniendo separación explícita respecto a Vault."
+        mugiwaraSlug="robin"
+        detailPills={['Continuidad viva', 'Fuentes separadas', apiState === 'ready' ? 'API solo lectura' : 'Fallback saneado']}
+      />
+
+      {apiNotice ? (
+        <section className="section-block">
+          <StatePanel
+            status={apiNotice.status}
+            title={apiNotice.title}
+            description={apiNotice.description}
+            detail={apiNotice.detail}
+            eyebrow="Estado API Memory"
+          />
+        </section>
+      ) : null}
+
+      <section className="layout-grid layout-grid--sidebar-detail">
+        <div style={{ display: 'grid', gap: '14px' }}>
+          <SurfaceCard title="Memoria operativa" elevated eyebrow="Contexto" accent="sky">
+            <div style={{ display: 'grid', gap: '10px' }}>
+              <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
+                Memory muestra continuidad por Mugiwara y estado resumido de fuentes. No es una superficie editable ni se mezcla con el canon curado del Vault.
+              </p>
+              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                <StatusBadge status={apiState === 'ready' ? 'operativo' : 'sin-datos'} />
+                <span
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    borderRadius: '999px',
+                    padding: '4px 10px',
+                    background: appTheme.colors.bgSurface1,
+                    border: `1px solid ${appTheme.colors.borderSubtle}`,
+                    color: appTheme.colors.brandSky500,
+                    fontSize: '12px',
+                    fontWeight: 700,
+                  }}
+                >
+                  Solo lectura
+                </span>
+              </div>
+            </div>
+          </SurfaceCard>
+
+          <SurfaceCard title="Selector de Mugiwara" elevated eyebrow="Tripulación" accent="gold">
+            <div style={{ display: 'grid', gap: '10px' }}>
+              {MUGIWARA_SLUGS.map((slug) => {
+                const profile = getMugiwaraProfile(slug)
+                const summary = summaries.find((item) => item.mugiwara_slug === slug)
+                const isSelected = slug === selectedMugiwara
+
+                return (
+                  <button
+                    key={slug}
+                    type="button"
+                    onClick={() => setSelectedMugiwara(slug)}
+                    aria-pressed={isSelected}
+                    style={{
+                      textAlign: 'left',
+                      borderRadius: '12px',
+                      padding: '12px',
+                      cursor: 'pointer',
+                      border: `1px solid ${isSelected ? appTheme.colors.brandSky500 : appTheme.colors.borderSubtle}`,
+                      background: isSelected ? appTheme.colors.bgSurface2 : appTheme.colors.bgSurface1,
+                      color: appTheme.colors.textPrimary,
+                      display: 'grid',
+                      gap: '8px',
+                    }}
+                  >
+                    <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', alignItems: 'center' }}>
+                      <div style={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
+                        <MugiwaraCrest slug={slug} size="sm" accent={isSelected} />
+                        <div style={{ display: 'grid', gap: '2px' }}>
+                          <strong>{profile.name}</strong>
+                          <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>{profile.role}</span>
+                        </div>
+                      </div>
+                      <StatusBadge status={summary && summary.fact_count >= 5 ? 'operativo' : 'revision'} />
+                    </div>
+                    {summary ? (
+                      <>
+                        <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{summary.summary}</span>
+                        <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>
+                          {summary.fact_count} facts · actualizado {formatTimestamp(summary.last_updated)}
+                        </span>
+                      </>
+                    ) : (
+                      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>Sin resumen cargado.</span>
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+          </SurfaceCard>
+        </div>
+
+        <div style={{ display: 'grid', gap: '14px' }}>
+          <SurfaceCard title="Fuentes de memoria" elevated eyebrow="Fuentes" accent="sky">
+            <div style={{ display: 'grid', gap: '12px' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap', alignItems: 'center' }}>
+                <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
+                  <MugiwaraCrest slug={selectedMugiwara} size="md" accent />
+                  <div style={{ display: 'grid', gap: '2px' }}>
+                    <strong style={{ fontSize: '18px' }}>{selectedProfile.name}</strong>
+                    <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>{selectedProfile.role}</span>
+                  </div>
+                </div>
+                <StatusBadge status={mapSourceStateToStatus(selectedSnapshot.state)} />
+              </div>
+
+              <div role="tablist" aria-label="Fuente de memoria" style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                {(['built-in', 'honcho'] as MemorySourceKey[]).map((source) => {
+                  const active = source === selectedSource
+                  return (
+                    <button
+                      key={source}
+                      type="button"
+                      role="tab"
+                      aria-selected={active}
+                      onClick={() => setSelectedSource(source)}
+                      style={{
+                        borderRadius: '999px',
+                        border: `1px solid ${active ? appTheme.colors.brandSky500 : appTheme.colors.borderSubtle}`,
+                        background: active ? appTheme.colors.bgSurface2 : appTheme.colors.bgSurface1,
+                        color: active ? appTheme.colors.brandSky500 : appTheme.colors.textSecondary,
+                        padding: '8px 14px',
+                        fontWeight: 700,
+                        cursor: 'pointer',
+                      }}
+                    >
+                      {sourceLabelMap[source]}
+                    </button>
+                  )
+                })}
+              </div>
+
+              <div
+                style={{
+                  display: 'grid',
+                  gap: '10px',
+                  padding: '12px',
+                  borderRadius: '12px',
+                  background: appTheme.colors.bgSurface1,
+                  border: `1px solid ${appTheme.colors.borderSubtle}`,
+                }}
+              >
+                <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Estado de fuente</span>
+                <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+                  <StatusBadge status={mapSourceStateToStatus(selectedSnapshot.state)} />
+                  <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{selectedSnapshot.availability}</span>
+                  <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>
+                    Última actualización: {formatTimestamp(selectedSnapshot.updated_at)}
+                  </span>
+                </div>
+                <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>{selectedSnapshot.summary}</p>
+              </div>
+
+              {sourceNotice ? (
+                <StatePanel
+                  status={sourceNotice.status}
+                  title={sourceNotice.title}
+                  description={sourceNotice.description}
+                  detail={sourceNotice.detail}
+                  eyebrow="Estado de fuente"
+                />
+              ) : null}
+            </div>
+          </SurfaceCard>
+
+          <SurfaceCard title="Contenido resumido" elevated eyebrow="Lectura viva" accent="gold">
+            <div style={{ display: 'grid', gap: '12px' }}>
+              <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
+                Vista legible y resumida de la memoria {sourceLabelMap[selectedSource]} para {selectedProfile.name}. El detalle sigue siendo operacional y no documental.
+              </p>
+
+              {selectedBadges.length > 0 ? (
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+                  {selectedBadges.map((badge) => (
+                    <span
+                      key={badge}
+                      style={{
+                        border: `1px solid ${appTheme.colors.borderSubtle}`,
+                        borderRadius: '999px',
+                        padding: '4px 10px',
+                        color: appTheme.colors.textSecondary,
+                        fontSize: '12px',
+                        background: appTheme.colors.bgSurface1,
+                      }}
+                    >
+                      {badge}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <StatePanel
+                  status="sin-datos"
+                  title="Sin etiquetas visibles"
+                  description={`Todavía no hay badges resumidos para ${selectedProfile.name}. La ausencia de etiquetas no debe romper la lectura del resto del contenido.`}
+                  eyebrow="Estado vacío"
+                />
+              )}
+
+              <div style={{ display: 'grid', gap: '8px' }}>
+                {selectedSnapshot.facts.length > 0 ? (
+                  selectedSnapshot.facts.map((fact) => (
+                    <div
+                      key={fact}
+                      style={{
+                        borderRadius: '12px',
+                        border: `1px solid ${appTheme.colors.borderSubtle}`,
+                        padding: '12px',
+                        background: appTheme.colors.bgSurface1,
+                        color: appTheme.colors.textSecondary,
+                      }}
+                    >
+                      {fact}
+                    </div>
+                  ))
+                ) : (
+                  <StatePanel
+                    status={sourceNotice?.status ?? 'sin-datos'}
+                    title="Sin facts resumidos"
+                    description={`No hay hechos operativos visibles para la combinación ${selectedProfile.name} + ${sourceLabelMap[selectedSource]}.`}
+                    detail={selectedSnapshot.availability}
+                    eyebrow="Estado vacío"
+                  />
+                )}
+              </div>
+            </div>
+          </SurfaceCard>
+        </div>
+      </section>
+    </>
+  )
+}

--- a/apps/web/src/app/memory/page.tsx
+++ b/apps/web/src/app/memory/page.tsx
@@ -1,319 +1,80 @@
-'use client'
+import type { MemoryAgentDetail as ApiMemoryAgentDetail, MemoryAgentSummary as ApiMemoryAgentSummary } from '@contracts/read-models'
 
-import { useMemo, useState } from 'react'
+import { fetchMemoryDetail, fetchMemorySummary, MemoryApiError } from '@/modules/memory/api/memory-http'
+import { MUGIWARA_SLUGS, type MugiwaraSlug } from '@/shared/mugiwara/crest-map'
+import type { AppStatus } from '@/shared/theme/tokens'
 
-import { memoryAgentDetailFixture, type MemorySourceKey, type MemorySourceSnapshot, type MemorySourceState } from '@/modules/memory/view-models/memory-agent-detail.fixture'
-import { memoryAgentSummaryFixture } from '@/modules/memory/view-models/memory-agent-summary.fixture'
-import { getMugiwaraProfile, MUGIWARA_SLUGS, type MugiwaraSlug } from '@/shared/mugiwara/crest-map'
-import { MugiwaraCrest } from '@/shared/mugiwara/MugiwaraCrest'
-import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
-import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
-import { StatePanel } from '@/shared/ui/state/StatePanel'
-import { StatusBadge } from '@/shared/ui/status/StatusBadge'
-import { appTheme, type AppStatus } from '@/shared/theme/tokens'
+import { MemoryClient, type MemoryPageNotice } from './MemoryClient'
 
-const sourceLabelMap: Record<MemorySourceKey, string> = {
-  'built-in': 'Built-in',
-  honcho: 'Honcho',
+type InitialMemoryData = {
+  apiSummaries: ApiMemoryAgentSummary[] | null
+  apiDetails: Partial<Record<MugiwaraSlug, ApiMemoryAgentDetail>>
+  apiState: 'ready' | 'fallback'
+  apiNotice: MemoryPageNotice | null
 }
 
-function formatTimestamp(value: string) {
-  const date = new Date(value)
+async function getInitialMemoryData(): Promise<InitialMemoryData> {
+  try {
+    const summary = await fetchMemorySummary()
 
-  if (Number.isNaN(date.getTime())) {
-    return value
-  }
-
-  return new Intl.DateTimeFormat('es-ES', {
-    dateStyle: 'short',
-    timeStyle: 'short',
-  }).format(date)
-}
-
-function mapSourceStateToStatus(state: MemorySourceState): AppStatus {
-  switch (state) {
-    case 'initialized':
-      return 'operativo'
-    case 'stale':
-      return 'stale'
-    case 'error':
-      return 'incidencia'
-    case 'unavailable':
-    default:
-      return 'sin-datos'
-  }
-}
-
-function getMemoryStateNotice(snapshot: MemorySourceSnapshot, sourceLabel: string, mugiwaraName: string) {
-  switch (snapshot.state) {
-    case 'stale':
+    if (summary.status !== 'ready') {
       return {
-        status: 'stale' as const,
-        title: `${sourceLabel} disponible pero desactualizada`,
-        description: `La fuente sigue siendo legible para ${mugiwaraName}, pero conviene refrescarla antes de usarla como referencia operativa fuerte.`,
-        detail: snapshot.availability,
+        apiSummaries: null,
+        apiDetails: {},
+        apiState: 'fallback',
+        apiNotice: {
+          status: 'sin-datos',
+          title: 'API Memory sin datos configurados',
+          description: 'La API respondió sin catálogo disponible; se mantiene fixture saneado para no romper la lectura.',
+          detail: summary.status,
+        },
       }
-    case 'error':
-      return {
-        status: 'incidencia' as const,
-        title: `${sourceLabel} con incidencia activa`,
-        description: `La última sincronización de ${sourceLabel} falló para ${mugiwaraName}. La lectura actual no debe tomarse como síntesis fiable hasta reintentar la generación.`,
-        detail: snapshot.availability,
+    }
+
+    const detailResults = await Promise.allSettled(MUGIWARA_SLUGS.map((slug) => fetchMemoryDetail(slug)))
+    const apiDetails: Partial<Record<MugiwaraSlug, ApiMemoryAgentDetail>> = {}
+
+    detailResults.forEach((result, index) => {
+      if (result.status === 'fulfilled') {
+        apiDetails[MUGIWARA_SLUGS[index]] = result.value.data
       }
-    case 'unavailable':
-      return {
-        status: 'sin-datos' as const,
-        title: `${sourceLabel} todavía no inicializada`,
-        description: `No hay contexto suficiente para mostrar una vista completa de ${sourceLabel} en ${mugiwaraName}. El resto del workspace debe seguir siendo navegable sin romper la superficie.`,
-        detail: snapshot.availability,
-      }
-    case 'initialized':
-    default:
-      return null
+    })
+
+    const missingDetails = MUGIWARA_SLUGS.length - Object.keys(apiDetails).length
+
+    return {
+      apiSummaries: summary.data.items,
+      apiDetails,
+      apiState: 'ready',
+      apiNotice:
+        missingDetails > 0
+          ? {
+              status: 'stale' as AppStatus,
+              title: 'API Memory parcialmente disponible',
+              description: 'El catálogo se ha cargado desde backend, pero algún detalle ha caído a fixture saneado.',
+              detail: `${missingDetails} detalles no disponibles`,
+            }
+          : null,
+    }
+  } catch (error) {
+    const apiError = error instanceof MemoryApiError ? error : null
+
+    return {
+      apiSummaries: null,
+      apiDetails: {},
+      apiState: 'fallback',
+      apiNotice: {
+        status: apiError?.code === 'not_configured' ? 'sin-datos' : 'incidencia',
+        title: apiError?.code === 'not_configured' ? 'API Memory no configurada' : 'API Memory no disponible',
+        description: 'La página mantiene el fallback saneado local. No se muestran dumps crudos ni detalles técnicos de memoria.',
+        detail: apiError?.code,
+      },
+    }
   }
 }
 
-export default function MemoryPage() {
-  const [selectedMugiwara, setSelectedMugiwara] = useState<MugiwaraSlug>('zoro')
-  const [selectedSource, setSelectedSource] = useState<MemorySourceKey>('built-in')
+export default async function MemoryPage() {
+  const initialData = await getInitialMemoryData()
 
-  const selectedDetail = useMemo(
-    () => memoryAgentDetailFixture.find((item) => item.mugiwara_slug === selectedMugiwara) ?? memoryAgentDetailFixture[0],
-    [selectedMugiwara],
-  )
-
-  const selectedSnapshot = selectedSource === 'built-in' ? selectedDetail.built_in : selectedDetail.honcho
-  const selectedProfile = getMugiwaraProfile(selectedMugiwara)
-  const selectedSummary = memoryAgentSummaryFixture.find((item) => item.mugiwara_slug === selectedMugiwara)
-  const selectedBadges = selectedSummary?.badges ?? []
-  const sourceNotice = getMemoryStateNotice(selectedSnapshot, sourceLabelMap[selectedSource], selectedProfile.name)
-
-  return (
-    <>
-      <PageHeader
-        eyebrow="Memory"
-        title="Memoria operativa"
-        subtitle="Selector por Mugiwara, tabs Built-in/Honcho y lectura resumida de fuente, manteniendo separación explícita respecto a Vault."
-        mugiwaraSlug="robin"
-        detailPills={['Continuidad viva', 'Fuentes separadas', 'Sin canon curado']}
-      />
-
-      <section className="layout-grid layout-grid--sidebar-detail">
-        <div style={{ display: 'grid', gap: '14px' }}>
-          <SurfaceCard title="Memoria operativa" elevated eyebrow="Contexto" accent="sky">
-            <div style={{ display: 'grid', gap: '10px' }}>
-              <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
-                Memory muestra continuidad por Mugiwara y estado resumido de fuentes. No es una superficie editable ni se mezcla con el canon curado del Vault.
-              </p>
-              <div role="tablist" aria-label="Fuentes de memoria" style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                <StatusBadge status="operativo" />
-                <span
-                  style={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    borderRadius: '999px',
-                    padding: '4px 10px',
-                    background: appTheme.colors.bgSurface1,
-                    border: `1px solid ${appTheme.colors.borderSubtle}`,
-                    color: appTheme.colors.brandSky500,
-                    fontSize: '12px',
-                    fontWeight: 700,
-                  }}
-                >
-                  Solo lectura
-                </span>
-              </div>
-            </div>
-          </SurfaceCard>
-
-          <SurfaceCard title="Selector de Mugiwara" elevated eyebrow="Tripulación" accent="gold">
-            <div style={{ display: 'grid', gap: '10px' }}>
-              {MUGIWARA_SLUGS.map((slug) => {
-                const profile = getMugiwaraProfile(slug)
-                const summary = memoryAgentSummaryFixture.find((item) => item.mugiwara_slug === slug)
-                const isSelected = slug === selectedMugiwara
-
-                return (
-                  <button
-                    key={slug}
-                    type="button"
-                    onClick={() => setSelectedMugiwara(slug)}
-                    aria-pressed={isSelected}
-                    style={{
-                      textAlign: 'left',
-                      borderRadius: '12px',
-                      padding: '12px',
-                      cursor: 'pointer',
-                      border: `1px solid ${isSelected ? appTheme.colors.brandSky500 : appTheme.colors.borderSubtle}`,
-                      background: isSelected ? appTheme.colors.bgSurface2 : appTheme.colors.bgSurface1,
-                      color: appTheme.colors.textPrimary,
-                      display: 'grid',
-                      gap: '8px',
-                    }}
-                  >
-                    <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', alignItems: 'center' }}>
-                      <div style={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
-                        <MugiwaraCrest slug={slug} size="sm" accent={isSelected} />
-                        <div style={{ display: 'grid', gap: '2px' }}>
-                          <strong>{profile.name}</strong>
-                          <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>{profile.role}</span>
-                        </div>
-                      </div>
-                      <StatusBadge status={summary && summary.fact_count >= 5 ? 'operativo' : 'revision'} />
-                    </div>
-                    {summary ? (
-                      <>
-                        <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{summary.summary}</span>
-                        <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>
-                          {summary.fact_count} facts · actualizado {formatTimestamp(summary.last_updated)}
-                        </span>
-                      </>
-                    ) : (
-                      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>Sin resumen cargado.</span>
-                    )}
-                  </button>
-                )
-              })}
-            </div>
-          </SurfaceCard>
-        </div>
-
-        <div style={{ display: 'grid', gap: '14px' }}>
-          <SurfaceCard title="Fuentes de memoria" elevated eyebrow="Fuentes" accent="sky">
-            <div style={{ display: 'grid', gap: '12px' }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap', alignItems: 'center' }}>
-                <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
-                  <MugiwaraCrest slug={selectedMugiwara} size="md" accent />
-                  <div style={{ display: 'grid', gap: '2px' }}>
-                    <strong style={{ fontSize: '18px' }}>{selectedProfile.name}</strong>
-                    <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>{selectedProfile.role}</span>
-                  </div>
-                </div>
-                <StatusBadge status={mapSourceStateToStatus(selectedSnapshot.state)} />
-              </div>
-
-              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                {(['built-in', 'honcho'] as MemorySourceKey[]).map((source) => {
-                  const active = source === selectedSource
-                  return (
-                    <button
-                      key={source}
-                      type="button"
-                      role="tab"
-                      aria-selected={active}
-                      onClick={() => setSelectedSource(source)}
-                      style={{
-                        borderRadius: '999px',
-                        border: `1px solid ${active ? appTheme.colors.brandSky500 : appTheme.colors.borderSubtle}`,
-                        background: active ? appTheme.colors.bgSurface2 : appTheme.colors.bgSurface1,
-                        color: active ? appTheme.colors.brandSky500 : appTheme.colors.textSecondary,
-                        padding: '8px 14px',
-                        fontWeight: 700,
-                        cursor: 'pointer',
-                      }}
-                    >
-                      {sourceLabelMap[source]}
-                    </button>
-                  )
-                })}
-              </div>
-
-              <div
-                style={{
-                  display: 'grid',
-                  gap: '10px',
-                  padding: '12px',
-                  borderRadius: '12px',
-                  background: appTheme.colors.bgSurface1,
-                  border: `1px solid ${appTheme.colors.borderSubtle}`,
-                }}
-              >
-                <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Estado de fuente</span>
-                <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
-                  <StatusBadge status={mapSourceStateToStatus(selectedSnapshot.state)} />
-                  <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{selectedSnapshot.availability}</span>
-                  <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>
-                    Última actualización: {formatTimestamp(selectedSnapshot.updated_at)}
-                  </span>
-                </div>
-                <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>{selectedSnapshot.summary}</p>
-              </div>
-
-              {sourceNotice ? (
-                <StatePanel
-                  status={sourceNotice.status}
-                  title={sourceNotice.title}
-                  description={sourceNotice.description}
-                  detail={sourceNotice.detail}
-                  eyebrow="Estado de fuente"
-                />
-              ) : null}
-            </div>
-          </SurfaceCard>
-
-          <SurfaceCard title="Contenido resumido" elevated eyebrow="Lectura viva" accent="gold">
-            <div style={{ display: 'grid', gap: '12px' }}>
-              <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
-                Vista legible y resumida de la memoria {sourceLabelMap[selectedSource]} para {selectedProfile.name}. El detalle sigue siendo operacional y no documental.
-              </p>
-
-              {selectedBadges.length > 0 ? (
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
-                  {selectedBadges.map((badge) => (
-                    <span
-                      key={badge}
-                      style={{
-                        border: `1px solid ${appTheme.colors.borderSubtle}`,
-                        borderRadius: '999px',
-                        padding: '4px 10px',
-                        color: appTheme.colors.textSecondary,
-                        fontSize: '12px',
-                        background: appTheme.colors.bgSurface1,
-                      }}
-                    >
-                      {badge}
-                    </span>
-                  ))}
-                </div>
-              ) : (
-                <StatePanel
-                  status="sin-datos"
-                  title="Sin etiquetas visibles"
-                  description={`Todavía no hay badges resumidos para ${selectedProfile.name}. La ausencia de etiquetas no debe romper la lectura del resto del contenido.`}
-                  eyebrow="Estado vacío"
-                />
-              )}
-
-              <div style={{ display: 'grid', gap: '8px' }}>
-                {selectedSnapshot.facts.length > 0 ? (
-                  selectedSnapshot.facts.map((fact) => (
-                    <div
-                      key={fact}
-                      style={{
-                        borderRadius: '12px',
-                        border: `1px solid ${appTheme.colors.borderSubtle}`,
-                        padding: '12px',
-                        background: appTheme.colors.bgSurface1,
-                        color: appTheme.colors.textSecondary,
-                      }}
-                    >
-                      {fact}
-                    </div>
-                  ))
-                ) : (
-                  <StatePanel
-                    status={sourceNotice?.status ?? 'sin-datos'}
-                    title="Sin facts resumidos"
-                    description={`No hay hechos operativos visibles para la combinación ${selectedProfile.name} + ${sourceLabelMap[selectedSource]}.`}
-                    detail={selectedSnapshot.availability}
-                    eyebrow="Estado vacío"
-                  />
-                )}
-              </div>
-            </div>
-          </SurfaceCard>
-        </div>
-      </section>
-    </>
-  )
+  return <MemoryClient {...initialData} />
 }

--- a/apps/web/src/modules/memory/api/memory-http.ts
+++ b/apps/web/src/modules/memory/api/memory-http.ts
@@ -1,0 +1,86 @@
+import type { MemoryDetailResponse, MemorySummaryResponse } from '@contracts/read-models'
+
+export class MemoryApiError extends Error {
+  status: number
+  code: string
+
+  constructor(message: string, options: { status: number; code: string }) {
+    super(message)
+    this.name = 'MemoryApiError'
+    this.status = options.status
+    this.code = options.code
+  }
+}
+
+type ApiErrorPayload = {
+  detail?: {
+    code?: string
+    message?: string
+  }
+}
+
+function trimTrailingSlash(value: string) {
+  return value.replace(/\/$/, '')
+}
+
+export function getMemoryApiBaseUrl() {
+  const value = process.env.NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL
+  return value ? trimTrailingSlash(value) : null
+}
+
+async function parseApiError(response: Response) {
+  let payload: ApiErrorPayload | null = null
+
+  try {
+    payload = (await response.json()) as ApiErrorPayload
+  } catch {
+    payload = null
+  }
+
+  return new MemoryApiError(payload?.detail?.message ?? `http_${response.status}`, {
+    status: response.status,
+    code: payload?.detail?.code ?? `http_${response.status}`,
+  })
+}
+
+export async function fetchMemorySummary(): Promise<MemorySummaryResponse> {
+  const baseUrl = getMemoryApiBaseUrl()
+
+  if (!baseUrl) {
+    throw new MemoryApiError('not_configured', { status: 0, code: 'not_configured' })
+  }
+
+  const response = await fetch(`${baseUrl}/api/v1/memory`, {
+    cache: 'no-store',
+    headers: {
+      Accept: 'application/json',
+    },
+  })
+
+  if (!response.ok) {
+    throw await parseApiError(response)
+  }
+
+  return (await response.json()) as MemorySummaryResponse
+}
+
+export async function fetchMemoryDetail(slug: string): Promise<MemoryDetailResponse> {
+  const baseUrl = getMemoryApiBaseUrl()
+
+  if (!baseUrl) {
+    throw new MemoryApiError('not_configured', { status: 0, code: 'not_configured' })
+  }
+
+  const response = await fetch(`${baseUrl}/api/v1/memory/${encodeURIComponent(slug)}`, {
+    cache: 'no-store',
+    headers: {
+      Accept: 'application/json',
+    },
+  })
+
+  if (!response.ok) {
+    throw await parseApiError(response)
+  }
+
+  return (await response.json()) as MemoryDetailResponse
+}

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -26,6 +26,7 @@
 ### `memory`
 - exponer `GET /api/v1/memory` como catálogo read-only de resúmenes saneados por agente
 - exponer `GET /api/v1/memory/{slug}` como detalle read-only acotado
+- integrar `/memory` desde frontend mediante loader server-side y componente cliente interactivo
 - exponer built-in memory solo como resumen allowlisted, nunca como dump crudo
 - exponer Honcho solo como facts resumidos y estado de frescura
 - dejar Engram modelado por proyecto en una fase posterior

--- a/openspec/phase-12-3b-memory-frontend-integration.md
+++ b/openspec/phase-12-3b-memory-frontend-integration.md
@@ -1,0 +1,37 @@
+# Phase 12.3b — memory frontend API integration
+
+## Scope
+Integrate `/memory` with the Phase 12.3a read-only Memory API while preserving the existing safe fixture fallback and the explicit built-in/Honcho separation.
+
+## Design
+- Keep `/memory` interactive, but move API reads to the server page to avoid browser-side CORS and prevent direct client fetching of memory endpoints.
+- Split the route into:
+  - `page.tsx` server loader: fetches `GET /api/v1/memory` and safe details for all known Mugiwara slugs when API URL is configured.
+  - `MemoryClient.tsx` client component: owns only UI state (`selectedMugiwara`, `selectedSource`) and receives sanitized initial data.
+- Preserve fixture fallback when `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` is absent, unavailable or partially degraded.
+- Keep payloads limited to existing contracts: summaries, counts, badges, freshness, links and allowlisted facts.
+
+## Tasks
+- [x] Add frontend Memory API adapter.
+- [x] Split `/memory` into server loader + client component.
+- [x] Render `API solo lectura` vs `Fallback saneado` state in the header.
+- [x] Tighten Memory tab semantics and prevent short status badges from wrapping.
+- [x] Preserve source tabs and safe fallback content.
+- [x] Smoke `/memory` with API configured and verify no browser console CORS/fetch errors.
+
+## Out of scope
+- No live memory store connector.
+- No backend contract expansion.
+- No raw prompts, observations, sessions or Engram detail.
+- No write actions.
+
+## Definition of done
+- With API configured, `/memory` renders API-backed summary/detail content.
+- The source tabs expose a real `tablist`; informational badges are not announced as tabs.
+- Without API configured or on API error, `/memory` keeps the safe fallback and explicit notice.
+- Browser console stays clean in the API-backed smoke.
+- Typecheck/build/backend regression pass.
+
+## Reviewer routing
+- Chopper: review data boundary and that server-side fetch still exposes only sanitized payloads.
+- Usopp: review visible `/memory` UI state, copy and source separation.

--- a/openspec/phase-12-3b-memory-frontend-verify-checklist.md
+++ b/openspec/phase-12-3b-memory-frontend-verify-checklist.md
@@ -1,0 +1,20 @@
+# Phase 12.3b verify checklist — memory frontend API integration
+
+## Frontend/API integration
+- [x] `npm --prefix apps/web run typecheck`
+- [x] `npm --prefix apps/web run build`
+- [x] API-backed smoke with `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011`.
+- [x] `/memory` renders `API read-only` and API-backed Zoro built-in/Honcho content.
+- [x] Browser console clean after initial load and Honcho tab interaction.
+
+## Backend regression
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py` → 15 passed.
+
+## Hygiene
+- [x] `git diff --check`
+- [x] `git status --short --branch`
+
+## Review
+- [ ] Open PR against `main`.
+- [ ] Ask Chopper for security/leak review.
+- [ ] Ask Usopp for UI/UX review.


### PR DESCRIPTION
## Qué he hecho
- Integro `/memory` con la API read-only de Phase 12.3a.
- Divido la ruta en loader server-side (`page.tsx`) y componente cliente interactivo (`MemoryClient.tsx`).
- Añado adapter `apps/web/src/modules/memory/api/memory-http.ts`.
- El server loader carga `GET /api/v1/memory` y detalles saneados para los Mugiwara conocidos cuando `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` está configurada.
- El cliente solo gestiona selección UI por Mugiwara y fuente Built-in/Honcho; no hace fetch directo al endpoint de memoria.
- Mantengo fallback saneado y aviso explícito si la API no está configurada o falla.

## Por qué existe este cambio
- Phase 12.3b mueve la superficie `/memory` desde fixtures hacia backend read-only sin conectar todavía stores reales.
- El fetch queda server-side para evitar CORS en navegador y mantener la frontera de datos más controlada.

## Superficie afectada
- Frontend visible `/memory`.
- Adapter HTTP frontend de Memory.
- Docs/openspec/Engram de continuidad.
- No toca backend, contratos, auth, dependencias, runtime ni stores reales.

## Verificación hecha por Zoro
- Backend regression: `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py` → 15 passed.
- `npm --prefix apps/web run typecheck` → OK.
- `npm --prefix apps/web run build` → OK.
- Smoke local API + web con `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011`:
  - `/memory` muestra `API read-only`.
  - Built-in y Honcho de Zoro muestran contenido API-backed.
  - Consola del navegador sin errores tras carga e interacción con tab Honcho.
- `git diff --check` → OK.

## Riesgos que veo
- Bajo-medio: la UI muestra datos de memoria, pero siguen siendo payloads saneados de backend-owned catalog.
- No conecta stores reales ni expone prompts/raw dumps/sesiones/observaciones completas.
- El loader pide detalles de todos los Mugiwara; aceptable por tamaño actual, pero si crece convendrá endpoint agregado o lazy seguro.

## Reviewers solicitados
- Chopper: revisar frontera de datos y que la integración no abre fuga de memoria ni fetching inseguro.
- Usopp: revisar UI/UX visible de `/memory`, estado `API read-only`, fallback y separación Built-in/Honcho.

## Regla de merge
No mergear hasta que Chopper y Usopp dejen `approve` o `mergeable_with_minor_followups`.
