### PR TITLE
feat: add health dashboard aggregation api

### DIFF
--- a/.engram/phase-12-5-health-dashboard-closeout.md
+++ b/.engram/phase-12-5-health-dashboard-closeout.md
@@ -1,0 +1,34 @@
+# Phase 12.5 closeout — Healthcheck and Dashboard aggregation APIs
+
+## Goal
+Move `/healthcheck` and `/dashboard` from frontend-only fixtures to backend-owned read-only summaries without opening host-control or shell surfaces.
+
+## Completed
+- Added backend `healthcheck` module and tests.
+- Added backend `dashboard` aggregation module and tests.
+- Added `GET /api/v1/healthcheck` and `GET /api/v1/dashboard`.
+- Added server-only frontend adapters for Healthcheck and Dashboard.
+- Converted `/healthcheck` and `/dashboard` to dynamic server pages that fetch backend data and fall back to sane local fixtures with visible API-state notices.
+- Added `npm run verify:health-dashboard-server-only` guardrail.
+- Added OpenSpec artifact and verify checklist.
+
+## Security notes
+- No shell commands, Docker/systemd control, logs, stdout/stderr, host paths or secrets are read or exposed.
+- Healthcheck uses a backend-owned safe catalog for this phase.
+- Dashboard aggregates only safe summaries and allowlisted links.
+- Unavailable Healthcheck is explicit (`not_configured`/stale warning) rather than silently treated as healthy.
+- Frontend uses private `MUGIWARA_CONTROL_PANEL_API_URL`; no `NEXT_PUBLIC_*` backend URL is introduced.
+
+## Verify snapshot
+- `python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/service.py apps/api/src/modules/healthcheck/router.py apps/api/src/modules/dashboard/service.py apps/api/src/modules/dashboard/router.py` OK.
+- `PYTHONPATH=. pytest apps/api/tests/test_healthcheck_dashboard_api.py` → 5 passed.
+- `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py apps/api/tests/test_vault_api.py apps/api/tests/test_healthcheck_dashboard_api.py` → 27 passed.
+- `npm run verify:health-dashboard-server-only` OK.
+- `npm --prefix apps/web run typecheck` OK.
+- `npm --prefix apps/web run build` OK with `/dashboard` and `/healthcheck` dynamic.
+- API smoke on local Phase 12.5 backend (`127.0.0.1:8001`): `/api/v1/healthcheck` 200 and `/api/v1/dashboard` 200.
+- Browser smoke on local web (`127.0.0.1:3002` with backend configured): `/healthcheck` 200 and `/dashboard` 200, backend-backed content visible, console clean.
+
+## Review expectation
+- Franky: runtime/server-only/dynamic behaviour and aggregation semantics.
+- Chopper: healthcheck/host-output safety boundary and sanitized error/fallback behaviour.

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -4,12 +4,16 @@ from .modules.skills.router import router as skills_router
 from .modules.mugiwaras.router import router as mugiwaras_router
 from .modules.memory.router import router as memory_router
 from .modules.vault.router import router as vault_router
+from .modules.healthcheck.router import router as healthcheck_router
+from .modules.dashboard.router import router as dashboard_router
 
 app = FastAPI(title='Mugiwara Control Panel API')
 app.include_router(skills_router)
 app.include_router(mugiwaras_router)
 app.include_router(memory_router)
 app.include_router(vault_router)
+app.include_router(healthcheck_router)
+app.include_router(dashboard_router)
 
 
 @app.get('/health')

--- a/apps/api/src/modules/dashboard/AGENTS.md
+++ b/apps/api/src/modules/dashboard/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS.md — apps/api/src/modules/dashboard
+
+## Rol
+Módulo backend read-only de agregación para Dashboard.
+
+## Reglas
+- Componer solo resúmenes ya saneados y links allowlisted.
+- No duplicar lógica sensible ni leer fuentes host directas.
+- La agregación debe hacer visibles `stale`/`not_configured` sin filtrar detalles internos.

--- a/apps/api/src/modules/dashboard/router.py
+++ b/apps/api/src/modules/dashboard/router.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from ...shared.contracts import resource_response
+from .service import DashboardService
+
+router = APIRouter(prefix='/api/v1/dashboard', tags=['dashboard'])
+_service = DashboardService()
+
+
+def get_dashboard_service() -> DashboardService:
+    return _service
+
+
+@router.get('')
+def get_dashboard_summary(service: DashboardService = Depends(get_dashboard_service)) -> dict:
+    summary = service.get_summary()
+    return resource_response(
+        resource='dashboard.summary',
+        status=service.summary_status(),
+        data=summary,
+        meta={
+            'links_count': len(summary['links']),
+            'read_only': True,
+            'sanitized': True,
+            'source': 'backend-owned-aggregation',
+        },
+    )

