### PR TITLE
feat: add skills bff server boundary

### DIFF
--- a/.engram/phase-12-3h-skills-bff-closeout.md
+++ b/.engram/phase-12-3h-skills-bff-closeout.md
@@ -30,6 +30,7 @@ Implement the `/skills` BFF/server-only migration approved in Phase 12.3g.
 
 ## Notes
 - Preview smoke used a non-persisting diff. Update smoke was intentionally not run against real allowlisted skills to avoid modifying production skill files without a fixture/restore workflow.
+- Chopper asked for a minor followup documenting that `/api/control-panel/skills/**`, especially `PUT`, must remain behind Tailscale/private-auth perimeter unless future auth/rate-limit is added; this was added to runtime docs and OpenSpec before merge.
 - One stale `.next` dev-server state caused an initial `/skills` 500 after route changes; removing `apps/web/.next` and restarting dev server resolved it. Build/typecheck were already clean.
 
 ## Review needed

--- a/.engram/phase-12-3h-skills-bff-closeout.md
+++ b/.engram/phase-12-3h-skills-bff-closeout.md
@@ -1,0 +1,37 @@
+# Phase 12.3h closeout — Skills BFF/server-only implementation
+
+## Goal
+Implement the `/skills` BFF/server-only migration approved in Phase 12.3g.
+
+## Completed
+- Added same-origin Next route handlers under `/api/control-panel/skills/**`.
+- Added server-only upstream adapter using `MUGIWARA_CONTROL_PANEL_API_URL`.
+- Added BFF validation for `skillId`, `Content-Type`, body size, preview payload and update payload.
+- Refactored browser skills adapter to same-origin endpoints only.
+- Removed browser-visible backend base URL copy from `/skills`.
+- Added `npm run verify:skills-server-only`.
+- Updated `README.md`, `docs/runtime-config.md` and `openspec/phase-12-3h-skills-bff-implementation.md`.
+
+## Verify
+- `npm run verify:skills-server-only` OK.
+- `npm run verify:memory-server-only` OK.
+- `npm run verify:mugiwaras-server-only` OK.
+- `npm --prefix apps/web run typecheck` OK.
+- `npm --prefix apps/web run build` OK.
+- Backend regression `15 passed`.
+- Smoke local:
+  - `/api/control-panel/skills` returns catalog via BFF with valid server env.
+  - `/api/control-panel/skills/{skillId}` returns detail via BFF.
+  - `/api/control-panel/skills/{skillId}/preview` returns diff preview via BFF without persisting writes.
+  - invalid `skillId` returns 400 sanitized.
+  - wrong `Content-Type` returns 415 sanitized.
+  - missing/invalid `MUGIWARA_CONTROL_PANEL_API_URL` returns 503 `not_configured` sanitized.
+  - `/skills` renders through BFF with clean browser console.
+
+## Notes
+- Preview smoke used a non-persisting diff. Update smoke was intentionally not run against real allowlisted skills to avoid modifying production skill files without a fixture/restore workflow.
+- One stale `.next` dev-server state caused an initial `/skills` 500 after route changes; removing `apps/web/.next` and restarting dev server resolved it. Build/typecheck were already clean.
+
+## Review needed
+- Chopper for endpoint/input/security boundary.
+- Franky for runtime/route-handler/no-store/guardrail operation.

--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@ npm run build:web
 npm run typecheck:web
 npm run verify:memory-server-only
 npm run verify:mugiwaras-server-only
