### PR TITLE
fix: expose vault fallback state

### DIFF
--- a/.engram/phase-12-6a-closeout.md
+++ b/.engram/phase-12-6a-closeout.md
@@ -1,0 +1,36 @@
+# Phase 12.6a closeout — Follow-ups, docs and guardrails
+
+## Goal
+Resolve the first focused Phase 12 closeout slice: make `/vault` fallback visible and align server-only runtime docs/guardrails for Vault, Dashboard and Healthcheck.
+
+## Completed in this branch
+- `/vault` now distinguishes real API data from fixture fallback in page state.
+- `VaultClient` renders a visible `Estado de API` notice when using fallback.
+- `vault-http.ts` uses typed `VaultApiError` codes for controlled failure states.
+- `verify:vault-server-only` now checks that fallback observability remains present.
+- `docs/runtime-config.md`, README, development docs, API module docs and read-model docs were aligned with current Phase 12 runtime contracts.
+- `openspec/phase-12-6a-followups-docs-guardrails.md` and this checklist/closeout record the microphase boundary.
+
+## Security notes
+- The fallback notice only shows controlled status codes like `not_configured`, `http_<status>`, `invalid_payload` or `fetch_failed`.
+- It does not expose backend URL, filesystem path, stack trace, response body or host detail.
+- No new write surface, route, dependency or backend filesystem capability was added.
+
+## Verify snapshot
+- `npm run verify:vault-server-only` → passed.
+- `npm run verify:health-dashboard-server-only` → passed.
+- `npm --prefix apps/web run typecheck` → passed.
+- `npm --prefix apps/web run build` → passed; `/vault`, `/dashboard` and `/healthcheck` remain dynamic (`ƒ`).
+- `PYTHONPATH=. pytest apps/api/tests/test_vault_api.py apps/api/tests/test_healthcheck_dashboard_api.py` → 12 passed.
+- Full Phase 12 backend regression → 27 passed.
+- `git diff --check` → passed.
+
+## Expected reviewers
+- Franky: operational observability, server-only runtime docs and guardrail coverage.
+- Chopper: Vault fallback safety and no leak regression.
+
+## Deferred intentionally
+- Full integration smoke and visual baseline: Phase 12.6b.
+- Final Phase 12 block closeout / vault summary update: Phase 12.6c.
+- Next/PostCSS advisory audit: separate dependency/security maintenance track, not Phase 12.6a.
+- Future live Healthcheck source hardening: deferred until real sources are connected.

--- a/README.md
+++ b/README.md
@@ -41,14 +41,17 @@ npm run typecheck:web
 npm run verify:memory-server-only
 npm run verify:mugiwaras-server-only
 npm run verify:skills-server-only