--- a/apps/api/src/modules/dashboard/service.py
+++ b/apps/api/src/modules/dashboard/service.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from ..healthcheck.service import HealthcheckService
+
+_SEVERITY_RANK = {'low': 1, 'medium': 2, 'high': 3, 'critical': 4}
+_STATUS_TO_SECTION = {'pass': 'healthy', 'warn': 'warning', 'stale': 'warning', 'fail': 'degraded'}
+_STATUS_TO_SEVERITY = {'pass': 'low', 'warn': 'medium', 'stale': 'medium', 'fail': 'high'}
+
+
+class DashboardService:
+    def __init__(self, *, healthcheck_service: HealthcheckService | None = None) -> None:
+        self._healthcheck_service = healthcheck_service or HealthcheckService()
+
+    def summary_status(self) -> str:
+        return 'ready'
+
+    def get_summary(self) -> dict:
+        health_status = self._healthcheck_service.workspace_status()
+        health = self._healthcheck_service.get_workspace()
+        summary_bar = health['summary_bar']
+        health_section_status = 'warning' if health_status != 'ready' else _STATUS_TO_SECTION.get(summary_bar['overall_status'], 'warning')
+        highest = self._highest_severity(health)
+        freshness_state = 'stale' if health_status != 'ready' or summary_bar['overall_status'] == 'stale' else 'fresh'
+        updated_at = summary_bar['updated_at']
+        freshness_label = 'Healthcheck backend no configurado' if health_status != 'ready' else 'Agregado backend actualizado'
+        warnings = int(summary_bar['warnings']) if health_status == 'ready' else 0
+        incidents = int(summary_bar['incidents']) if health_status == 'ready' else 0
+        return {
+            'sections': [
+                {'id': 'dashboard', 'label': 'Dashboard', 'status': 'healthy'},
+                {'id': 'healthcheck', 'label': 'Healthcheck', 'status': health_section_status},
+                {'id': 'mugiwaras', 'label': 'Mugiwaras', 'status': 'healthy'},
+                {'id': 'memory', 'label': 'Memory', 'status': 'warning'},
+                {'id': 'vault', 'label': 'Vault', 'status': 'healthy'},
+                {'id': 'skills', 'label': 'Skills', 'status': 'healthy'},
+            ],
+            'highest_severity': highest,
+            'freshness': {'updated_at': updated_at, 'label': freshness_label, 'state': freshness_state},
+            'counts': [
+                {'label': 'Superficies monitorizadas', 'value': 6, 'note': 'lectura backend agregada'},
+                {'label': 'Checks con warning', 'value': warnings, 'note': 'desde Healthcheck saneado'},
+                {'label': 'Mugiwaras activos', 'value': 9, 'note': 'catálogo allowlisted'},
+                {'label': 'Incidencias críticas', 'value': incidents, 'note': 'sin salidas crudas'},
+            ],
+            'links': [
+                {'label': 'Abrir Healthcheck', 'href': '/healthcheck'},
+                {'label': 'Abrir Mugiwaras', 'href': '/mugiwaras'},
+                {'label': 'Abrir Memory', 'href': '/memory'},
+                {'label': 'Abrir Vault', 'href': '/vault'},
+                {'label': 'Abrir Skills', 'href': '/skills'},
+            ],
+        }
+
+    def _highest_severity(self, health: dict) -> str:
+        severities = [_STATUS_TO_SEVERITY.get(module['status'], module.get('severity', 'medium')) for module in health['modules']]
+        if not severities:
+            return 'medium'
+        return max(severities, key=lambda severity: _SEVERITY_RANK[severity])

--- a/apps/api/src/modules/healthcheck/AGENTS.md
+++ b/apps/api/src/modules/healthcheck/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS.md — apps/api/src/modules/healthcheck
+
+## Rol
+Módulo backend read-only para la superficie Healthcheck.
+
+## Reglas
+- Exponer solo resúmenes saneados, módulos, eventos y señales allowlisted.
+- No ejecutar shell, Docker, systemd ni leer salidas crudas del host en esta fase.
+- No incluir secretos, paths absolutos, comandos, stdout/stderr ni logs crudos.
+- Los estados `stale` y `not_configured` deben ser visibles y semánticos.

--- a/apps/api/src/modules/healthcheck/domain.py
+++ b/apps/api/src/modules/healthcheck/domain.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class HealthcheckFreshness:
+    updated_at: str | None
+    label: str
+    state: str
+
+
+@dataclass(frozen=True)
+class HealthcheckRecord:
+    module_id: str
+    label: str
+    status: str
+    severity: str
+    updated_at: str
+    summary: str
+    warning_text: str
+    source_label: str
+    freshness_label: str
+
+
+@dataclass(frozen=True)
+class HealthcheckSummaryBar:
+    overall_status: str
+    checks_total: int
+    warnings: int
+    incidents: int
+    updated_at: str | None
+
+
+@dataclass(frozen=True)
+class HealthcheckModuleCard:
+    module_id: str
+    label: str
+    status: str
+    severity: str
+    updated_at: str
+    summary: str
+
+
+@dataclass(frozen=True)
+class HealthcheckEvent:
+    event_id: str
+    source: str
+    status: str
+    timestamp: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class HealthcheckSummaryItem:
+    check_id: str
+    label: str
+    severity: str
+    status: str
+    freshness: HealthcheckFreshness
+    warning_text: str
+    source_label: str

--- a/apps/api/src/modules/healthcheck/router.py
+++ b/apps/api/src/modules/healthcheck/router.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from ...shared.contracts import resource_response
+from .service import HealthcheckService
+
+router = APIRouter(prefix='/api/v1/healthcheck', tags=['healthcheck'])
+_service = HealthcheckService()
+
+
+def get_healthcheck_service() -> HealthcheckService:
+    return _service
+
+
+@router.get('')
+def get_healthcheck_workspace(service: HealthcheckService = Depends(get_healthcheck_service)) -> dict:
+    workspace = service.get_workspace()
+    return resource_response(
+        resource='healthcheck.workspace',
+        status=service.workspace_status(),
+        data=workspace,
+        meta={
+            'count': len(workspace['modules']),
+            'read_only': True,
+            'sanitized': True,
+            'source': 'backend-owned-safe-catalog',
+        },
+    )