+npm run verify:skills-server-only
 ```
 
 ## Configuración runtime
 Ver `docs/runtime-config.md`.
 
 Resumen actual:
-- `/memory` y `/mugiwaras` usan `MUGIWARA_CONTROL_PANEL_API_URL` como variable server-only.
-- `/skills` conserva temporalmente `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` hasta una fase de migración propia.
+- `/memory`, `/mugiwaras` y `/skills` usan `MUGIWARA_CONTROL_PANEL_API_URL` como variable server-only.
+- `/skills` expone al navegador solo endpoints BFF same-origin bajo `/api/control-panel/skills/**`; la URL real del backend no entra en el bundle cliente.
 
 
 ## OpenCode + Engram

--- a/apps/web/src/app/api/control-panel/skills/[skillId]/preview/route.ts
+++ b/apps/web/src/app/api/control-panel/skills/[skillId]/preview/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+
+import {
+  buildSkillsBffValidationErrorPayload,
+  isSkillsBffValidationError,
+  parseSkillPreviewPayload,
+  validateSkillId,
+} from '@/modules/skills/api/skills-bff-validation'
+import {
+  buildSkillsServerErrorPayload,
+  fetchSkillsServerJson,
+  normalizeSkillsServerError,
+} from '@/modules/skills/api/skills-server-http'
+
+export const dynamic = 'force-dynamic'
+export const fetchCache = 'force-no-store'
+
+type SkillPreviewRouteContext = {
+  params: Promise<{
+    skillId: string
+  }>
+}
+
+export async function POST(request: Request, { params }: SkillPreviewRouteContext) {
+  try {
+    const { skillId } = await params
+    const safeSkillId = validateSkillId(skillId)
+    const payload = await parseSkillPreviewPayload(request)
+    const response = await fetchSkillsServerJson(`/api/v1/skills/${safeSkillId}/preview`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+
+    return NextResponse.json(response)
+  } catch (error) {
+    if (isSkillsBffValidationError(error)) {
+      return NextResponse.json(buildSkillsBffValidationErrorPayload(error), { status: error.status })
+    }
+
+    const normalized = normalizeSkillsServerError(error)
+    return NextResponse.json(buildSkillsServerErrorPayload(normalized), { status: normalized.status })
+  }
+}

--- a/apps/web/src/app/api/control-panel/skills/[skillId]/route.ts
+++ b/apps/web/src/app/api/control-panel/skills/[skillId]/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server'
+
+import {
+  buildSkillsBffValidationErrorPayload,
+  isSkillsBffValidationError,
+  parseSkillUpdatePayload,
+  validateSkillId,
+} from '@/modules/skills/api/skills-bff-validation'
+import {
+  buildSkillsServerErrorPayload,
+  fetchSkillsServerJson,
+  normalizeSkillsServerError,
+} from '@/modules/skills/api/skills-server-http'
+
+export const dynamic = 'force-dynamic'
+export const fetchCache = 'force-no-store'
+
+type SkillRouteContext = {
+  params: Promise<{
+    skillId: string
+  }>
+}
+
+export async function GET(_request: Request, { params }: SkillRouteContext) {
+  try {
+    const { skillId } = await params
+    const safeSkillId = validateSkillId(skillId)
+    const payload = await fetchSkillsServerJson(`/api/v1/skills/${safeSkillId}`)
+    return NextResponse.json(payload)
+  } catch (error) {
+    if (isSkillsBffValidationError(error)) {
+      return NextResponse.json(buildSkillsBffValidationErrorPayload(error), { status: error.status })
+    }
+
+    const normalized = normalizeSkillsServerError(error)
+    return NextResponse.json(buildSkillsServerErrorPayload(normalized), { status: normalized.status })
+  }
+}
+
+export async function PUT(request: Request, { params }: SkillRouteContext) {
+  try {
+    const { skillId } = await params
+    const safeSkillId = validateSkillId(skillId)
+    const payload = await parseSkillUpdatePayload(request)
+    const response = await fetchSkillsServerJson(`/api/v1/skills/${safeSkillId}`, {
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    })
+
+    return NextResponse.json(response)
+  } catch (error) {
+    if (isSkillsBffValidationError(error)) {
+      return NextResponse.json(buildSkillsBffValidationErrorPayload(error), { status: error.status })
+    }
+
+    const normalized = normalizeSkillsServerError(error)
+    return NextResponse.json(buildSkillsServerErrorPayload(normalized), { status: normalized.status })
+  }
+}

--- a/apps/web/src/app/api/control-panel/skills/audit/route.ts
+++ b/apps/web/src/app/api/control-panel/skills/audit/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+
+import {
+  buildSkillsServerErrorPayload,
+  fetchSkillsServerJson,
+  normalizeSkillsServerError,
+} from '@/modules/skills/api/skills-server-http'
+
+export const dynamic = 'force-dynamic'
+export const fetchCache = 'force-no-store'
+
+export async function GET() {
+  try {
+    const payload = await fetchSkillsServerJson('/api/v1/skills/audit')
+    return NextResponse.json(payload)
+  } catch (error) {
+    const normalized = normalizeSkillsServerError(error)
+    return NextResponse.json(buildSkillsServerErrorPayload(normalized), { status: normalized.status })
+  }
+}

--- a/apps/web/src/app/api/control-panel/skills/route.ts
+++ b/apps/web/src/app/api/control-panel/skills/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+
+import {
+  buildSkillsServerErrorPayload,
+  fetchSkillsServerJson,
+  normalizeSkillsServerError,
+} from '@/modules/skills/api/skills-server-http'
+
+export const dynamic = 'force-dynamic'
+export const fetchCache = 'force-no-store'
+
+export async function GET() {
+  try {
+    const payload = await fetchSkillsServerJson('/api/v1/skills')
+    return NextResponse.json(payload)
+  } catch (error) {
+    const normalized = normalizeSkillsServerError(error)
+    return NextResponse.json(buildSkillsServerErrorPayload(normalized), { status: normalized.status })
+  }
+}

--- a/apps/web/src/app/skills/page.tsx
+++ b/apps/web/src/app/skills/page.tsx
@@ -9,7 +9,7 @@ import {
   fetchSkillPreview,
   fetchSkillsAudit,
   fetchSkillsCatalog,
-  getSkillsApiBaseUrl,
+  getSkillsApiConnectionLabel,
   SkillsApiError,
   updateSkill,
 } from '@/modules/skills/api/skills-http'
@@ -64,35 +64,35 @@ function getSaveStateStatus(state: SaveState): AppStatus {
   }
 }
 
-function getSkillsViewNotice(state: SkillsViewState, apiBaseUrl: string | null, errorMessage: string | null) {
+function getSkillsViewNotice(state: SkillsViewState, connectionLabel: string, errorMessage: string | null) {
   switch (state) {
     case 'loading':
       return {
         status: 'revision' as const,
-        title: 'Conectando con el backend real de skills',
-        description: 'La UI está cargando catálogo, detalle y auditoría allowlisted sin romper el shell durante la espera.',
-        detail: apiBaseUrl ? `API base URL: ${apiBaseUrl}` : null,
+        title: 'Conectando con la frontera BFF de skills',
+        description: 'La UI está cargando catálogo, detalle y auditoría allowlisted mediante endpoints same-origin sin exponer la URL del backend.',
+        detail: `Conexión: ${connectionLabel}`,
       }
     case 'not_configured':
       return {
         status: 'sin-datos' as const,
-        title: 'API base URL no configurada',
-        description: 'Configura `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` para conectar esta vista al backend real sin caer en estados ambiguos.',
-        detail: apiBaseUrl ? `API base URL: ${apiBaseUrl}` : 'Variable ausente en el runtime actual.',
+        title: 'BFF de Skills sin configuración server-only',
+        description: 'Configura `MUGIWARA_CONTROL_PANEL_API_URL` solo en el runtime server para conectar esta vista al backend real.',
+        detail: 'El navegador no necesita conocer la URL del backend.',
       }
     case 'error':
       return {
         status: 'incidencia' as const,
         title: 'No se pudo cargar la fuente real de skills',
-        description: 'La superficie mantiene el shell, pero la conectividad o la respuesta del backend impiden mostrar catálogo y detalle con garantías.',
+        description: 'La superficie mantiene el shell, pero la conectividad o la respuesta saneada del BFF impiden mostrar catálogo y detalle con garantías.',
         detail: errorMessage ?? 'Sin detalle adicional.',
       }
     case 'empty':
       return {
         status: 'sin-datos' as const,
         title: 'La allowlist no devolvió skills visibles',
-        description: 'El backend respondió correctamente, pero no hay entradas disponibles para esta selección allowlisted.',
-        detail: apiBaseUrl ? `API base URL: ${apiBaseUrl}` : null,
+        description: 'El backend respondió correctamente a través del BFF, pero no hay entradas disponibles para esta selección allowlisted.',
+        detail: `Conexión: ${connectionLabel}`,
       }
     case 'ready':
     default:
@@ -114,8 +114,8 @@ function formatSignedDelta(value: number) {
 
 export default function SkillsPage() {
   const policy = skillSurfaceFixture
-  const apiBaseUrl = getSkillsApiBaseUrl()
-  const [viewState, setViewState] = useState<SkillsViewState>(apiBaseUrl ? 'loading' : 'not_configured')
+  const apiConnectionLabel = getSkillsApiConnectionLabel()
+  const [viewState, setViewState] = useState<SkillsViewState>('loading')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [catalog, setCatalog] = useState<SkillCatalogItem[]>([])
   const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null)
@@ -134,12 +134,6 @@ export default function SkillsPage() {
     let cancelled = false
 
     async function loadCatalog() {
-      if (!apiBaseUrl) {
-        setViewState('not_configured')
-        setErrorMessage(null)
-        return
-      }
-
       setViewState('loading')
       setErrorMessage(null)
 
@@ -182,13 +176,13 @@ export default function SkillsPage() {
     return () => {
       cancelled = true
     }
-  }, [apiBaseUrl])
+  }, [])
 
   useEffect(() => {
     let cancelled = false
 
     async function loadDetail() {
-      if (!apiBaseUrl || !selectedSkillId || !['ready', 'loading'].includes(viewState)) {
+      if (!selectedSkillId || !['ready', 'loading'].includes(viewState)) {
         return
       }
 
@@ -216,7 +210,7 @@ export default function SkillsPage() {
     return () => {
       cancelled = true
     }
-  }, [apiBaseUrl, selectedSkillId, viewState])
+  }, [selectedSkillId, viewState])
 
   useEffect(() => {
     if (!selectedSkill) {
@@ -247,7 +241,7 @@ export default function SkillsPage() {
     return getLatestAuditForSkill(audit, selectedSkill.skill_id)
   }, [audit, selectedSkill])
 
-  const sourceNotice = getSkillsViewNotice(viewState, apiBaseUrl, errorMessage)
+  const sourceNotice = getSkillsViewNotice(viewState, apiConnectionLabel, errorMessage)
   const hasDraftChanges = selectedSkill ? draftContent !== selectedSkill.content : false
   const normalizedActor = actorInput.trim()
   const canSave = Boolean(selectedSkill?.editable && hasDraftChanges && normalizedActor && saveState !== 'saving')
@@ -559,12 +553,12 @@ export default function SkillsPage() {
         <SurfaceCard title="Estado del origen" elevated eyebrow="Enlace" accent="sky">
           <div style={{ display: 'grid', gap: '10px' }}>
             <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
-              El frontend usa backend real cuando la base URL está configurada; si no, cae a un estado explícito de fuente no
-              configurada sin romper el shell ni el build.
+              El navegador habla con una frontera BFF same-origin; la URL real del backend queda solo en configuración server-only
+              y los errores llegan saneados sin romper el shell ni el build.
             </p>
             <StatusBadge status={mapSkillsViewStateToBadgeStatus(viewState)} />
             <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-              {apiBaseUrl ? `API base URL: ${apiBaseUrl}` : 'API base URL no configurada'}
+              Conexión: {apiConnectionLabel}
             </span>
             {sourceNotice ? (
               <StatePanel
@@ -577,9 +571,9 @@ export default function SkillsPage() {
             ) : (
               <StatePanel
                 status="operativo"
-                title="Fuente real conectada"
-                description="Catálogo, detalle y auditoría están listos para operar sobre la allowlist activa sin recurrir a estados implícitos."
-                detail={apiBaseUrl ? `API base URL: ${apiBaseUrl}` : null}
+                title="BFF same-origin conectado"
+                description="Catálogo, detalle y auditoría están listos para operar sobre la allowlist activa sin exponer la URL del backend al navegador."
+                detail={`Conexión: ${apiConnectionLabel}`}
                 eyebrow="Estado de fuente"
               />
             )}

--- a/apps/web/src/modules/skills/api/skills-bff-validation.ts
+++ b/apps/web/src/modules/skills/api/skills-bff-validation.ts
@@ -1,0 +1,181 @@
+export const SKILLS_BFF_BODY_LIMIT_BYTES = 256 * 1024
+export const SKILLS_BFF_CONTENT_LIMIT_BYTES = 200_000
+
+const SKILL_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,79}$/
+const SHA256_PATTERN = /^[a-fA-F0-9]{64}$/
+
+type BffErrorCode = 'validation_error' | 'unsupported_media_type'
+
+type BffErrorPayload = {
+  detail: {
+    code: BffErrorCode
+    message: string
+  }
+}
+
+export class SkillsBffValidationError extends Error {
+  status: number
+  code: BffErrorCode
+
+  constructor(message: string, options: { status: number; code: BffErrorCode }) {
+    super(message)
+    this.name = 'SkillsBffValidationError'
+    this.status = options.status
+    this.code = options.code
+  }
+}
+
+function utf8Bytes(value: string) {
+  return new TextEncoder().encode(value).length
+}
+
+export function validateSkillId(skillId: string) {
+  if (!SKILL_ID_PATTERN.test(skillId)) {
+    throw new SkillsBffValidationError('Skill inválida para la frontera BFF.', {
+      status: 400,
+      code: 'validation_error',
+    })
+  }
+
+  return skillId
+}
+
+export function assertJsonContentType(request: Request) {
+  const contentType = request.headers.get('content-type') ?? ''
+  const mediaType = contentType.split(';', 1)[0]?.trim().toLowerCase()
+
+  if (mediaType !== 'application/json') {
+    throw new SkillsBffValidationError('La frontera BFF de Skills solo acepta application/json.', {
+      status: 415,
+      code: 'unsupported_media_type',
+    })
+  }
+}
+
+async function readLimitedJson(request: Request): Promise<unknown> {
+  const body = await request.text()
+
+  if (utf8Bytes(body) > SKILLS_BFF_BODY_LIMIT_BYTES) {
+    throw new SkillsBffValidationError('El payload supera el tamaño máximo permitido por la frontera BFF.', {
+      status: 413,
+      code: 'validation_error',
+    })
+  }
+
+  try {
+    return JSON.parse(body) as unknown
+  } catch {
+    throw new SkillsBffValidationError('El payload debe ser JSON válido.', {
+      status: 400,
+      code: 'validation_error',
+    })
+  }
+}
+
+function validateContent(value: unknown) {
+  if (typeof value !== 'string') {
+    throw new SkillsBffValidationError('El contenido de la skill debe ser texto.', {
+      status: 400,
+      code: 'validation_error',
+    })
+  }
+
+  if (!value.trim()) {
+    throw new SkillsBffValidationError('El contenido de la skill no puede quedar vacío.', {
+      status: 400,
+      code: 'validation_error',
+    })
+  }
+
+  if (value.includes('\0')) {
+    throw new SkillsBffValidationError('El contenido de la skill contiene bytes nulos no permitidos.', {
+      status: 400,
+      code: 'validation_error',
+    })
+  }
+
+  if (utf8Bytes(value) > SKILLS_BFF_CONTENT_LIMIT_BYTES) {
+    throw new SkillsBffValidationError('El contenido de la skill supera el tamaño máximo permitido.', {
+      status: 413,
+      code: 'validation_error',
+    })
+  }
+
+  return value
+}
+
+function validateExpectedSha(value: unknown) {
+  if (typeof value !== 'string' || !SHA256_PATTERN.test(value)) {
+    throw new SkillsBffValidationError('El fingerprint esperado debe ser un sha256 válido.', {
+      status: 400,
+      code: 'validation_error',
+    })
+  }
+
+  return value
+}
+
+function validateActor(value: unknown) {
+  if (typeof value !== 'string') {
+    throw new SkillsBffValidationError('El actor visible es obligatorio.', {
+      status: 400,
+      code: 'validation_error',
+    })
+  }
+
+  const actor = value.trim()
+
+  if (!actor || actor.length > 120) {
+    throw new SkillsBffValidationError('El actor visible debe tener entre 1 y 120 caracteres.', {
+      status: 400,
+      code: 'validation_error',
+    })
+  }
+
+  return actor
+}
+
+function assertObject(payload: unknown): Record<string, unknown> {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new SkillsBffValidationError('El payload debe ser un objeto JSON.', {
+      status: 400,
+      code: 'validation_error',
+    })
+  }
+
+  return payload as Record<string, unknown>
+}
+
+export async function parseSkillPreviewPayload(request: Request) {
+  assertJsonContentType(request)
+  const payload = assertObject(await readLimitedJson(request))
+
+  return {
+    content: validateContent(payload.content),
+    expected_sha256: validateExpectedSha(payload.expected_sha256),
+  }
+}
+
+export async function parseSkillUpdatePayload(request: Request) {
+  assertJsonContentType(request)
+  const payload = assertObject(await readLimitedJson(request))
+
+  return {
+    actor: validateActor(payload.actor),
+    content: validateContent(payload.content),
+    expected_sha256: validateExpectedSha(payload.expected_sha256),
+  }
+}
+
+export function buildSkillsBffValidationErrorPayload(error: SkillsBffValidationError): BffErrorPayload {
+  return {
+    detail: {
+      code: error.code,
+      message: error.message,
+    },
+  }
+}
+
+export function isSkillsBffValidationError(error: unknown): error is SkillsBffValidationError {
+  return error instanceof SkillsBffValidationError
+}

--- a/apps/web/src/modules/skills/api/skills-http.ts
+++ b/apps/web/src/modules/skills/api/skills-http.ts
@@ -13,6 +13,8 @@ type ApiErrorPayload = {
   }
 }
 
+const SKILLS_BFF_BASE_PATH = '/api/control-panel/skills'
+
 export class SkillsApiError extends Error {
   status: number
   code: string
@@ -25,27 +27,16 @@ export class SkillsApiError extends Error {
   }
 }
 
-function trimTrailingSlash(value: string) {
-  return value.replace(/\/$/, '')
-}
-
-export function getSkillsApiBaseUrl() {
-  const value = process.env.NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL
-  return value ? trimTrailingSlash(value) : null
+export function getSkillsApiConnectionLabel() {
+  return 'BFF same-origin'
 }
 
 async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
-  const baseUrl = getSkillsApiBaseUrl()
-
-  if (!baseUrl) {
-    throw new SkillsApiError('not_configured', { status: 0, code: 'not_configured' })
-  }
-
-  const response = await fetch(`${baseUrl}${path}`, {
+  const response = await fetch(`${SKILLS_BFF_BASE_PATH}${path}`, {
     ...init,
     headers: {
       Accept: 'application/json',
-      'Content-Type': 'application/json',
+      ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
       ...init?.headers,
     },
   })
@@ -69,26 +60,26 @@ async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 export function fetchSkillsCatalog() {
-  return fetchJson<SkillsCatalogResponse>('/api/v1/skills')
+  return fetchJson<SkillsCatalogResponse>('')
 }
 
 export function fetchSkillDetail(skillId: string) {
-  return fetchJson<SkillDetailResponse>(`/api/v1/skills/${skillId}`)
+  return fetchJson<SkillDetailResponse>(`/${encodeURIComponent(skillId)}`)
 }
 
 export function fetchSkillsAudit() {
-  return fetchJson<SkillAuditResponse>('/api/v1/skills/audit')
+  return fetchJson<SkillAuditResponse>('/audit')
 }
 
 export function fetchSkillPreview(skillId: string, payload: { content: string; expected_sha256: string }) {
-  return fetchJson<SkillPreviewResponse>(`/api/v1/skills/${skillId}/preview`, {
+  return fetchJson<SkillPreviewResponse>(`/${encodeURIComponent(skillId)}/preview`, {
     method: 'POST',
     body: JSON.stringify(payload),
   })
 }
 
 export function updateSkill(skillId: string, payload: { actor: string; content: string; expected_sha256: string }) {
-  return fetchJson<SkillUpdateResponse>(`/api/v1/skills/${skillId}`, {
+  return fetchJson<SkillUpdateResponse>(`/${encodeURIComponent(skillId)}`, {
     method: 'PUT',
     body: JSON.stringify(payload),
   })

--- a/apps/web/src/modules/skills/api/skills-server-http.ts
+++ b/apps/web/src/modules/skills/api/skills-server-http.ts
@@ -1,0 +1,175 @@
+import 'server-only'
+
+export const SKILLS_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'
+
+export type SkillsServerApiErrorCode =
+  | 'not_configured'
+  | 'validation_error'
+  | 'unsupported_media_type'
+  | 'stale'
+  | 'forbidden'
+  | 'not_found'
+  | 'source_unavailable'
+  | 'upstream_unavailable'
+  | `http_${number}`
+
+export type SkillsServerErrorPayload = {
+  detail: {
+    code: SkillsServerApiErrorCode
+    message: string
+  }
+}
+
+type ApiErrorPayload = {
+  detail?: {
+    code?: string
+    message?: string
+  }
+}
+
+export class SkillsServerApiError extends Error {
+  status: number
+  code: SkillsServerApiErrorCode
+
+  constructor(message: string, options: { status: number; code: SkillsServerApiErrorCode }) {
+    super(message)
+    this.name = 'SkillsServerApiError'
+    this.status = options.status
+    this.code = options.code
+  }
+}
+
+function trimTrailingSlash(value: string) {
+  return value.replace(/\/$/, '')
+}
+
+function sanitizeUpstreamCode(status: number, code: string | undefined): SkillsServerApiErrorCode {
+  if (
+    code === 'validation_error' ||
+    code === 'unsupported_media_type' ||
+    code === 'stale' ||
+    code === 'forbidden' ||
+    code === 'not_found' ||
+    code === 'source_unavailable' ||
+    code === 'not_configured' ||
+    code === 'upstream_unavailable'
+  ) {
+    return code
+  }
+
+  return `http_${status}`
+}
+
+function sanitizeUpstreamMessage(status: number, code: SkillsServerApiErrorCode, message: string | undefined) {
+  if (message && !message.includes('://') && !message.includes('Traceback') && !message.includes('/srv/')) {
+    return message
+  }
+
+  switch (code) {
+    case 'not_configured':
+      return 'La configuración server-only de Skills no está disponible.'
+    case 'validation_error':
+      return 'La petición no cumple el contrato de Skills.'
+    case 'stale':
+      return 'Fingerprint desactualizado; recarga la skill antes de guardar.'
+    case 'forbidden':
+      return 'Operación no permitida para esta skill allowlisted.'
+    case 'not_found':
+      return 'Skill no disponible en la allowlist.'
+    case 'source_unavailable':
+      return 'La fuente allowlisted de Skills no está disponible.'
+    default:
+      return `El backend de Skills respondió con estado ${status}.`
+  }
+}
+
+export function getSkillsServerApiBaseUrl() {
+  const value = process.env[SKILLS_API_BASE_URL_ENV]
+
+  if (!value) {
+    throw new SkillsServerApiError('La configuración server-only de Skills no está disponible.', {
+      status: 503,
+      code: 'not_configured',
+    })
+  }
+
+  let parsed: URL
+
+  try {
+    parsed = new URL(value)
+  } catch {
+    throw new SkillsServerApiError('La configuración server-only de Skills no está disponible.', {
+      status: 503,
+      code: 'not_configured',
+    })
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new SkillsServerApiError('La configuración server-only de Skills no está disponible.', {
+      status: 503,
+      code: 'not_configured',
+    })
+  }
+
+  return trimTrailingSlash(value)
+}
+
+export async function fetchSkillsServerJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const baseUrl = getSkillsServerApiBaseUrl()
+
+  let response: Response
+
+  try {
+    response = await fetch(`${baseUrl}${path}`, {
+      ...init,
+      cache: 'no-store',
+      headers: {
+        Accept: 'application/json',
+        ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
+      },
+    })
+  } catch {
+    throw new SkillsServerApiError('El backend de Skills no está disponible.', {
+      status: 503,
+      code: 'upstream_unavailable',
+    })
+  }
+
+  if (!response.ok) {
+    let payload: ApiErrorPayload | null = null
+
+    try {
+      payload = (await response.json()) as ApiErrorPayload
+    } catch {
+      payload = null
+    }
+
+    const code = sanitizeUpstreamCode(response.status, payload?.detail?.code)
+    throw new SkillsServerApiError(sanitizeUpstreamMessage(response.status, code, payload?.detail?.message), {
+      status: response.status,
+      code,
+    })
+  }
+
+  return (await response.json()) as T
+}
+
+export function buildSkillsServerErrorPayload(error: SkillsServerApiError): SkillsServerErrorPayload {
+  return {
+    detail: {
+      code: error.code,
+      message: error.message,
+    },
+  }
+}
+
+export function normalizeSkillsServerError(error: unknown): SkillsServerApiError {
+  if (error instanceof SkillsServerApiError) {
+    return error
+  }
+
+  return new SkillsServerApiError('Error interno saneado en la frontera BFF de Skills.', {
+    status: 500,
+    code: 'upstream_unavailable',
+  })
+}

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -11,8 +11,7 @@ El control plane distingue entre configuración pública de frontend y configura
 
 | Variable | Consumidor | Exposición | Uso |
 | --- | --- | --- | --- |
-| `MUGIWARA_CONTROL_PANEL_API_URL` | `/memory`, `/mugiwaras` server loaders | Server-only | Base URL del backend para superficies read-only que pueden cargar desde servidor. |
-| `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` | `/skills` | Pública/cliente | Base URL histórica para la superficie Skills hasta que tenga frontera BFF/server-side propia. |
+| `MUGIWARA_CONTROL_PANEL_API_URL` | `/memory`, `/mugiwaras`, `/skills` BFF/server loaders | Server-only | Base URL del backend para superficies que deben resolver datos desde servidor o frontera BFF. |
 
 ## Memory
 `/memory` usa el patrón server-only desde Phase 12.3c:
@@ -59,15 +58,28 @@ Antes de cerrar cambios que toquen Mugiwaras config, ejecutar:
 npm run verify:mugiwaras-server-only
 ```
 
-## Pendiente deliberado
-`/skills` sigue usando `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` por compatibilidad con fases previas.
+## Skills
+`/skills` usa el patrón BFF/server-only desde Phase 12.3h:
 
-La planificación inicial vive en `openspec/phase-12-3e-server-only-migration-plan.md` y el diseño específico de Skills BFF vive en `openspec/phase-12-3g-skills-bff-design.md`.
+1. El navegador llama solo a endpoints same-origin bajo `/api/control-panel/skills/**`.
+2. `apps/web/src/modules/skills/api/skills-server-http.ts` importa `server-only` y lee `MUGIWARA_CONTROL_PANEL_API_URL`.
+3. La base URL se valida como `http:` o `https:` antes del fetch upstream.
+4. Los route handlers de Next.js usan `cache: 'no-store'`, `force-dynamic` y endpoints allowlisted, no proxy genérico.
+5. Las rutas BFF validan `skillId`, método, `Content-Type`, tamaño y schema antes de reenviar preview/update.
+6. Los errores devueltos al navegador están saneados y no incluyen backend URL, stack traces, bodies, diffs ni secretos.
+7. FastAPI sigue siendo fuente de verdad para allowlist, path safety, stale hash, edición y auditoría.
+
+Antes de cerrar cambios que toquen Skills config o BFF, ejecutar:
+
+```bash
+npm run verify:skills-server-only
+```
+
+## Decisiones relacionadas
+La planificación inicial vive en `openspec/phase-12-3e-server-only-migration-plan.md`, el diseño específico de Skills BFF vive en `openspec/phase-12-3g-skills-bff-design.md` y la implementación vive en `openspec/phase-12-3h-skills-bff-implementation.md`.
 
 Resumen de la decisión:
 - `/mugiwaras` ya migró en Phase 12.3f porque era server component, dinámico y no necesitaba browser fetch directo.
-- `/skills` requiere implementación propia porque hoy es client component y contiene preview/update controlados.
-- Phase 12.3g decide usar Next.js route handlers bajo `/api/control-panel/skills/**` como BFF same-origin, no server actions por ahora.
-- Ese BFF debe usar `MUGIWARA_CONTROL_PANEL_API_URL` solo en servidor, no ser proxy abierto, validar `skillId`/método/`Content-Type`/tamaño/schema, usar `cache: no-store` y devolver errores saneados.
+- `/skills` migró en Phase 12.3h con route handlers BFF same-origin porque es client component y contiene preview/update controlados.
+- Ese BFF usa `MUGIWARA_CONTROL_PANEL_API_URL` solo en servidor, no es proxy abierto, valida entradas críticas, usa `cache: no-store` y devuelve errores saneados.
 - FastAPI sigue siendo la fuente de verdad para allowlist, path safety, stale hash, edición y auditoría.
-- La implementación de `/skills` debe llevar revisión de Chopper + Franky.

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -68,6 +68,7 @@ npm run verify:mugiwaras-server-only
 5. Las rutas BFF validan `skillId`, método, `Content-Type`, tamaño y schema antes de reenviar preview/update.
 6. Los errores devueltos al navegador están saneados y no incluyen backend URL, stack traces, bodies, diffs ni secretos.
 7. FastAPI sigue siendo fuente de verdad para allowlist, path safety, stale hash, edición y auditoría.
+8. Los endpoints `/api/control-panel/skills/**`, especialmente `PUT`, pertenecen al control plane privado: no deben exponerse fuera de Tailscale/perímetro autenticado sin añadir auth/autorización server-side y rate limiting.
 
 Antes de cerrar cambios que toquen Skills config o BFF, ejecutar:
 

--- a/openspec/phase-12-3h-skills-bff-implementation.md
+++ b/openspec/phase-12-3h-skills-bff-implementation.md
@@ -44,11 +44,12 @@ The browser no longer needs `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` for `/s
 
 The server adapter validates `http:`/`https:` URL schemes. Missing or invalid config returns sanitized `not_configured` errors through the BFF instead of exposing the value.
 
-## Cache/logging/credential policy
+## Cache/logging/credential/perimeter policy
 - BFF upstream fetches use `cache: 'no-store'`.
 - Route handlers force dynamic/no-store execution.
 - No request-body logging is introduced.
 - The BFF does not forward browser cookies or arbitrary Authorization headers to FastAPI.
+- The `/api/control-panel/skills/**` endpoints, especially `PUT`, remain private-control-plane endpoints and must not be exposed outside Tailscale/an authenticated perimeter without adding server-side auth/authorization and rate limiting.
 - Browser-visible errors use a narrow `detail.code` / `detail.message` shape.
 
 ## FastAPI remains source of truth

--- a/openspec/phase-12-3h-skills-bff-implementation.md
+++ b/openspec/phase-12-3h-skills-bff-implementation.md
@@ -1,0 +1,99 @@
+# Phase 12.3h — Skills BFF/server-only implementation
+
+## Scope
+Implement the `/skills` BFF/server-only migration designed in Phase 12.3g.
+
+## Implemented changes
+- Added Next.js route handlers under `/api/control-panel/skills/**`:
+  - `GET /api/control-panel/skills`
+  - `GET /api/control-panel/skills/audit`
+  - `GET /api/control-panel/skills/[skillId]`
+  - `POST /api/control-panel/skills/[skillId]/preview`
+  - `PUT /api/control-panel/skills/[skillId]`
+- Added `apps/web/src/modules/skills/api/skills-server-http.ts` as server-only upstream adapter.
+- Added `apps/web/src/modules/skills/api/skills-bff-validation.ts` for BFF guardrail validation.
+- Refactored browser adapter `apps/web/src/modules/skills/api/skills-http.ts` to call same-origin `/api/control-panel/skills` endpoints only.
+- Updated `/skills/page.tsx` operational copy to avoid backend base URL display and public env instructions.
+- Added `scripts/check-skills-server-only.mjs` and `npm run verify:skills-server-only`.
+- Updated `README.md` and `docs/runtime-config.md`.
+
+## Security boundary
+The BFF is an allowlisted route boundary, not a generic proxy.
+
+It does not accept arbitrary upstream path, URL, target, method or query-controlled routing. Dynamic routes validate `skillId` against:
+
+```text
+^[a-z0-9][a-z0-9_-]{0,79}$
+```
+
+Preview/update routes validate:
+- `Content-Type: application/json`;
+- request body <= 256 KiB;
+- `content` is non-empty text, max 200,000 UTF-8 bytes, no NUL;
+- `expected_sha256` is 64 hex chars;
+- `actor` is non-empty, trimmed and <= 120 chars for update.
+
+## Runtime config
+`/skills` now uses:
+
+```bash
+MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011
+```
+
+The browser no longer needs `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` for `/skills`.
+
+The server adapter validates `http:`/`https:` URL schemes. Missing or invalid config returns sanitized `not_configured` errors through the BFF instead of exposing the value.
+
+## Cache/logging/credential policy
+- BFF upstream fetches use `cache: 'no-store'`.
+- Route handlers force dynamic/no-store execution.
+- No request-body logging is introduced.
+- The BFF does not forward browser cookies or arbitrary Authorization headers to FastAPI.
+- Browser-visible errors use a narrow `detail.code` / `detail.message` shape.
+
+## FastAPI remains source of truth
+The Next BFF is a boundary of exposure and validation, not the final authorization layer.
+
+FastAPI still owns:
+- skill allowlist;
+- editable vs read-only policy;
+- path safety and symlink rejection;
+- stale hash checks;
+- write execution;
+- audit append.
+
+## Guardrail
+Run:
+
+```bash
+npm run verify:skills-server-only
+```
+
+The check fails if:
+- the browser adapter reads `process.env` or `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL`;
+- the browser adapter contains absolute backend URLs;
+- the server adapter lacks `server-only` or `MUGIWARA_CONTROL_PANEL_API_URL`;
+- route handlers lose dynamic/no-store flags;
+- key validation functions disappear;
+- obvious generic proxy snippets appear.
+
+## Verify expected before merge
+```bash
+npm run verify:skills-server-only
+npm run verify:memory-server-only
+npm run verify:mugiwaras-server-only
+npm --prefix apps/web run typecheck
+npm --prefix apps/web run build
+PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py
+```
+
+Manual smoke expected:
+- BFF returns sanitized `not_configured` when server env is missing or invalid.
+- With local FastAPI configured, `/skills` loads catalog/detail/audit through BFF.
+- Preview works through BFF for a safe, non-persisting diff.
+- Update route is not smoke-tested against production skills unless a safe fixture/restore workflow is in place.
+
+## Reviewer routing
+- Chopper: required because this touches endpoint/input boundary and the only write-capable MVP surface.
+- Franky: required because this touches Next route handlers, runtime config, no-store behaviour and guardrails.
+- Usopp: not required unless reviewers consider the visible copy changes material. The UI structure remains unchanged; only operational copy changes to remove backend URL exposure.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "verify:visual-baseline": "node scripts/visual-verify-baseline.mjs",
     "verify:memory-server-only": "node scripts/check-memory-server-only.mjs",
     "verify:mugiwaras-server-only": "node scripts/check-mugiwaras-server-only.mjs",
+    "verify:skills-server-only": "node scripts/check-skills-server-only.mjs",
     "dev:api": "uvicorn apps.api.src.main:app --reload",
     "lint": "echo 'Pending lint setup'",
     "test": "echo 'Pending test setup'"

--- a/scripts/check-skills-server-only.mjs
+++ b/scripts/check-skills-server-only.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Static safety check for Phase 12.3h.
+ *
+ * Inputs: Skills browser adapter, server-only adapter, route handlers and page.
+ * Output: exits non-zero when Skills regresses to public backend config, loses
+ * the BFF route boundary, or shows obvious generic-proxy patterns. Read-only.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = process.cwd()
+const paths = {
+  browserAdapter: join(repoRoot, 'apps/web/src/modules/skills/api/skills-http.ts'),
+  serverAdapter: join(repoRoot, 'apps/web/src/modules/skills/api/skills-server-http.ts'),
+  validation: join(repoRoot, 'apps/web/src/modules/skills/api/skills-bff-validation.ts'),
+  page: join(repoRoot, 'apps/web/src/app/skills/page.tsx'),
+  catalogRoute: join(repoRoot, 'apps/web/src/app/api/control-panel/skills/route.ts'),
+  auditRoute: join(repoRoot, 'apps/web/src/app/api/control-panel/skills/audit/route.ts'),
+  detailRoute: join(repoRoot, 'apps/web/src/app/api/control-panel/skills/[skillId]/route.ts'),
+  previewRoute: join(repoRoot, 'apps/web/src/app/api/control-panel/skills/[skillId]/preview/route.ts'),
+}
+
+const failures = []
+
+for (const [name, path] of Object.entries(paths)) {
+  if (!existsSync(path)) {
+    failures.push(`missing ${name} at ${path}`)
+  }
+}
+
+function read(path) {
+  return existsSync(path) ? readFileSync(path, 'utf8') : ''
+}
+
+const browserAdapter = read(paths.browserAdapter)
+const serverAdapter = read(paths.serverAdapter)
+const validation = read(paths.validation)
+const page = read(paths.page)
+const catalogRoute = read(paths.catalogRoute)
+const auditRoute = read(paths.auditRoute)
+const detailRoute = read(paths.detailRoute)
+const previewRoute = read(paths.previewRoute)
+const allRoutes = [catalogRoute, auditRoute, detailRoute, previewRoute].join('\n')
+
+if (browserAdapter.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL') || browserAdapter.includes('process.env')) {
+  failures.push('skills browser adapter must not read public env or process.env')
+}
+
+if (!browserAdapter.includes("const SKILLS_BFF_BASE_PATH = '/api/control-panel/skills'")) {
+  failures.push('skills browser adapter must use same-origin /api/control-panel/skills base path')
+}
+
+if (browserAdapter.includes('http://') || browserAdapter.includes('https://')) {
+  failures.push('skills browser adapter must not contain an absolute backend URL')
+}
+
+if (browserAdapter.includes('skills-server-http')) {
+  failures.push('browser-side skills adapter must not import the server-only adapter')
+}
+
+if (!serverAdapter.includes("import 'server-only'")) {
+  failures.push('skills server adapter must be guarded with server-only')
+}
+
+if (!serverAdapter.includes("SKILLS_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'")) {
+  failures.push('skills server adapter must use MUGIWARA_CONTROL_PANEL_API_URL')
+}
+
+if (serverAdapter.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL')) {
+  failures.push('skills server adapter must not read NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL')
+}
+
+if (!serverAdapter.includes("parsed.protocol !== 'http:'") || !serverAdapter.includes("parsed.protocol !== 'https:'")) {
+  failures.push('skills server adapter must reject non-http(s) API base URLs')
+}
+
+if (!serverAdapter.includes("cache: 'no-store'")) {
+  failures.push('skills server adapter must fetch upstream with cache: no-store')
+}
+
+if (page.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL') || page.includes('API base URL')) {
+  failures.push('/skills page must not show public env instructions or backend base URL copy')
+}
+
+if (!page.includes('BFF same-origin') || !page.includes('MUGIWARA_CONTROL_PANEL_API_URL')) {
+  failures.push('/skills page must describe same-origin BFF and server-only configuration')
+}
+
+for (const [name, route] of Object.entries({ catalogRoute, auditRoute, detailRoute, previewRoute })) {
+  if (!route.includes("export const dynamic = 'force-dynamic'")) {
+    failures.push(`${name} must force dynamic execution`)
+  }
+  if (!route.includes("export const fetchCache = 'force-no-store'")) {
+    failures.push(`${name} must force no-store fetch cache`)
+  }
+}
+
+if (!catalogRoute.includes("fetchSkillsServerJson('/api/v1/skills')")) {
+  failures.push('catalog route must call the allowlisted FastAPI catalog endpoint')
+}
+
+if (!auditRoute.includes("fetchSkillsServerJson('/api/v1/skills/audit')")) {
+  failures.push('audit route must call the allowlisted FastAPI audit endpoint')
+}
+
+if (!detailRoute.includes('validateSkillId(skillId)') || !previewRoute.includes('validateSkillId(skillId)')) {
+  failures.push('dynamic skills routes must validate skillId before upstream fetch')
+}
+
+if (!detailRoute.includes('parseSkillUpdatePayload(request)')) {
+  failures.push('update route must validate update payload before upstream fetch')
+}
+
+if (!previewRoute.includes('parseSkillPreviewPayload(request)')) {
+  failures.push('preview route must validate preview payload before upstream fetch')
+}
+
+if (!validation.includes('SKILLS_BFF_BODY_LIMIT_BYTES = 256 * 1024')) {
+  failures.push('BFF validation must keep the 256 KiB request body cap')
+}
+
+if (!validation.includes('SKILLS_BFF_CONTENT_LIMIT_BYTES = 200_000')) {
+  failures.push('BFF validation must keep the 200,000 byte skill content cap')
+}
+
+if (!validation.includes('assertJsonContentType')) {
+  failures.push('BFF validation must enforce application/json for write routes')
+}
+
+const forbiddenGenericProxySnippets = [
+  'searchParams.get(\'path\')',
+  'searchParams.get("path")',
+  'searchParams.get(\'url\')',
+  'searchParams.get("url")',
+  'searchParams.get(\'target\')',
+  'searchParams.get("target")',
+  'request.nextUrl.searchParams',
+  'params.path',
+  'params.url',
+  'params.target',
+]
+
+for (const snippet of forbiddenGenericProxySnippets) {
+  if (allRoutes.includes(snippet) || serverAdapter.includes(snippet)) {
+    failures.push(`skills BFF must not contain generic-proxy snippet: ${snippet}`)
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Skills server-only BFF check failed:')
+  for (const failure of failures) {
+    console.error(`- ${failure}`)
+  }
+  process.exit(1)
+}
+
+console.log('Skills server-only BFF check passed')


### PR DESCRIPTION
## Summary
- implements Phase 12.3h Skills BFF/server-only boundary
- adds same-origin Next route handlers under `/api/control-panel/skills/**`
- moves upstream FastAPI access to `skills-server-http.ts` guarded by `server-only` and `MUGIWARA_CONTROL_PANEL_API_URL`
- refactors browser Skills adapter to call same-origin BFF endpoints only
- adds BFF validation for `skillId`, JSON content type, request size and preview/update schemas
- adds `npm run verify:skills-server-only` guardrail and updates docs/OpenSpec/Engram

## Security/runtime notes
- BFF is not a generic proxy.
- Browser no longer needs `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL` for `/skills`.
- BFF does not forward cookies or arbitrary Authorization headers to FastAPI.
- Upstream calls use `cache: 'no-store'` and route handlers force dynamic/no-store.
- FastAPI remains source of truth for allowlist, path safety, stale hash, write policy and audit.

## Verification
- `git diff --check`
- `npm run verify:skills-server-only`
- `npm run verify:memory-server-only`
- `npm run verify:mugiwaras-server-only`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build`
- `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py` → `15 passed`

## Smoke
- Valid local env: `GET /api/control-panel/skills` → 200 catalog through BFF
- Detail through BFF → 200
- Preview through BFF → 200, non-persisting diff
- Invalid `skillId` → 400 sanitized
- Wrong `Content-Type` on preview → 415 sanitized
- Missing server env → 503 `not_configured` sanitized
- Invalid server env `file:///tmp` → 503 `not_configured` sanitized
- `/skills` renders via BFF; browser console clean

## Deliberate limitation
No update smoke against real allowlisted skills. Preview was tested without persisting writes. Update needs a safe fixture/restore workflow before smoke-writing production skills.

## Review requested
- Chopper: endpoint/input/security boundary, no generic proxy, validation, sanitized errors, credential forwarding, write-surface risk.
- Franky: route handler/runtime config, no-store, guardrail, build/smoke/rollback maintainability.
