### PR TITLE
fix: harden mugiwaras api server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,15 @@ npm run dev:web
 npm run build:web
 npm run typecheck:web
 npm run verify:memory-server-only
+npm run verify:mugiwaras-server-only
 ```
 
 ## Configuración runtime
 Ver `docs/runtime-config.md`.
 
 Resumen actual:
-- `/memory` usa `MUGIWARA_CONTROL_PANEL_API_URL` como variable server-only.
-- `/skills` y `/mugiwaras` conservan temporalmente `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` hasta una fase de migración propia.
+- `/memory` y `/mugiwaras` usan `MUGIWARA_CONTROL_PANEL_API_URL` como variable server-only.
+- `/skills` conserva temporalmente `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` hasta una fase de migración propia.
 
 
 ## OpenCode + Engram

--- a/apps/web/src/app/mugiwaras/page.tsx
+++ b/apps/web/src/app/mugiwaras/page.tsx
@@ -32,25 +32,29 @@ type MugiwarasViewModel = {
   } | null
 }
 
-async function getMugiwarasViewModel(): Promise<MugiwarasViewModel> {
-  const apiBaseUrl = getMugiwarasApiBaseUrl()
-
-  if (!apiBaseUrl) {
-    return {
-      state: 'not_configured',
-      cards: mugiwaraCardFixture,
-      crewRulesDocument: null,
-      notice: {
-        status: 'sin-datos',
-        title: 'Backend de Mugiwara no configurado',
-        description:
-          'La página mantiene el fixture saneado, pero la lectura canónica de /srv/crew-core/AGENTS.md requiere NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL.',
-        detail: 'Variable ausente en el runtime actual.',
-      },
-    }
+function getMugiwarasConfigNotice(error: MugiwarasApiError | null): MugiwarasViewModel {
+  return {
+    state: 'not_configured',
+    cards: mugiwaraCardFixture,
+    crewRulesDocument: null,
+    notice: {
+      status: error?.code === 'invalid_config' ? 'incidencia' : 'sin-datos',
+      title: error?.code === 'invalid_config' ? 'Configuración server-only de Mugiwara inválida' : 'Backend de Mugiwara no configurado',
+      description:
+        'La página mantiene el fixture saneado, pero la lectura canónica de /srv/crew-core/AGENTS.md requiere MUGIWARA_CONTROL_PANEL_API_URL válida en el runtime server.',
+      detail: error?.code ?? 'Variable ausente en el runtime actual.',
+    },
   }
+}
 
+async function getMugiwarasViewModel(): Promise<MugiwarasViewModel> {
   try {
+    const apiBaseUrl = getMugiwarasApiBaseUrl()
+
+    if (!apiBaseUrl) {
+      return getMugiwarasConfigNotice(null)
+    }
+
     const response = await fetchMugiwarasCatalog()
     return {
       state: 'ready',
@@ -59,6 +63,10 @@ async function getMugiwarasViewModel(): Promise<MugiwarasViewModel> {
       notice: null,
     }
   } catch (error) {
+    if (error instanceof MugiwarasApiError && error.code === 'invalid_config') {
+      return getMugiwarasConfigNotice(error)
+    }
+
     const detail = error instanceof MugiwarasApiError ? `${error.code}: ${error.message}` : error instanceof Error ? error.message : 'Error desconocido'
     return {
       state: 'error',

--- a/apps/web/src/modules/mugiwaras/api/mugiwaras-http.ts
+++ b/apps/web/src/modules/mugiwaras/api/mugiwaras-http.ts
@@ -1,4 +1,8 @@
+import 'server-only'
+
 import type { MugiwarasCatalogResponse } from '@contracts/read-models'
+
+export const MUGIWARAS_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'
 
 export class MugiwarasApiError extends Error {
   status: number
@@ -23,9 +27,25 @@ function trimTrailingSlash(value: string) {
   return value.replace(/\/$/, '')
 }
 
+function parseMugiwarasApiBaseUrl(value: string) {
+  let parsed: URL
+
+  try {
+    parsed = new URL(value)
+  } catch {
+    throw new MugiwarasApiError('invalid_config', { status: 0, code: 'invalid_config' })
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new MugiwarasApiError('invalid_config', { status: 0, code: 'invalid_config' })
+  }
+
+  return trimTrailingSlash(value)
+}
+
 export function getMugiwarasApiBaseUrl() {
-  const value = process.env.NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL
-  return value ? trimTrailingSlash(value) : null
+  const value = process.env[MUGIWARAS_API_BASE_URL_ENV]
+  return value ? parseMugiwarasApiBaseUrl(value) : null
 }
 
 export async function fetchMugiwarasCatalog(): Promise<MugiwarasCatalogResponse> {

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -11,8 +11,8 @@ El control plane distingue entre configuración pública de frontend y configura
 
 | Variable | Consumidor | Exposición | Uso |
 | --- | --- | --- | --- |
-| `MUGIWARA_CONTROL_PANEL_API_URL` | `/memory` server loader | Server-only | Base URL del backend para la superficie Memory read-only. |
-| `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` | `/skills`, `/mugiwaras` | Pública/cliente | Base URL histórica para verticales que todavía consumen backend desde cliente o patrón previo. |
+| `MUGIWARA_CONTROL_PANEL_API_URL` | `/memory`, `/mugiwaras` server loaders | Server-only | Base URL del backend para superficies read-only que pueden cargar desde servidor. |
+| `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` | `/skills` | Pública/cliente | Base URL histórica para la superficie Skills hasta que tenga frontera BFF/server-side propia. |
 
 ## Memory
 `/memory` usa el patrón server-only desde Phase 12.3c:
@@ -44,12 +44,27 @@ Este check confirma que Memory mantiene:
 - ausencia de `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` en el adapter y el aviso operativo de `/memory`;
 - render dinámico de `/memory`.
 
+## Mugiwaras
+`/mugiwaras` usa el patrón server-only desde Phase 12.3f:
+
+1. `apps/web/src/modules/mugiwaras/api/mugiwaras-http.ts` importa `server-only`.
+2. El adapter lee `MUGIWARA_CONTROL_PANEL_API_URL`.
+3. La base URL se valida como `http:` o `https:` antes del fetch.
+4. `/mugiwaras` mantiene `export const dynamic = 'force-dynamic'` para leer la configuración en runtime.
+5. Si la variable falta o es inválida, la página mantiene fixture saneado y no muestra AGENTS.md.
+
+Antes de cerrar cambios que toquen Mugiwaras config, ejecutar:
+
+```bash
+npm run verify:mugiwaras-server-only
+```
+
 ## Pendiente deliberado
-`/skills` y `/mugiwaras` siguen usando `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` por compatibilidad con fases previas.
+`/skills` sigue usando `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` por compatibilidad con fases previas.
 
 La planificación de migración vive en `openspec/phase-12-3e-server-only-migration-plan.md`.
 
 Resumen de la decisión:
-- `/mugiwaras` debe migrar primero porque ya es server component, ya es dinámico y no necesita browser fetch directo.
+- `/mugiwaras` ya migró en Phase 12.3f porque era server component, dinámico y no necesitaba browser fetch directo.
 - `/skills` requiere fase propia de diseño/implementación porque hoy es client component y contiene preview/update controlados; debe pasar por una frontera server-side tipo BFF/route handlers o server actions sin debilitar la política FastAPI.
-- Ambas migraciones deben llevar revisión de Chopper + Franky.
+- La migración de `/skills` debe llevar revisión de Chopper + Franky.

--- a/openspec/phase-12-3f-mugiwaras-server-only-config.md
+++ b/openspec/phase-12-3f-mugiwaras-server-only-config.md
@@ -1,0 +1,52 @@
+# Phase 12.3f — mugiwaras server-only config migration
+
+## Scope
+Migrate `/mugiwaras` from public frontend backend configuration to the server-only config pattern established by `/memory`.
+
+## Why `/mugiwaras` first
+`/mugiwaras` is the low-risk migration target from Phase 12.3e because:
+
+- the route is already a server component;
+- it already declares `export const dynamic = 'force-dynamic'`;
+- it fetches the backend from the server page;
+- it has no browser-side interactivity that requires direct backend fetch;
+- its data is read-only and allowlisted.
+
+## Changes
+- `apps/web/src/modules/mugiwaras/api/mugiwaras-http.ts` imports `server-only`.
+- The adapter reads `MUGIWARA_CONTROL_PANEL_API_URL` instead of `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL`.
+- The adapter validates configured base URLs as `http:` or `https:`.
+- `/mugiwaras` not-configured copy now instructs operators to use server runtime config.
+- `scripts/check-mugiwaras-server-only.mjs` adds a static guardrail.
+- `npm run verify:mugiwaras-server-only` exposes the guardrail.
+- Runtime docs and README now list `/mugiwaras` alongside `/memory` as server-only.
+
+## Out of scope
+- No `/skills` migration.
+- No Next BFF or route handlers for `/skills`.
+- No backend API contract changes.
+- No auth model change.
+- No change to AGENTS markdown content or allowlist source.
+
+## Definition of done
+- `/mugiwaras` adapter no longer reads `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL`.
+- `/mugiwaras` remains dynamic in `next build` output (`ƒ`).
+- API-backed smoke works with `MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011`.
+- AGENTS content is still only rendered when received from backend allowlisted endpoint.
+- Browser console is clean in smoke.
+- Chopper + Franky review and accept the migration.
+
+## Verify checklist
+- [x] `npm run verify:mugiwaras-server-only`
+- [x] `npm run verify:memory-server-only`
+- [x] `npm --prefix apps/web run typecheck`
+- [x] `npm --prefix apps/web run build`
+- [x] Backend regression: `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py`
+- [x] Browser/API smoke for `/mugiwaras` with server-only env.
+- [x] Invalid config smoke: `MUGIWARA_CONTROL_PANEL_API_URL=file:///tmp` keeps `/mugiwaras` at HTTP 200 with fixture fallback and without AGENTS content.
+- [x] `git diff --check`
+
+## Reviewer routing
+- **Chopper:** required; config/security boundary and AGENTS read-only exposure.
+- **Franky:** required; runtime config, dynamic rendering, smoke and guardrail.
+- **Usopp:** not required; no UI layout/UX change beyond operational copy.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typecheck:web": "npm --prefix apps/web run typecheck",
     "verify:visual-baseline": "node scripts/visual-verify-baseline.mjs",
     "verify:memory-server-only": "node scripts/check-memory-server-only.mjs",