--- a/apps/api/src/modules/healthcheck/service.py
+++ b/apps/api/src/modules/healthcheck/service.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from .domain import (
+    HealthcheckEvent,
+    HealthcheckFreshness,
+    HealthcheckModuleCard,
+    HealthcheckRecord,
+    HealthcheckSummaryBar,
+    HealthcheckSummaryItem,
+)
+
+SAFE_HEALTHCHECK_RECORDS: tuple[HealthcheckRecord, ...] = (
+    HealthcheckRecord('cronjobs', 'Cronjobs', 'warn', 'medium', '2026-04-24T07:41:00Z', 'La revisión nocturna ejecutó, pero queda una advertencia operativa menor en skills del job.', 'Quedan referencias de skills a normalizar.', 'Cron safe summary', 'Actualizado hace 5 min'),
+    HealthcheckRecord('backups', 'Backups', 'pass', 'low', '2026-04-24T07:35:00Z', 'Último backup local completado y checksum disponible.', 'Sin alerta activa.', 'Backup safe summary', 'Actualizado hace 11 min'),
+    HealthcheckRecord('gateways', 'Gateways', 'warn', 'medium', '2026-04-24T07:44:00Z', 'Latencia por encima del umbral recomendado en la puerta principal.', 'Latencia por encima del umbral recomendado.', 'Gateway safe summary', 'Actualizado hace 2 min'),
+    HealthcheckRecord('honcho', 'Honcho', 'stale', 'medium', '2026-04-24T07:22:00Z', 'Parte del contexto relacional está disponible, pero algunos resúmenes necesitan refresco.', 'Resumen relacional pendiente de refresco.', 'Honcho safe summary', 'Actualizado hace 24 min'),
+    HealthcheckRecord('docker', 'Docker', 'pass', 'low', '2026-04-24T07:32:00Z', 'Servicios contenedorizados sin incidencias visibles en este corte.', 'Sin alerta activa.', 'Docker safe summary', 'Actualizado hace 14 min'),
+    HealthcheckRecord('system', 'System', 'fail', 'high', '2026-04-24T07:39:00Z', 'Se detectó una incidencia abierta de capacidad que requiere revisión prioritaria.', 'Incidencia de capacidad marcada para revisión.', 'System safe summary', 'Actualizado hace 7 min'),
+)
+
+SAFE_EVENTS: tuple[HealthcheckEvent, ...] = (
+    HealthcheckEvent('evt-cron-nightly', 'cronjobs', 'warn', '2026-04-24T01:33:40+02:00', 'Ejecución nocturna completada con advertencia saneada pendiente de revisión.'),
+    HealthcheckEvent('evt-gateway-latency', 'gateways', 'warn', '2026-04-24T07:44:00Z', 'Latencia sostenida por encima del umbral objetivo durante la última ventana de observación.'),
+    HealthcheckEvent('evt-system-capacity', 'system', 'fail', '2026-04-24T07:39:00Z', 'Capacidad degradada en un componente operativo; se ha marcado como incidencia para revisión.'),
+    HealthcheckEvent('evt-backup-checksum', 'backups', 'pass', '2026-04-24T07:35:00Z', 'Backup reciente validado con checksum sin desviaciones visibles.'),
+)
+
+SAFE_PRINCIPLES: tuple[str, ...] = (
+    'Repo público',
+    'Deny by default',
+    'Allowlists explícitas',
+    'Sin acceso arbitrario al host',
+    'Sin shell remoto',
+)
+
+_STATUS_ORDER = {'fail': 4, 'warn': 3, 'stale': 2, 'pass': 1}
+
+
+class HealthcheckService:
+    def __init__(self, *, records: tuple[HealthcheckRecord, ...] = SAFE_HEALTHCHECK_RECORDS, events: tuple[HealthcheckEvent, ...] = SAFE_EVENTS) -> None:
+        self._records = records
+        self._events = events
+
+    def workspace_status(self) -> str:
+        return 'ready' if self._records else 'not_configured'
+
+    def get_workspace(self) -> dict:
+        modules = [self._to_module(record) for record in self._records]
+        signals = [self._to_signal(record) for record in self._records if record.status in {'warn', 'stale', 'fail'}]
+        summary_bar = self._summary_bar(modules)
+        events = self._events if self._records else ()
+        return {
+            'summary_bar': asdict(summary_bar),
+            'modules': [asdict(module) for module in modules],
+            'events': [asdict(event) for event in events],
+            'principles': list(SAFE_PRINCIPLES),
+            'signals': [asdict(signal) for signal in signals],
+        }
+
+    def _summary_bar(self, modules: list[HealthcheckModuleCard]) -> HealthcheckSummaryBar:
+        if not modules:
+            return HealthcheckSummaryBar('stale', 0, 0, 0, None)
+        incidents = sum(1 for module in modules if module.status == 'fail')
+        warnings = sum(1 for module in modules if module.status in {'warn', 'stale'})
+        overall = max(modules, key=lambda module: _STATUS_ORDER[module.status]).status
+        updated_at = max(module.updated_at for module in modules)
+        return HealthcheckSummaryBar(overall, len(modules), warnings, incidents, updated_at)
+
+    def _to_module(self, record: HealthcheckRecord) -> HealthcheckModuleCard:
+        return HealthcheckModuleCard(record.module_id, record.label, record.status, record.severity, record.updated_at, record.summary)
+
+    def _to_signal(self, record: HealthcheckRecord) -> HealthcheckSummaryItem:
+        return HealthcheckSummaryItem(
+            check_id=f'{record.module_id}-safe-signal',
+            label=record.label,
+            severity=record.severity,
+            status=record.status,
+            freshness=HealthcheckFreshness(updated_at=record.updated_at, label=record.freshness_label, state='stale' if record.status == 'stale' else 'fresh'),
+            warning_text=record.warning_text,
+            source_label=record.source_label,
+        )