+npm run verify:vault-server-only
+npm run verify:health-dashboard-server-only
 ```
 
 ## Configuración runtime
 Ver `docs/runtime-config.md`.
 
 Resumen actual:
-- `/memory`, `/mugiwaras` y `/skills` usan `MUGIWARA_CONTROL_PANEL_API_URL` como variable server-only.
+- `/memory`, `/mugiwaras`, `/skills`, `/vault`, `/dashboard` y `/healthcheck` usan `MUGIWARA_CONTROL_PANEL_API_URL` como variable server-only.
 - `/skills` expone al navegador solo endpoints BFF same-origin bajo `/api/control-panel/skills/**`; la URL real del backend no entra en el bundle cliente.
+- `/vault`, `/dashboard` y `/healthcheck` mantienen fallback saneado visible si la API no está configurada o falla.
 
 
 ## OpenCode + Engram

--- a/apps/web/src/app/vault/VaultClient.tsx
+++ b/apps/web/src/app/vault/VaultClient.tsx
@@ -28,11 +28,31 @@ function formatTimestamp(value: string) {
 
 type VaultClientProps = {
   initialWorkspace: VaultWorkspace
+  apiState: 'ready' | 'fallback'
+  apiErrorCode?: string
 }
 
-export function VaultClient({ initialWorkspace }: VaultClientProps) {
+function getVaultApiNotice(apiState: VaultClientProps['apiState'], apiErrorCode?: string) {
+  if (apiState === 'ready') {
+    return null
+  }
+
+  const isNotConfigured = apiErrorCode === 'not_configured'
+
+  return {
+    status: isNotConfigured ? ('sin-datos' as const) : ('incidencia' as const),
+    title: isNotConfigured ? 'Vault API no configurada' : 'Vault en fallback saneado',
+    description: isNotConfigured
+      ? 'La página muestra fixture documental local porque falta la configuración server-only de la API. No se exponen rutas internas ni detalles del backend.'
+      : 'La carga real del Vault no está disponible y la página muestra un fallback documental local. Este estado degradado queda visible para no ocultar misconfiguración operativa.',
+    detail: apiErrorCode ? `Estado controlado: ${apiErrorCode}` : null,
+  }
+}
+
+export function VaultClient({ initialWorkspace, apiState, apiErrorCode }: VaultClientProps) {
   const workspace = initialWorkspace
   const [selectedDocumentId, setSelectedDocumentId] = useState(workspace.active_document_id)
+  const apiNotice = getVaultApiNotice(apiState, apiErrorCode)
 
   const activeDocument = useMemo(
     () => workspace.documents.find((document) => document.id === selectedDocumentId) ?? workspace.documents[0],
@@ -61,6 +81,16 @@ export function VaultClient({ initialWorkspace }: VaultClientProps) {
 
       <section className="layout-grid layout-grid--vault">
         <div style={{ display: 'grid', gap: '14px' }}>
+          {apiNotice ? (
+            <StatePanel
+              status={apiNotice.status}
+              title={apiNotice.title}
+              description={apiNotice.description}
+              detail={apiNotice.detail}
+              eyebrow="Estado de API"
+            />
+          ) : null}
+
           <SurfaceCard title="Canon curado" elevated eyebrow="Archivo" accent="gold">
             <div style={{ display: 'grid', gap: '10px' }}>
               <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>

--- a/apps/web/src/app/vault/page.tsx
+++ b/apps/web/src/app/vault/page.tsx
@@ -1,12 +1,33 @@
-import { fetchVaultWorkspace } from '@/modules/vault/api/vault-http'
+import { VaultApiError, fetchVaultWorkspace } from '@/modules/vault/api/vault-http'
 import { vaultWorkspaceFixture } from '@/modules/vault/view-models/vault-workspace.fixture'
 
 import { VaultClient } from './VaultClient'
 
 export const dynamic = 'force-dynamic'
 
-export default async function VaultPage() {
-  const workspace = await fetchVaultWorkspace().catch(() => vaultWorkspaceFixture)
+type VaultPageState = {
+  workspace: typeof vaultWorkspaceFixture
+  apiState: 'ready' | 'fallback'
+  apiErrorCode?: string
+}
 
-  return <VaultClient initialWorkspace={workspace} />
+async function loadVaultWorkspace(): Promise<VaultPageState> {
+  try {
+    return {
+      workspace: await fetchVaultWorkspace(),
+      apiState: 'ready',
+    }
+  } catch (error) {
+    return {
+      workspace: vaultWorkspaceFixture,
+      apiState: 'fallback',
+      apiErrorCode: error instanceof VaultApiError ? error.code : 'fetch_failed',
+    }
+  }
+}
+
+export default async function VaultPage() {
+  const { workspace, apiState, apiErrorCode } = await loadVaultWorkspace()
+
+  return <VaultClient apiErrorCode={apiErrorCode} apiState={apiState} initialWorkspace={workspace} />
 }

--- a/apps/web/src/modules/vault/api/vault-http.ts
+++ b/apps/web/src/modules/vault/api/vault-http.ts
@@ -8,6 +8,13 @@ type VaultWorkspaceResponse = {
   data: VaultWorkspace
 }
 
+export class VaultApiError extends Error {
+  constructor(readonly code: 'not_configured' | `http_${number}` | 'invalid_payload') {
+    super(code)
+    this.name = 'VaultApiError'
+  }
+}
+
 function trimTrailingSlash(value: string) {
   return value.replace(/\/$/, '')
 }
@@ -38,7 +45,7 @@ export async function fetchVaultWorkspace(): Promise<VaultWorkspace> {
   const baseUrl = getVaultApiBaseUrl()
 
   if (!baseUrl) {
-    throw new Error('not_configured')
+    throw new VaultApiError('not_configured')
   }
 
   const response = await fetch(`${baseUrl}/api/v1/vault`, {
@@ -49,9 +56,14 @@ export async function fetchVaultWorkspace(): Promise<VaultWorkspace> {
   })
 
   if (!response.ok) {
-    throw new Error(`http_${response.status}`)
+    throw new VaultApiError(`http_${response.status}`)
   }
 
   const payload = (await response.json()) as VaultWorkspaceResponse
+
+  if (!payload.data) {
+    throw new VaultApiError('invalid_payload')
+  }
+
   return payload.data
 }

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -33,7 +33,10 @@
 - no exponer prompts, IDs internos, sesiones, observaciones completas, tokens ni secretos
 
 ### `vault`
-- navegación, árbol, índices y lectura de markdown
+- exponer `GET /api/v1/vault` como workspace documental read-only allowlisted
+- exponer `GET /api/v1/vault/documents/{document_path:path}` para lectura de documentos markdown permitidos
+- normalizar paths y rechazar traversal, paths absolutos, symlinks, extensiones no soportadas y documentos fuera de allowlist
+- integrar `/vault` desde frontend mediante adapter server-only con fallback saneado visible
 - sin escritura en MVP
 
 ### `healthcheck`

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,3 +24,16 @@ Cualquier cambio estructural debe actualizar `README.md`, `docs/` y `AGENTS.md` 
 - El wrapper `scripts/opencode-safe-run.sh` soporta tanto arranque nuevo (`--title`) como continuación (`--session`) manteniendo agente explícito.
 - No declarar éxito de persistencia en Engram sin comprobar observaciones reales además de sesiones/prompts.
 - Evidencia y criterio operativo actual: `docs/sdd-runtime-validation.md`.
+
+## Verify server-only de Phase 12
+Las rutas API-backed del MVP tienen guardrails estáticos específicos. Antes de cerrar cambios sobre configuración runtime, adapters o fallback de estas superficies, ejecutar el subconjunto afectado:
+
+```bash
+npm run verify:memory-server-only
+npm run verify:mugiwaras-server-only
+npm run verify:skills-server-only
+npm run verify:vault-server-only
+npm run verify:health-dashboard-server-only
+```
+
+Para cierre de bloque o smoke global, ejecutar todos junto con backend regression, typecheck, build y baseline visual.

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -84,6 +84,7 @@ Campos esperados:
 
 Uso:
 - árbol navegable allowlisted y lectura de documento permitido
+- si el frontend usa fallback documental por fallo de API, el estado degradado debe quedar visible y no confundirse con lectura real del vault
 
 ### `mugiwara.card`
 Campos esperados:

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -11,7 +11,7 @@ El control plane distingue entre configuración pública de frontend y configura
 
 | Variable | Consumidor | Exposición | Uso |
 | --- | --- | --- | --- |
-| `MUGIWARA_CONTROL_PANEL_API_URL` | `/memory`, `/mugiwaras`, `/skills` BFF/server loaders | Server-only | Base URL del backend para superficies que deben resolver datos desde servidor o frontera BFF. |
+| `MUGIWARA_CONTROL_PANEL_API_URL` | `/memory`, `/mugiwaras`, `/skills` BFF/server loaders, `/vault`, `/dashboard`, `/healthcheck` | Server-only | Base URL del backend para superficies que deben resolver datos desde servidor o frontera BFF. |
 
 ## Memory
 `/memory` usa el patrón server-only desde Phase 12.3c:
@@ -76,8 +76,39 @@ Antes de cerrar cambios que toquen Skills config o BFF, ejecutar:
 npm run verify:skills-server-only
 ```
 
+## Vault
+`/vault` usa el patrón server-only desde Phase 12.4 y hace visible el fallback degradado desde Phase 12.6a:
+
+1. `apps/web/src/modules/vault/api/vault-http.ts` importa `server-only`.
+2. El adapter lee `MUGIWARA_CONTROL_PANEL_API_URL` y valida esquema `http:`/`https:`.
+3. `/vault` declara `export const dynamic = 'force-dynamic'`.
+4. Si la API falta, falla o devuelve un payload inválido, la página mantiene fixture documental saneado y muestra aviso explícito de estado degradado.
+5. El aviso no expone URL backend, rutas host, stack traces ni cuerpo de respuesta.
+
+Antes de cerrar cambios que toquen Vault config o fallback, ejecutar:
+
+```bash
+npm run verify:vault-server-only
+```
+
+## Dashboard y Healthcheck
+`/dashboard` y `/healthcheck` usan el patrón server-only desde Phase 12.5:
+
+1. `apps/web/src/modules/dashboard/api/dashboard-http.ts` y `apps/web/src/modules/healthcheck/api/healthcheck-http.ts` importan `server-only`.
+2. Ambos adapters leen `MUGIWARA_CONTROL_PANEL_API_URL` y validan esquema `http:`/`https:`.
+3. `/dashboard` y `/healthcheck` declaran `export const dynamic = 'force-dynamic'`.
+4. Los fetches usan `cache: 'no-store'`.
+5. Si la API falta o falla, ambas páginas muestran fallback local saneado con aviso visible; no muestran comandos, logs, stdout/stderr, URLs internas ni detalles host.
+6. Healthcheck usa por ahora catálogo backend-owned saneado. Cuando conecte fuentes reales deberá parsear timestamps explícitamente, revisar severidad `critical` en Dashboard y considerar allowlist operativa de hosts si el despliegue lo requiere.
+
+Antes de cerrar cambios que toquen Dashboard/Healthcheck config o fallback, ejecutar:
+
+```bash
+npm run verify:health-dashboard-server-only
+```
+
 ## Decisiones relacionadas
-La planificación inicial vive en `openspec/phase-12-3e-server-only-migration-plan.md`, el diseño específico de Skills BFF vive en `openspec/phase-12-3g-skills-bff-design.md` y la implementación vive en `openspec/phase-12-3h-skills-bff-implementation.md`.
+La planificación inicial vive en `openspec/phase-12-3e-server-only-migration-plan.md`, el diseño específico de Skills BFF vive en `openspec/phase-12-3g-skills-bff-design.md`, la implementación vive en `openspec/phase-12-3h-skills-bff-implementation.md`, Vault vive en `openspec/phase-12-4-vault-readonly-api.md` y Health/Dashboard en `openspec/phase-12-5-health-dashboard-aggregation.md`.
 
 Resumen de la decisión:
 - `/mugiwaras` ya migró en Phase 12.3f porque era server component, dinámico y no necesitaba browser fetch directo.

--- a/openspec/phase-12-6a-followups-docs-guardrails.md
+++ b/openspec/phase-12-6a-followups-docs-guardrails.md
@@ -1,0 +1,55 @@
+# Phase 12.6a — Follow-ups, docs and guardrails
+
+## Goal
+Start Phase 12 closeout by resolving focused review follow-ups and aligning runtime documentation/guardrails before the full integration smoke.
+
+## Why this is split out
+Phase 12.6 would be too large as a single PR: it spans runtime follow-ups, docs, guardrails, API/web smoke, visual baseline and final block closeout. 12.6a deliberately handles only the small corrective/doc layer so 12.6b can focus on integration verification and 12.6c can close the block.
+
+## Scope
+- Make `/vault` fallback/degraded state observable when the backend API is missing, failing or returning an invalid payload.
+- Keep `/vault` visually available through sane fixture fallback, but avoid silent success semantics.
+- Extend `verify:vault-server-only` so fallback observability becomes a static guardrail.
+- Document `/vault`, `/dashboard` and `/healthcheck` server-only runtime contracts in `docs/runtime-config.md`.
+- Refresh README/development/API/read-model docs where Phase 12 reality had drifted.
+
+## Out of scope
+- Full Phase 12 integration smoke matrix.
+- Visual baseline sweep across all routes.
+- Dependency audit follow-up for Next/PostCSS advisory (#17).
+- Connecting Healthcheck to live host sources.
+- New auth, deployment or write-surface changes.
+
+## Implementation notes
+- `/vault/page.tsx` now classifies API load as `ready` or `fallback` and passes a controlled `apiErrorCode` to the client.
+- `VaultClient` renders an explicit `Estado de API` notice in fallback mode.
+- `vault-http.ts` throws typed `VaultApiError` codes: `not_configured`, `http_<status>` and `invalid_payload`.
+- The notice deliberately does not show backend URL, host paths, stack traces or response bodies.
+
+## Definition of done
+- `/vault` fallback is visible, not silent.
+- Runtime docs name the server-only contracts for Vault, Dashboard and Healthcheck.
+- Guardrail check covers Vault fallback observability.
+- Verify affected stack passes.
+- PR review requested from Franky + Chopper.
+
+## Verify expected
+```bash
+npm run verify:vault-server-only
+npm run verify:health-dashboard-server-only
+npm --prefix apps/web run typecheck
+npm --prefix apps/web run build
+PYTHONPATH=. pytest apps/api/tests/test_vault_api.py apps/api/tests/test_healthcheck_dashboard_api.py
+PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py apps/api/tests/test_vault_api.py apps/api/tests/test_healthcheck_dashboard_api.py
+git diff --check
+```
+
+## Review routing
+- Franky: runtime config documentation, server-only guardrails, fallback semantics and operational observability.
+- Chopper: Vault fallback safety, no host/path/URL leakage, and continued deny-by-default boundary.
+- Usopp: not required unless reviewers consider the fallback notice visually material enough for design review.
+
+## Follow-up handling
+- Issue #14 should be closable by this PR if reviewers accept the `/vault` degraded fallback notice.
+- Issue #16 is partially addressed for runtime docs; future health-source hardening remains intentionally deferred.
+- Issue #17 remains outside Phase 12.6a.

--- a/openspec/phase-12-6a-verify-checklist.md
+++ b/openspec/phase-12-6a-verify-checklist.md
@@ -1,0 +1,23 @@
+# Phase 12.6a verify checklist — Follow-ups, docs and guardrails
+
+## Scope checks
+- [x] `/vault` fallback is explicit and observable.
+- [x] `/vault` fallback notice does not include backend URL, host paths, stack traces or response bodies.
+- [x] `verify:vault-server-only` checks fallback observability markers.
+- [x] `docs/runtime-config.md` documents Vault, Dashboard and Healthcheck server-only contracts.
+- [x] README and development docs list current Phase 12 server-only guardrails.
+- [x] `docs/api-modules.md` and `docs/read-models.md` align with Vault implementation.
+
+## Verify evidence
+- [x] `npm run verify:vault-server-only` → passed.
+- [x] `npm run verify:health-dashboard-server-only` → passed.
+- [x] `npm --prefix apps/web run typecheck` → passed.
+- [x] `npm --prefix apps/web run build` → passed; `/vault`, `/dashboard` and `/healthcheck` remain dynamic (`ƒ`).
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_vault_api.py apps/api/tests/test_healthcheck_dashboard_api.py` → 12 passed.
+- [x] Full Phase 12 backend regression → 27 passed.
+- [x] `git diff --check` → passed.
+
+## Review gate
+- [ ] Franky review requested.
+- [ ] Chopper review requested.
+- [ ] Review comments addressed or explicitly deferred.

--- a/scripts/check-vault-server-only.mjs
+++ b/scripts/check-vault-server-only.mjs
@@ -34,8 +34,14 @@ if (!vaultPage.includes("export const dynamic = 'force-dynamic'")) {
 if (vaultPage.includes("'use client'")) {
   failures.push('vault/page.tsx must remain a server page')
 }
+if (!vaultPage.includes("apiState: 'fallback'") || !vaultPage.includes('apiErrorCode')) {
+  failures.push('vault/page.tsx must make fallback state observable')
+}
 if (vaultClient.includes('process.env') || vaultClient.includes('MUGIWARA_CONTROL_PANEL_API_URL')) {
   failures.push('VaultClient must not read server env')
+}
+if (!vaultClient.includes('Estado de API') || !vaultClient.includes('Vault en fallback saneado')) {
+  failures.push('VaultClient must show an explicit degraded API notice when using fallback')
 }
 
 if (failures.length > 0) {


### PR DESCRIPTION
## Summary
- Makes `/vault` fallback/degraded state observable instead of silently rendering fixture data.
- Adds controlled `VaultApiError` codes and a visible `Estado de API` notice without exposing backend URL, host paths, stack traces or response bodies.
- Extends `verify:vault-server-only` to guard fallback observability.
- Aligns runtime/docs for Vault, Dashboard and Healthcheck server-only contracts.
- Adds Phase 12.6a OpenSpec checklist and Engram closeout.

## Scope
This is Phase 12.6a only: follow-ups, docs and guardrails. Full integration smoke/visual baseline remains for Phase 12.6b; final block closeout remains for Phase 12.6c.

## Verify
- `npm run verify:vault-server-only` → passed
- `npm run verify:health-dashboard-server-only` → passed
- `npm --prefix apps/web run typecheck` → passed
- `npm --prefix apps/web run build` → passed; `/vault`, `/dashboard`, `/healthcheck` remain dynamic (`ƒ`)
- `PYTHONPATH=. pytest apps/api/tests/test_vault_api.py apps/api/tests/test_healthcheck_dashboard_api.py` → 12 passed
- Full Phase 12 backend regression → 27 passed
- `git diff --check` → passed

## Review requested
- Franky: runtime config documentation, server-only guardrails, fallback semantics and operational observability.
- Chopper: Vault fallback safety, no host/path/URL leakage, and continued deny-by-default boundary.

## Issues
- Addresses #14 if reviewers accept the explicit `/vault` degraded fallback state.
- Partially addresses #16 runtime-docs portion for Dashboard/Healthcheck; future health-source hardening remains deferred.
- Does not address #17 dependency advisory; that remains a separate maintenance track.