+    "verify:mugiwaras-server-only": "node scripts/check-mugiwaras-server-only.mjs",
     "dev:api": "uvicorn apps.api.src.main:app --reload",
     "lint": "echo 'Pending lint setup'",
     "test": "echo 'Pending test setup'"

--- a/scripts/check-mugiwaras-server-only.mjs
+++ b/scripts/check-mugiwaras-server-only.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Static safety check for Phase 12.3f.
+ *
+ * Inputs: source files for the Mugiwaras server loader/API adapter.
+ * Output: exits non-zero when Mugiwaras falls back to a public API env var,
+ * loses the server-only guard, or loses runtime dynamic rendering. Read-only.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = process.cwd()
+const mugiwarasHttpPath = join(repoRoot, 'apps/web/src/modules/mugiwaras/api/mugiwaras-http.ts')
+const mugiwarasPagePath = join(repoRoot, 'apps/web/src/app/mugiwaras/page.tsx')
+
+const mugiwarasHttp = readFileSync(mugiwarasHttpPath, 'utf8')
+const mugiwarasPage = readFileSync(mugiwarasPagePath, 'utf8')
+
+const failures = []
+
+if (!mugiwarasHttp.includes("import 'server-only'")) {
+  failures.push('mugiwaras-http.ts must be server-only guarded')
+}
+
+if (!mugiwarasHttp.includes("MUGIWARAS_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'")) {
+  failures.push('mugiwaras-http.ts must use the server-only MUGIWARA_CONTROL_PANEL_API_URL env name')
+}
+
+if (mugiwarasHttp.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL')) {
+  failures.push('mugiwaras-http.ts must not read NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL')
+}
+
+if (!mugiwarasHttp.includes("parsed.protocol !== 'http:'") || !mugiwarasHttp.includes("parsed.protocol !== 'https:'")) {
+  failures.push('mugiwaras-http.ts must reject non-http(s) API base URLs')
+}
+
+if (!mugiwarasPage.includes("export const dynamic = 'force-dynamic'")) {
+  failures.push('mugiwaras/page.tsx must force dynamic rendering so server env is read at runtime')
+}
+
+if (!mugiwarasPage.includes('MUGIWARA_CONTROL_PANEL_API_URL')) {
+  failures.push('mugiwaras/page.tsx must tell operators to configure the server-only env var')
+}
+
+if (mugiwarasPage.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL')) {
+  failures.push('mugiwaras/page.tsx must not instruct operators to use the public env var')
+}
+
+if (failures.length > 0) {
+  console.error('Mugiwaras server-only config check failed:')
+  for (const failure of failures) {
+    console.error(`- ${failure}`)
+  }
+  process.exit(1)
+}
+
+console.log('Mugiwaras server-only config check passed')