--- a/apps/api/tests/test_healthcheck_dashboard_api.py
+++ b/apps/api/tests/test_healthcheck_dashboard_api.py
@@ -1,0 +1,93 @@
+from fastapi.testclient import TestClient
+
+from apps.api.src.main import app
+from apps.api.src.modules.healthcheck.service import HealthcheckService
+from apps.api.src.modules.dashboard.service import DashboardService
+
+client = TestClient(app)
+
+
+def _assert_no_sensitive_host_output(value):
+    forbidden = ('/srv/', '/home/', '.env', 'token', 'secret', 'password', 'raw_output', 'stdout', 'stderr', 'command')
+    if isinstance(value, dict):
+        for key, item in value.items():
+            assert all(term not in str(key).lower() for term in forbidden)
+            _assert_no_sensitive_host_output(item)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_no_sensitive_host_output(item)
+    elif isinstance(value, str):
+        lowered = value.lower()
+        assert all(term not in lowered for term in forbidden)
+
+
+def test_healthcheck_returns_sanitized_workspace():
+    response = client.get('/api/v1/healthcheck')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'healthcheck.workspace'
+    assert payload['status'] == 'ready'
+    assert payload['meta']['read_only'] is True
+    assert payload['meta']['sanitized'] is True
+    assert payload['meta']['source'] == 'backend-owned-safe-catalog'
+
+    data = payload['data']
+    assert data['summary_bar']['checks_total'] == len(data['modules'])
+    assert data['summary_bar']['warnings'] >= 1
+    assert data['summary_bar']['incidents'] >= 0
+    assert data['modules']
+    assert data['events']
+    assert data['signals']
+    assert {'Repo público', 'Deny by default', 'Sin shell remoto'}.issubset(set(data['principles']))
+    _assert_no_sensitive_host_output(payload)
+
+
+def test_healthcheck_empty_source_is_not_configured():
+    service = HealthcheckService(records=())
+
+    assert service.workspace_status() == 'not_configured'
+    assert service.get_workspace()['summary_bar']['checks_total'] == 0
+    assert service.get_workspace()['modules'] == []
+    assert service.get_workspace()['events'] == []
+    assert service.get_workspace()['signals'] == []
+
+
+def test_healthcheck_stale_state_is_visible():
+    payload = client.get('/api/v1/healthcheck').json()
+
+    assert any(module['status'] == 'stale' for module in payload['data']['modules'])
+    stale_signal = next(signal for signal in payload['data']['signals'] if signal['status'] == 'stale')
+    assert stale_signal['freshness']['label']
+    assert stale_signal['warning_text']
+
+
+def test_dashboard_aggregates_safe_summaries():
+    response = client.get('/api/v1/dashboard')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'dashboard.summary'
+    assert payload['status'] == 'ready'
+    assert payload['meta']['read_only'] is True
+    assert payload['meta']['sanitized'] is True
+    assert payload['meta']['links_count'] == 5
+
+    data = payload['data']
+    section_ids = {section['id'] for section in data['sections']}
+    assert section_ids == {'dashboard', 'healthcheck', 'mugiwaras', 'memory', 'vault', 'skills'}
+    assert data['highest_severity'] in {'low', 'medium', 'high', 'critical'}
+    assert data['freshness']['state'] in {'fresh', 'stale'}
+    assert any(count['label'] == 'Checks con warning' for count in data['counts'])
+    assert {'label': 'Abrir Healthcheck', 'href': '/healthcheck'} in data['links']
+    _assert_no_sensitive_host_output(payload)
+
+
+def test_dashboard_handles_unavailable_health_source_explicitly():
+    dashboard = DashboardService(healthcheck_service=HealthcheckService(records=()))
+
+    payload = dashboard.get_summary()
+    health_section = next(section for section in payload['sections'] if section['id'] == 'healthcheck')
+    assert health_section['status'] == 'warning'
+    assert payload['freshness']['state'] == 'stale'
+    assert any(count['label'] == 'Checks con warning' and count['value'] == 0 for count in payload['counts'])

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -3,7 +3,9 @@ import Link from 'next/link'
 import {
   dashboardSummaryFixture,
   type DashboardCount,
+  type DashboardSummary,
 } from '@/modules/dashboard/view-models/dashboard-summary.fixture'
