### PR TITLE
fix: harden memory api server config

### DIFF
--- a/apps/web/src/app/memory/page.tsx
+++ b/apps/web/src/app/memory/page.tsx
@@ -6,6 +6,8 @@ import type { AppStatus } from '@/shared/theme/tokens'
 
 import { MemoryClient, type MemoryPageNotice } from './MemoryClient'
 
+export const dynamic = 'force-dynamic'
+
 type InitialMemoryData = {
   apiSummaries: ApiMemoryAgentSummary[] | null
   apiDetails: Partial<Record<MugiwaraSlug, ApiMemoryAgentDetail>>
@@ -65,8 +67,16 @@ async function getInitialMemoryData(): Promise<InitialMemoryData> {
       apiState: 'fallback',
       apiNotice: {
         status: apiError?.code === 'not_configured' ? 'sin-datos' : 'incidencia',
-        title: apiError?.code === 'not_configured' ? 'API Memory no configurada' : 'API Memory no disponible',
-        description: 'La página mantiene el fallback saneado local. No se muestran dumps crudos ni detalles técnicos de memoria.',
+        title:
+          apiError?.code === 'not_configured'
+            ? 'API Memory no configurada'
+            : apiError?.code === 'invalid_config'
+              ? 'Configuración server-only de Memory inválida'
+              : 'API Memory no disponible',
+        description:
+          apiError?.code === 'not_configured'
+            ? 'Configura `MUGIWARA_CONTROL_PANEL_API_URL` solo en el entorno server para conectar esta vista al backend.'
+            : 'La página mantiene el fallback saneado local. No se muestran dumps crudos ni detalles técnicos de memoria.',
         detail: apiError?.code,
       },
     }

--- a/apps/web/src/modules/memory/api/memory-http.ts
+++ b/apps/web/src/modules/memory/api/memory-http.ts
@@ -1,4 +1,8 @@
+import 'server-only'
+
 import type { MemoryDetailResponse, MemorySummaryResponse } from '@contracts/read-models'
+
+export const MEMORY_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'
 
 export class MemoryApiError extends Error {
   status: number
@@ -23,9 +27,25 @@ function trimTrailingSlash(value: string) {
   return value.replace(/\/$/, '')
 }
 
+function parseMemoryApiBaseUrl(value: string) {
+  let parsed: URL
+
+  try {
+    parsed = new URL(value)
+  } catch {
+    throw new MemoryApiError('invalid_config', { status: 0, code: 'invalid_config' })
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new MemoryApiError('invalid_config', { status: 0, code: 'invalid_config' })
+  }
+
+  return trimTrailingSlash(value)
+}
+
 export function getMemoryApiBaseUrl() {
-  const value = process.env.NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL
-  return value ? trimTrailingSlash(value) : null
+  const value = process.env[MEMORY_API_BASE_URL_ENV]
+  return value ? parseMemoryApiBaseUrl(value) : null
 }
 
 async function parseApiError(response: Response) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:web": "npm --prefix apps/web run build",
     "typecheck:web": "npm --prefix apps/web run typecheck",
     "verify:visual-baseline": "node scripts/visual-verify-baseline.mjs",
+    "verify:memory-server-only": "node scripts/check-memory-server-only.mjs",
     "dev:api": "uvicorn apps.api.src.main:app --reload",
     "lint": "echo 'Pending lint setup'",
     "test": "echo 'Pending test setup'"

--- a/scripts/check-memory-server-only.mjs
+++ b/scripts/check-memory-server-only.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Static safety check for Phase 12.3c.
+ *
+ * Inputs: source files for the Memory server loader/API adapter.
+ * Output: exits non-zero when Memory falls back to a public API env var or loses
+ * the server-only guard. This script is intentionally read-only.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = process.cwd()
+const memoryHttpPath = join(repoRoot, 'apps/web/src/modules/memory/api/memory-http.ts')
+const memoryPagePath = join(repoRoot, 'apps/web/src/app/memory/page.tsx')
+
+const memoryHttp = readFileSync(memoryHttpPath, 'utf8')
+const memoryPage = readFileSync(memoryPagePath, 'utf8')
+
+const failures = []
+
+if (!memoryHttp.includes("import 'server-only'")) {
+  failures.push('memory-http.ts must be server-only guarded')
+}
+
+if (!memoryHttp.includes("MEMORY_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'")) {
+  failures.push('memory-http.ts must use the server-only MUGIWARA_CONTROL_PANEL_API_URL env name')
+}
+
+if (memoryHttp.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL')) {
+  failures.push('memory-http.ts must not read NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL')
+}
+
+if (!memoryHttp.includes("parsed.protocol !== 'http:'") || !memoryHttp.includes("parsed.protocol !== 'https:'")) {
+  failures.push('memory-http.ts must reject non-http(s) API base URLs')
+}
+
+if (!memoryPage.includes("export const dynamic = 'force-dynamic'")) {
+  failures.push('memory/page.tsx must force dynamic rendering so server env is read at runtime')
+}
+
+if (!memoryPage.includes('MUGIWARA_CONTROL_PANEL_API_URL')) {
+  failures.push('memory/page.tsx must tell operators to configure the server-only env var')
+}
+
+if (memoryPage.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL')) {
+  failures.push('memory/page.tsx must not instruct operators to use the public env var')
+}
+
+if (failures.length > 0) {
+  console.error('Memory server-only config check failed:')
+  for (const failure of failures) {
+    console.error(`- ${failure}`)
+  }
+  process.exit(1)
+}
+
+console.log('Memory server-only config check passed')


### PR DESCRIPTION
## Objetivo
Phase 12.3c — endurecer la configuración del frontend Memory para que el loader server-side use una variable server-only y no dependa de `NEXT_PUBLIC_*`.

## Cambios
- `memory-http.ts` queda marcado con `import 'server-only'`.
- Memory lee `MUGIWARA_CONTROL_PANEL_API_URL` en servidor, no `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL`.
- Se valida que la base URL sea `http` o `https`; configuración inválida cae a fallback saneado con código `invalid_config`.
- `/memory` fuerza render dinámico para leer configuración server-side en runtime y no congelar el fallback en build.
- Se añade `npm run verify:memory-server-only` como check estático de seguridad/config.

## Fuera de alcance
- No conecta stores reales de memoria.
- No cambia API backend ni contratos públicos.
- No toca auth/permisos todavía.

## Verificación de Zoro
- `npm run verify:memory-server-only` → OK.
- `npm --prefix apps/web run typecheck` → OK.
- `npm --prefix apps/web run build` → OK; `/memory` queda dinámico (`ƒ`).
- `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py` → `15 passed`.
- `git diff --check` → OK.
- Smoke local con `MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011`: `/memory` renderiza `API solo lectura`; consola del navegador limpia.

## Riesgo
Bajo. Es hardening preventivo de configuración. Reviewer principal: Chopper. Franky opcional por config/runtime ligera.