### PR DESCRIPTION
## Objetivo
Phase 12.3f — migrar `/mugiwaras` a configuración server-only siguiendo el patrón validado en `/memory`.

## Cambios
- `mugiwaras-http.ts` importa `server-only`.
- `/mugiwaras` usa `MUGIWARA_CONTROL_PANEL_API_URL`, no `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL`.
- Se valida que la base URL sea `http:` o `https:`.
- Se actualiza copy de estado no configurado para apuntar a runtime server.
- Se añade `scripts/check-mugiwaras-server-only.mjs`.
- Se añade `npm run verify:mugiwaras-server-only`.
- Se actualizan `README.md`, `docs/runtime-config.md` y OpenSpec Phase 12.3f.

## Fuera de alcance
- No se toca `/skills`.
- No se añade BFF/route handlers.
- No hay cambios backend/API.
- No hay auth nueva.

## Verificación de Zoro
- `npm run verify:mugiwaras-server-only` → OK.
- `npm run verify:memory-server-only` → OK.
- `npm --prefix apps/web run typecheck` → OK.
- `npm --prefix apps/web run build` → OK; `/mugiwaras` sigue dinámico (`ƒ`).
- Backend regression: `15 passed`.
- Smoke API + web con `MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011`:
  - `GET /api/v1/mugiwaras` → 200.
  - `GET /mugiwaras` → 200.
  - Browser renderiza AGENTS.md canónico desde API.
  - Consola del navegador limpia.
- Check dirigido: no queda `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` en adapter/copy de `/mugiwaras`.
- `git diff --check` → OK.

## Review solicitada
Chopper + Franky.