+import { fetchDashboardSummary, DashboardApiError } from '@/modules/dashboard/api/dashboard-http'
 import {
   getDashboardSeverityLabel,
   mapDashboardFreshnessToStatus,
@@ -11,8 +13,55 @@ import {
 } from '@/modules/dashboard/view-models/dashboard-mappers'
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
+import { StatePanel } from '@/shared/ui/state/StatePanel'
 import { StatusBadge } from '@/shared/ui/status/StatusBadge'
-import { appTheme } from '@/shared/theme/tokens'
+import { appTheme, type AppStatus } from '@/shared/theme/tokens'
+
+type DashboardPageNotice = {
+  status: AppStatus
+  title: string
+  description: string
+  detail?: string
+}
+
+export const dynamic = 'force-dynamic'
+
+async function getInitialDashboardData(): Promise<{ summary: DashboardSummary; apiNotice: DashboardPageNotice | null }> {
+  try {
+    const response = await fetchDashboardSummary()
+
+    if (response.status !== 'ready') {
+      return {
+        summary: dashboardSummaryFixture,
+        apiNotice: {
+          status: 'sin-datos',
+          title: 'API Dashboard sin datos configurados',
+          description: 'La API respondió sin agregado disponible; se mantiene fixture saneado para no romper la navegación.',
+          detail: response.status,
+        },
+      }
+    }
+
+    return { summary: response.data as DashboardSummary, apiNotice: null }
+  } catch (error) {
+    const apiError = error instanceof DashboardApiError ? error : null
+
+    return {
+      summary: dashboardSummaryFixture,
+      apiNotice: {
+        status: apiError?.code === 'not_configured' ? 'sin-datos' : 'incidencia',
+        title:
+          apiError?.code === 'not_configured'
+            ? 'API Dashboard no configurada'
+            : apiError?.code === 'invalid_config'
+              ? 'Configuración server-only de Dashboard inválida'
+              : 'API Dashboard no disponible',
+        description: 'La página mantiene fallback saneado local. No se muestran detalles internos del backend ni salidas operativas crudas.',
+        detail: apiError?.code,
+      },
+    }
+  }
+}
 
 function CountGridItem({ count }: { count: DashboardCount }) {
   return (
@@ -23,8 +72,8 @@ function CountGridItem({ count }: { count: DashboardCount }) {
   )
 }
 
-export default function DashboardPage() {
-  const summary = dashboardSummaryFixture
+export default async function DashboardPage() {
+  const { summary, apiNotice } = await getInitialDashboardData()
 
   return (
     <>
@@ -35,6 +84,16 @@ export default function DashboardPage() {
         mugiwaraSlug="luffy"
         detailPills={['Puente de mando', 'Lectura saneada', 'Módulos propietarios']}
       />
+
+      {apiNotice ? (
+        <StatePanel
+          status={apiNotice.status}
+          title={apiNotice.title}
+          description={apiNotice.description}
+          detail={apiNotice.detail}
+          eyebrow="Estado de API"
+        />
+      ) : null}
 
       <section className="layout-grid layout-grid--cards-260">
         {summary.counts.map((count) => (

--- a/apps/web/src/app/healthcheck/page.tsx
+++ b/apps/web/src/app/healthcheck/page.tsx
@@ -4,14 +4,66 @@ import {
   mapHealthcheckSeverityToBadgeStatus,
   mapHealthcheckStatusToBadgeStatus,
 } from '@/modules/healthcheck/view-models/healthcheck-mappers'
-import { healthcheckWorkspaceFixture } from '@/modules/healthcheck/view-models/healthcheck-summary.fixture'
+import { fetchHealthcheckWorkspace, HealthcheckApiError } from '@/modules/healthcheck/api/healthcheck-http'
+import { healthcheckWorkspaceFixture, type HealthcheckWorkspace } from '@/modules/healthcheck/view-models/healthcheck-summary.fixture'
+import type { AppStatus } from '@/shared/theme/tokens'
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
 import { StatePanel } from '@/shared/ui/state/StatePanel'
 import { StatusBadge } from '@/shared/ui/status/StatusBadge'
 import { appTheme } from '@/shared/theme/tokens'
 
-function formatTimestamp(value: string) {
+type HealthcheckPageNotice = {
+  status: AppStatus
+  title: string
+  description: string
+  detail?: string
+}
+
+export const dynamic = 'force-dynamic'
+
+async function getInitialHealthcheckData(): Promise<{ workspace: HealthcheckWorkspace; apiNotice: HealthcheckPageNotice | null }> {
+  try {
+    const response = await fetchHealthcheckWorkspace()
+
+    if (response.status !== 'ready') {
+      return {
+        workspace: healthcheckWorkspaceFixture,
+        apiNotice: {
+          status: 'sin-datos',
+          title: 'API Healthcheck sin datos configurados',
+          description: 'La API respondió sin catálogo disponible; se mantiene fixture saneado para no romper la lectura.',
+          detail: response.status,
+        },
+      }
+    }
+
+    return { workspace: response.data as HealthcheckWorkspace, apiNotice: null }
+  } catch (error) {
+    const apiError = error instanceof HealthcheckApiError ? error : null
+
+    return {
+      workspace: healthcheckWorkspaceFixture,
+      apiNotice: {
+        status: apiError?.code === 'not_configured' ? 'sin-datos' : 'incidencia',
+        title:
+          apiError?.code === 'not_configured'
+            ? 'API Healthcheck no configurada'
+            : apiError?.code === 'invalid_config'
+              ? 'Configuración server-only de Healthcheck inválida'
+              : 'API Healthcheck no disponible',
+        description: 'La página mantiene fallback saneado local. No se muestran comandos, logs crudos ni detalles internos del host.',
+        detail: apiError?.code,
+      },
+    }
+  }
+}
+
+function formatTimestamp(value: string | null) {
+  if (!value) {
+    return 'Sin actualización'
+  }
+
   const date = new Date(value)
 
   if (Number.isNaN(date.getTime())) {
@@ -24,8 +76,8 @@ function formatTimestamp(value: string) {
   }).format(date)
 }
 
-export default function HealthcheckPage() {
-  const workspace = healthcheckWorkspaceFixture
+export default async function HealthcheckPage() {
+  const { workspace, apiNotice } = await getInitialHealthcheckData()
   const healthSummaryNotice =
     workspace.summary_bar.incidents > 0
       ? {
@@ -52,6 +104,16 @@ export default function HealthcheckPage() {
         mugiwaraSlug="chopper"
         detailPills={['Perímetro', 'Señales saneadas', 'Respuesta priorizada']}
       />
+
+      {apiNotice ? (
+        <StatePanel
+          status={apiNotice.status}
+          title={apiNotice.title}
+          description={apiNotice.description}
+          detail={apiNotice.detail}
+          eyebrow="Estado de API"
+        />
+      ) : null}
 
       <SurfaceCard title="Resumen de salud" elevated eyebrow="Puesto médico" accent="danger">
         <div style={{ display: 'grid', gap: '14px' }}>

--- a/apps/web/src/modules/dashboard/api/dashboard-http.ts
+++ b/apps/web/src/modules/dashboard/api/dashboard-http.ts
@@ -1,0 +1,85 @@
+import 'server-only'
+
+import type { DashboardSummaryResponse } from '@contracts/read-models'
+
+export const DASHBOARD_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'
+
+export class DashboardApiError extends Error {
+  status: number
+  code: string
+
+  constructor(message: string, options: { status: number; code: string }) {
+    super(message)
+    this.name = 'DashboardApiError'
+    this.status = options.status
+    this.code = options.code
+  }
+}
+
+type ApiErrorPayload = {
+  detail?: {
+    code?: string
+    message?: string
+  }
+}
+
+function trimTrailingSlash(value: string) {
+  return value.replace(/\/$/, '')
+}
+
+function parseDashboardApiBaseUrl(value: string) {
+  let parsed: URL
+
+  try {
+    parsed = new URL(value)
+  } catch {
+    throw new DashboardApiError('invalid_config', { status: 0, code: 'invalid_config' })
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new DashboardApiError('invalid_config', { status: 0, code: 'invalid_config' })
+  }
+
+  return trimTrailingSlash(value)
+}
+
+export function getDashboardApiBaseUrl() {
+  const value = process.env[DASHBOARD_API_BASE_URL_ENV]
+  return value ? parseDashboardApiBaseUrl(value) : null
+}
+
+async function parseApiError(response: Response) {
+  let payload: ApiErrorPayload | null = null
+
+  try {
+    payload = (await response.json()) as ApiErrorPayload
+  } catch {
+    payload = null
+  }
+
+  return new DashboardApiError(payload?.detail?.message ?? `http_${response.status}`, {
+    status: response.status,
+    code: payload?.detail?.code ?? `http_${response.status}`,
+  })
+}
+
+export async function fetchDashboardSummary(): Promise<DashboardSummaryResponse> {
+  const baseUrl = getDashboardApiBaseUrl()
+
+  if (!baseUrl) {
+    throw new DashboardApiError('not_configured', { status: 0, code: 'not_configured' })
+  }
+
+  const response = await fetch(`${baseUrl}/api/v1/dashboard`, {
+    cache: 'no-store',
+    headers: {
+      Accept: 'application/json',
+    },
+  })
+
+  if (!response.ok) {
+    throw await parseApiError(response)
+  }
+
+  return (await response.json()) as DashboardSummaryResponse
+}

--- a/apps/web/src/modules/healthcheck/api/healthcheck-http.ts
+++ b/apps/web/src/modules/healthcheck/api/healthcheck-http.ts
@@ -1,0 +1,85 @@
+import 'server-only'
+
+import type { HealthcheckWorkspaceResponse } from '@contracts/read-models'
+
+export const HEALTHCHECK_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'
+
+export class HealthcheckApiError extends Error {
+  status: number
+  code: string
+
+  constructor(message: string, options: { status: number; code: string }) {
+    super(message)
+    this.name = 'HealthcheckApiError'
+    this.status = options.status
+    this.code = options.code
+  }
+}
+
+type ApiErrorPayload = {
+  detail?: {
+    code?: string
+    message?: string
+  }
+}
+
+function trimTrailingSlash(value: string) {
+  return value.replace(/\/$/, '')
+}
+
+function parseHealthcheckApiBaseUrl(value: string) {
+  let parsed: URL
+
+  try {
+    parsed = new URL(value)
+  } catch {
+    throw new HealthcheckApiError('invalid_config', { status: 0, code: 'invalid_config' })
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new HealthcheckApiError('invalid_config', { status: 0, code: 'invalid_config' })
+  }
+
+  return trimTrailingSlash(value)
+}
+
+export function getHealthcheckApiBaseUrl() {
+  const value = process.env[HEALTHCHECK_API_BASE_URL_ENV]
+  return value ? parseHealthcheckApiBaseUrl(value) : null
+}
+
+async function parseApiError(response: Response) {
+  let payload: ApiErrorPayload | null = null
+
+  try {
+    payload = (await response.json()) as ApiErrorPayload
+  } catch {
+    payload = null
+  }
+
+  return new HealthcheckApiError(payload?.detail?.message ?? `http_${response.status}`, {
+    status: response.status,
+    code: payload?.detail?.code ?? `http_${response.status}`,
+  })
+}
+
+export async function fetchHealthcheckWorkspace(): Promise<HealthcheckWorkspaceResponse> {
+  const baseUrl = getHealthcheckApiBaseUrl()
+
+  if (!baseUrl) {
+    throw new HealthcheckApiError('not_configured', { status: 0, code: 'not_configured' })
+  }
+
+  const response = await fetch(`${baseUrl}/api/v1/healthcheck`, {
+    cache: 'no-store',
+    headers: {
+      Accept: 'application/json',
+    },
+  })
+
+  if (!response.ok) {
+    throw await parseApiError(response)
+  }
+
+  return (await response.json()) as HealthcheckWorkspaceResponse
+}

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -37,8 +37,16 @@
 - sin escritura en MVP
 
 ### `healthcheck`
-- resumir cronjobs, backups, gateways, honcho, docker y checks operativos
-- consumir fuentes saneadas y timestamps de frescura
+- exponer `GET /api/v1/healthcheck` como workspace read-only saneado
+- resumir cronjobs, backups, gateways, honcho, docker y checks operativos desde catálogo seguro backend-owned
+- consumir solo fuentes saneadas y timestamps de frescura
+- no ejecutar shell, Docker, systemd ni leer logs/salidas crudas del host en esta fase
+- representar `stale`/`not_configured` de forma explícita
+
+### `dashboard`
+- exponer `GET /api/v1/dashboard` como agregación read-only para la home operativa
+- componer solo resúmenes seguros y links allowlisted
+- degradar Healthcheck no configurado a warning/stale visible, nunca a sano silencioso
 
 ### `system`
 - estado general del servidor y señales operativas de alto nivel

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -13,15 +13,24 @@ Todos los recursos usan la envoltura común:
 ## Modelos por recurso
 ### `dashboard.summary`
 Campos esperados:
-- `sections`
-- `highest_severity`
-- `freshness`
-- `counts`
-- `links`
+- `sections[]` con `id`, `label` y estado saneado (`healthy`, `warning`, `degraded`)
+- `highest_severity` (`low`, `medium`, `high`, `critical`)
+- `freshness` con `updated_at`, `label` y `state`
+- `counts[]` con `label`, `value` y `note`
+- `links[]` allowlisted
 
 Uso:
 - entrada global de operador
 - navegación hacia superficies propietarias
+- agregación backend-owned de resúmenes ya saneados
+
+### `healthcheck.workspace`
+Campos esperados:
+- `summary_bar`
+- `modules[]`
+- `events[]`
+- `principles[]`
+- `signals[]`
 
 ### `healthcheck.summary[]`
 Campos esperados:

--- a/openspec/phase-12-5-health-dashboard-aggregation.md
+++ b/openspec/phase-12-5-health-dashboard-aggregation.md
@@ -1,0 +1,40 @@
+# Phase 12.5 — Healthcheck and Dashboard aggregation APIs
+
+## Scope
+Backend-own the read-only Healthcheck workspace and Dashboard aggregation before Phase 12 closeout.
+
+## Implemented
+- Backend `healthcheck` module:
+  - `GET /api/v1/healthcheck` returns sanitized summary bar, module cards, events, principles and signals.
+  - Uses backend-owned safe catalog only; no shell, Docker, systemd, log, stdout/stderr or host path reads.
+  - Supports explicit `not_configured` state when no safe records exist.
+- Backend `dashboard` module:
+  - `GET /api/v1/dashboard` aggregates safe Healthcheck output plus allowlisted product links/counts.
+  - Makes unavailable Healthcheck state visible as stale/warning instead of hiding it.
+- Frontend server-only integration:
+  - `/healthcheck` uses `apps/web/src/modules/healthcheck/api/healthcheck-http.ts` with `server-only`, private `MUGIWARA_CONTROL_PANEL_API_URL`, `cache: 'no-store'` and dynamic rendering.
+  - `/dashboard` uses `apps/web/src/modules/dashboard/api/dashboard-http.ts` with the same server-only boundary.
+  - Both routes keep sane local fallback and now show an API-state notice when falling back.
+- Added static guardrail `npm run verify:health-dashboard-server-only`.
+
+## Security boundary
+- Read-only only.
+- No live host internals are read in this phase.
+- No arbitrary path, URL, command or method is accepted from the browser.
+- API payloads are backend-owned fixtures/summaries and are sanitized by construction.
+- Frontend adapters do not expose backend URL through `NEXT_PUBLIC_*`.
+
+## Verify expected
+```bash
+python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/service.py apps/api/src/modules/healthcheck/router.py apps/api/src/modules/dashboard/service.py apps/api/src/modules/dashboard/router.py
+PYTHONPATH=. pytest apps/api/tests/test_healthcheck_dashboard_api.py
+PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py apps/api/tests/test_vault_api.py apps/api/tests/test_healthcheck_dashboard_api.py
+npm run verify:health-dashboard-server-only
+npm --prefix apps/web run typecheck
+npm --prefix apps/web run build
+```
+
+## Review routing
+- Franky required: runtime/server-only frontend loading, health/dashboard aggregation and operational semantics.
+- Chopper required: healthcheck safety boundary, no shell/host output exposure and sanitized fallback behavior.
+- Usopp only if visual layout changes materially; this phase preserves layout and adds fallback notices.

--- a/openspec/phase-12-5-verify-checklist.md
+++ b/openspec/phase-12-5-verify-checklist.md
@@ -1,0 +1,30 @@
+# Phase 12.5 verify checklist — Healthcheck and Dashboard aggregation APIs
+
+## Backend
+- [x] `healthcheck` backend module added under `apps/api/src/modules/healthcheck`.
+- [x] `dashboard` backend module added under `apps/api/src/modules/dashboard`.
+- [x] Endpoints registered in FastAPI app.
+- [x] Tests cover normal, stale and unavailable/not-configured states.
+- [x] Tests reject sensitive host output patterns in payloads.
+
+## Frontend
+- [x] `/healthcheck` reads via server-only adapter and remains dynamic.
+- [x] `/dashboard` reads via server-only adapter and remains dynamic.
+- [x] Both pages keep sane fallback and visible API-state notices.
+- [x] Static guardrail blocks public env regression and generic browser-side backend config usage.
+
+## Verify evidence
+- [x] `python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/service.py apps/api/src/modules/healthcheck/router.py apps/api/src/modules/dashboard/service.py apps/api/src/modules/dashboard/router.py`.
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_healthcheck_dashboard_api.py` → 5 passed.
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py apps/api/tests/test_vault_api.py apps/api/tests/test_healthcheck_dashboard_api.py` → 27 passed.
+- [x] `npm run verify:health-dashboard-server-only` → passed.
+- [x] `npm --prefix apps/web run typecheck` → passed.
+- [x] `npm --prefix apps/web run build` → passed; `/dashboard` and `/healthcheck` are dynamic (`ƒ`).
+
+## Pending before merge
+- [x] API + web smoke with local backend configured:
+  - `GET http://127.0.0.1:8001/api/v1/healthcheck` → 200.
+  - `GET http://127.0.0.1:8001/api/v1/dashboard` → 200.
+  - Browser smoke `http://127.0.0.1:3002/healthcheck` → 200, backend-backed Healthcheck content visible, no console errors.
+  - Browser smoke `http://127.0.0.1:3002/dashboard` → 200, backend-backed Dashboard content visible, no console errors.
+- [ ] PR review by Franky + Chopper.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "verify:mugiwaras-server-only": "node scripts/check-mugiwaras-server-only.mjs",
     "verify:skills-server-only": "node scripts/check-skills-server-only.mjs",
     "verify:vault-server-only": "node scripts/check-vault-server-only.mjs",
+    "verify:health-dashboard-server-only": "node scripts/check-health-dashboard-server-only.mjs",
     "dev:api": "uvicorn apps.api.src.main:app --reload",
     "lint": "echo 'Pending lint setup'",
     "test": "echo 'Pending test setup'"

--- a/packages/contracts/src/read-models.ts
+++ b/packages/contracts/src/read-models.ts
@@ -12,20 +12,32 @@ export type SafeLink = {
 }
 
 export type Severity = 'operativo' | 'revision' | 'incidencia' | 'stale' | 'sin-datos'
+export type OperationalSeverity = 'low' | 'medium' | 'high' | 'critical'
+export type HealthcheckStatus = 'pass' | 'warn' | 'fail' | 'stale'
 
 export type DashboardSection = {
-  section_id: string
+  id: 'dashboard' | 'healthcheck' | 'mugiwaras' | 'memory' | 'vault' | 'skills'
   label: string
-  status: Severity
-  summary: string
-  href?: string
+  status: 'healthy' | 'warning' | 'degraded'
+}
+
+export type DashboardFreshness = {
+  updated_at: string | null
+  label: string
+  state: 'fresh' | 'stale'
+}
+
+export type DashboardCount = {
+  label: string
+  value: number
+  note: string
 }
 
 export type DashboardSummary = {
   sections: DashboardSection[]
-  highest_severity: Severity
-  freshness: Freshness
-  counts: Record<string, number>
+  highest_severity: OperationalSeverity
+  freshness: DashboardFreshness
+  counts: DashboardCount[]
   links: SafeLink[]
 }
 
@@ -97,14 +109,53 @@ export type VaultDocument = {
   breadcrumbs: SafeLink[]
 }
 
+export type HealthcheckFreshness = {
+  updated_at: string | null
+  label: string
+  state: 'fresh' | 'stale'
+}
+
+export type HealthcheckSummaryBar = {
+  overall_status: HealthcheckStatus
+  checks_total: number
+  warnings: number
+  incidents: number
+  updated_at: string | null
+}
+
+export type HealthcheckModuleCard = {
+  module_id: string
+  label: string
+  status: HealthcheckStatus
+  severity: OperationalSeverity
+  updated_at: string
+  summary: string
+}
+
+export type HealthcheckEvent = {
+  event_id: string
+  source: string
+  status: HealthcheckStatus
+  timestamp: string
+  detail: string
+}
+
 export type HealthcheckSummary = {
   check_id: string
   label: string
-  severity: Severity
-  status: string
-  freshness: Freshness
+  severity: OperationalSeverity
+  status: HealthcheckStatus
+  freshness: HealthcheckFreshness
   warning_text: string | null
   source_label: string
+}
+
+export type HealthcheckWorkspace = {
+  summary_bar: HealthcheckSummaryBar
+  modules: HealthcheckModuleCard[]
+  events: HealthcheckEvent[]
+  principles: string[]
+  signals: HealthcheckSummary[]
 }
 
 export type SystemSignal = {
@@ -122,5 +173,6 @@ export type MemorySummaryResponse = ResourceEnvelope<{ items: MemoryAgentSummary
 export type MemoryDetailResponse = ResourceEnvelope<MemoryAgentDetail, { mugiwara_slug: string; read_only: true }>
 export type VaultIndexResponse = ResourceEnvelope<VaultIndex, { safe_root: string }>
 export type VaultDocumentResponse = ResourceEnvelope<VaultDocument, { path: string; markdown_only: true }>
+export type HealthcheckWorkspaceResponse = ResourceEnvelope<HealthcheckWorkspace, { count: number; read_only: true; sanitized: true; source: string }>
 export type HealthcheckSummaryResponse = ResourceEnvelope<{ items: HealthcheckSummary[] }, { count: number }>
 export type SystemSignalsResponse = ResourceEnvelope<{ items: SystemSignal[] }, { count: number }>

--- a/scripts/check-health-dashboard-server-only.mjs
+++ b/scripts/check-health-dashboard-server-only.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/** Static safety check for Phase 12.5 Healthcheck/Dashboard server-only integration. */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = process.cwd()
+const targets = [
+  {
+    name: 'healthcheck',
+    httpPath: join(repoRoot, 'apps/web/src/modules/healthcheck/api/healthcheck-http.ts'),
+    pagePath: join(repoRoot, 'apps/web/src/app/healthcheck/page.tsx'),
+    envSnippet: "HEALTHCHECK_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'",
+  },
+  {
+    name: 'dashboard',
+    httpPath: join(repoRoot, 'apps/web/src/modules/dashboard/api/dashboard-http.ts'),
+    pagePath: join(repoRoot, 'apps/web/src/app/dashboard/page.tsx'),
+    envSnippet: "DASHBOARD_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'",
+  },
+]
+const failures = []
+
+for (const target of targets) {
+  const http = readFileSync(target.httpPath, 'utf8')
+  const page = readFileSync(target.pagePath, 'utf8')
+
+  if (!http.includes("import 'server-only'")) {
+    failures.push(`${target.name} http adapter must be server-only guarded`)
+  }
+  if (!http.includes(target.envSnippet)) {
+    failures.push(`${target.name} http adapter must use MUGIWARA_CONTROL_PANEL_API_URL`)
+  }
+  if (http.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL')) {
+    failures.push(`${target.name} http adapter must not use public backend env`)
+  }
+  if (!http.includes("parsed.protocol !== 'http:'") || !http.includes("parsed.protocol !== 'https:'")) {
+    failures.push(`${target.name} http adapter must reject non-http(s) API base URLs`)
+  }
+  if (!http.includes("cache: 'no-store'")) {
+    failures.push(`${target.name} http adapter must fetch with cache: no-store`)
+  }
+  if (!page.includes("export const dynamic = 'force-dynamic'")) {
+    failures.push(`${target.name} page must force dynamic rendering`)
+  }
+  if (page.includes("'use client'")) {
+    failures.push(`${target.name} page must remain a server page`)
+  }
+  if (page.includes('process.env') || page.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL')) {
+    failures.push(`${target.name} page must not read backend env directly`)
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Healthcheck/Dashboard server-only integration check failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log('Healthcheck/Dashboard server-only integration check passed')


### PR DESCRIPTION
## Objetivo
Cerrar Phase 12.5 añadiendo APIs read-only backend-owned para `healthcheck` y `dashboard`, e integrar ambas rutas desde frontend con frontera server-only.

## Cambios
- Añade módulo backend `healthcheck` con `GET /api/v1/healthcheck` y catálogo seguro saneado.
- Añade módulo backend `dashboard` con `GET /api/v1/dashboard`, agregando solo resúmenes y links allowlisted.
- Convierte `/healthcheck` y `/dashboard` en páginas dinámicas server-side con adapters `server-only` y `MUGIWARA_CONTROL_PANEL_API_URL` privada.
- Añade fallback saneado visible cuando la API no está configurada/no disponible.
- Añade guardrail `npm run verify:health-dashboard-server-only`.
- Actualiza contratos, docs, OpenSpec y closeout Engram.

## Verificación de Zoro
- `python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/service.py apps/api/src/modules/healthcheck/router.py apps/api/src/modules/dashboard/service.py apps/api/src/modules/dashboard/router.py`
- `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py apps/api/tests/test_vault_api.py apps/api/tests/test_healthcheck_dashboard_api.py` → 27 passed
- `npm run verify:health-dashboard-server-only` → passed
- `npm --prefix apps/web run typecheck` → passed
- `npm --prefix apps/web run build` → passed; `/dashboard` y `/healthcheck` dinámicas (`ƒ`)
- Smoke API local con backend en `127.0.0.1:8001`: `/api/v1/healthcheck` 200, `/api/v1/dashboard` 200
- Smoke browser local con web en `127.0.0.1:3002`: `/healthcheck` 200, `/dashboard` 200, contenido backend visible, consola limpia
- `git diff --check` → passed

## Riesgos y límites
- El catálogo de Healthcheck sigue siendo backend-owned/saneado; no lee host real ni ejecuta shell.
- No se abre superficie de escritura ni consola remota.
- Requiere revisión Franky + Chopper por mezcla de runtime/server-only y frontera de exposición healthcheck.

## Review solicitada
- Franky: runtime, server-only/dynamic behaviour, semántica operativa de agregación y mantenibilidad.
- Chopper: boundary de seguridad, ausencia de host output/shell/logs/paths sensibles y fallback saneado.
