### PR TITLE
docs: align memory runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,16 @@ Este repo será público en GitHub.
 npm run dev:web
 npm run build:web
 npm run typecheck:web
+npm run verify:memory-server-only
 ```
+
+## Configuración runtime
+Ver `docs/runtime-config.md`.
+
+Resumen actual:
+- `/memory` usa `MUGIWARA_CONTROL_PANEL_API_URL` como variable server-only.
+- `/skills` y `/mugiwaras` conservan temporalmente `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` hasta una fase de migración propia.
+
 
 ## OpenCode + Engram
 Siempre abrir OpenCode desde la raíz del proyecto:

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -1,0 +1,48 @@
+# Configuración runtime del control plane
+
+## Principio
+El control plane distingue entre configuración pública de frontend y configuración privada de servidor.
+
+- Las variables `NEXT_PUBLIC_*` pueden acabar embebidas en bundles cliente y solo deben usarse para valores no sensibles que el navegador pueda conocer.
+- Las variables sin prefijo `NEXT_PUBLIC_` deben leerse solo desde server loaders, adapters server-only o backend.
+- Cualquier URL o ruta que revele topología interna debe preferir configuración server-only cuando la página pueda cargar los datos desde servidor.
+
+## Variables actuales
+
+| Variable | Consumidor | Exposición | Uso |
+| --- | --- | --- | --- |
+| `MUGIWARA_CONTROL_PANEL_API_URL` | `/memory` server loader | Server-only | Base URL del backend para la superficie Memory read-only. |
+| `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` | `/skills`, `/mugiwaras` | Pública/cliente | Base URL histórica para verticales que todavía consumen backend desde cliente o patrón previo. |
+
+## Memory
+`/memory` usa el patrón server-only desde Phase 12.3c:
+
+1. `apps/web/src/modules/memory/api/memory-http.ts` importa `server-only`.
+2. El adapter lee `MUGIWARA_CONTROL_PANEL_API_URL`.
+3. La base URL se valida como `http:` o `https:` antes del fetch.
+4. `/memory` declara `export const dynamic = 'force-dynamic'` para leer la configuración en runtime y evitar prerender estático con fallback congelado.
+5. Si la variable falta o es inválida, la página mantiene fallback saneado y no muestra el valor de la URL.
+
+Ejemplo de smoke local:
+
+```bash
+PYTHONPATH=. uvicorn apps.api.src.main:app --host 127.0.0.1 --port 8011
+MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011 npm --prefix apps/web run dev -- --hostname 127.0.0.1 --port 3017
+```
+
+## Guardarraíl de Memory
+Antes de cerrar cambios que toquen Memory config, ejecutar:
+
+```bash
+npm run verify:memory-server-only
+```
+
+Este check confirma que Memory mantiene:
+
+- adapter `server-only`;
+- env privada `MUGIWARA_CONTROL_PANEL_API_URL`;
+- ausencia de `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` en el adapter y el aviso operativo de `/memory`;
+- render dinámico de `/memory`.
+
+## Pendiente deliberado
+`/skills` y `/mugiwaras` siguen usando `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` por compatibilidad con fases previas. Migrarlos al patrón server-only requiere fase separada, review de Chopper/Franky y verificación específica de UI/runtime.

--- a/openspec/phase-12-3b-memory-frontend-integration.md
+++ b/openspec/phase-12-3b-memory-frontend-integration.md
@@ -8,7 +8,7 @@ Integrate `/memory` with the Phase 12.3a read-only Memory API while preserving t
 - Split the route into:
   - `page.tsx` server loader: fetches `GET /api/v1/memory` and safe details for all known Mugiwara slugs when API URL is configured.
   - `MemoryClient.tsx` client component: owns only UI state (`selectedMugiwara`, `selectedSource`) and receives sanitized initial data.
-- Preserve fixture fallback when `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` is absent, unavailable or partially degraded.
+- Preserve fixture fallback when `MUGIWARA_CONTROL_PANEL_API_URL` is absent, invalid, unavailable or partially degraded. This server-only env replaced the earlier `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` Memory smoke variable in Phase 12.3c.
 - Keep payloads limited to existing contracts: summaries, counts, badges, freshness, links and allowlisted facts.
 
 ## Tasks

--- a/openspec/phase-12-3b-memory-frontend-verify-checklist.md
+++ b/openspec/phase-12-3b-memory-frontend-verify-checklist.md
@@ -3,7 +3,7 @@
 ## Frontend/API integration
 - [x] `npm --prefix apps/web run typecheck`
 - [x] `npm --prefix apps/web run build`
-- [x] API-backed smoke with `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011`.
+- [x] API-backed smoke with `MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011` after Phase 12.3c server-only hardening.
 - [x] `/memory` renders `API read-only` and API-backed Zoro built-in/Honcho content.
 - [x] Browser console clean after initial load and Honcho tab interaction.
 

--- a/openspec/phase-12-3c-memory-server-config-hardening.md
+++ b/openspec/phase-12-3c-memory-server-config-hardening.md
@@ -1,0 +1,34 @@
+# Phase 12.3c — memory server-only config hardening
+
+## Scope
+Harden `/memory` runtime configuration before any live memory-store connector is introduced.
+
+## Decision
+Memory must use a server-only backend URL:
+
+- Use `MUGIWARA_CONTROL_PANEL_API_URL` for `/memory`.
+- Do not use `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` in the Memory adapter or Memory operational notice.
+- Keep `/skills` and `/mugiwaras` on their previous config path until a separate migration phase decides otherwise.
+
+## Implementation
+- `apps/web/src/modules/memory/api/memory-http.ts` imports `server-only`.
+- The Memory adapter validates configured URLs as `http:` or `https:`.
+- Invalid or missing config falls back to sanitized local fixtures and does not display the configured URL.
+- `apps/web/src/app/memory/page.tsx` declares `export const dynamic = 'force-dynamic'` so runtime server config is not frozen at build time.
+- `npm run verify:memory-server-only` checks the server-only boundary textually until formal CI exists.
+
+## Verify evidence
+- `npm run verify:memory-server-only` → OK.
+- `npm --prefix apps/web run typecheck` → OK.
+- `npm --prefix apps/web run build` → OK; `/memory` is dynamic (`ƒ`).
+- `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py` → 15 passed.
+- Browser smoke with `MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011` → `/memory` renders API-backed content and browser console stays clean.
+
+## Review
+- Chopper: `mergeable_with_minor_followups`.
+- Franky: `mergeable_with_minor_followups`.
+
+## Follow-ups accepted
+- Document the new Memory config contract.
+- Add `verify:memory-server-only` to CI when formal CI exists.
+- Decide later whether `/skills` and `/mugiwaras` should migrate to server-only config.

--- a/openspec/phase-12-3d-memory-docs-config-cleanup.md
+++ b/openspec/phase-12-3d-memory-docs-config-cleanup.md
@@ -1,0 +1,27 @@
+# Phase 12.3d — memory config documentation cleanup
+
+## Scope
+Close the documentation follow-up from Phase 12.3c by aligning Memory docs and OpenSpec artifacts with the server-only runtime config contract.
+
+## Changes
+- Add `docs/runtime-config.md` as the canonical runtime configuration note.
+- Update root `README.md` to expose `verify:memory-server-only` and point to runtime config docs.
+- Correct Phase 12.3b artifacts that still described Memory smoke/fallback using `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL`.
+- Add Phase 12.3c closeout artifact documenting the server-only decision and verify evidence.
+
+## Out of scope
+- No code runtime changes.
+- No backend/API contract changes.
+- No migration of `/skills` or `/mugiwaras` from `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL`.
+- No live memory-store connector.
+
+## Definition of done
+- Memory documentation names `MUGIWARA_CONTROL_PANEL_API_URL` as the runtime variable for `/memory`.
+- Docs explicitly state that `/skills` and `/mugiwaras` still use the historical `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` pending a separate migration.
+- `npm run verify:memory-server-only`, frontend typecheck/build and backend regression still pass.
+- Search confirms no Memory-specific OpenSpec artifact instructs operators to configure Memory via `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL`.
+
+## Reviewer routing
+- Chopper: required, because this is security/config documentation for a leak-boundary follow-up.
+- Franky: optional unless he wants to review operational clarity; no runtime change.
+- Usopp: not required; no UI/copy surface change.


### PR DESCRIPTION
## Objetivo
Phase 12.3d — cerrar el follow-up documental de Phase 12.3c y alinear la documentación de Memory con la variable server-only `MUGIWARA_CONTROL_PANEL_API_URL`.

## Cambios
- Añade `docs/runtime-config.md` como referencia canónica de configuración runtime.
- Actualiza `README.md` con `npm run verify:memory-server-only` y enlace a configuración runtime.
- Corrige los artefactos Phase 12.3b que todavía describían el smoke/fallback de Memory con `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL`.
- Añade closeout OpenSpec de Phase 12.3c y spec de Phase 12.3d.
- Deja explícito que `/skills` y `/mugiwaras` mantienen `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` hasta una fase separada.

## Fuera de alcance
- Sin cambios runtime/código productivo.
- Sin cambios backend/API.
- Sin conexión a stores reales.
- Sin migración de `/skills` ni `/mugiwaras`.

## Verificación de Zoro
- Check docs Memory config con script inline Python → OK.
- `npm run verify:memory-server-only` → OK.
- `npm --prefix apps/web run typecheck` → OK.
- `npm --prefix apps/web run build` → OK; `/memory` sigue dinámico (`ƒ`).
- `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py` → `15 passed`.
- `git diff --check` → OK.

## Review solicitada
Chopper: revisión de seguridad/config documental. Franky no es gate salvo que Chopper derive a operación; no hay cambio runtime.
