### PR TITLE
docs: close phase 12 backend integration block

### DIFF
--- a/.engram/phase-12-6c-closeout.md
+++ b/.engram/phase-12-6c-closeout.md
@@ -1,0 +1,30 @@
+# Phase 12.6c closeout — Block closeout and canon refresh
+
+## Goal
+Close Phase 12 after the integration smoke/visual baseline slice and refresh the canonical project summary so the next session starts from the real backend/server-only state.
+
+## Completed in this branch
+- Added `openspec/phase-12-6c-block-closeout-canon.md` to define Phase 12 block outcome, remaining issues and review routing.
+- Added `openspec/phase-12-6c-verify-checklist.md` to track closeout verification.
+- Refreshed `/srv/crew-core/vault/03-Projects/Project Summary - Mugiwara Control Panel.md` from stale Phase 12.3a status to Phase 12.6c/Phase 12 closed state.
+- Reviewed open GitHub issues #16 and #17 and kept both open intentionally as future tracks rather than pretending Phase 12 closed them.
+
+## Phase 12 state after closeout
+- `mugiwaras`, `memory`, `vault`, `dashboard` and `healthcheck` are now backend-owned read-only surfaces with server-only frontend config.
+- `skills` remains the only MVP write surface and uses the same-origin BFF boundary for browser interactions.
+- Runtime config is private through `MUGIWARA_CONTROL_PANEL_API_URL`; no `NEXT_PUBLIC_*` backend URL is used for Phase 12 surfaces.
+- Healthcheck is still a safe catalog/fallback surface, not a live host command/log reader.
+- Vault is read-only, allowlisted and traversal/symlink guarded.
+
+## Verification basis
+- Phase 12.6b is the runtime evidence for this closeout: all guardrails, typecheck, production build, full Phase 12 backend regression, API/web smoke, browser console and visual baseline passed.
+- Phase 12.6c itself is documentation/canon-only and should be verified with diff review, `git diff --check`, repo status and PR review.
+
+## Open follow-ups
+- #16 remains open for future Healthcheck/Dashboard hardening: explicit timestamp parsing when real sources are connected, real `critical` severity aggregation and possible backend host allowlist.
+- #17 remains open for the existing Next/PostCSS moderate advisory audit; do not solve it inside closeout.
+- Future block should decide between auth/perimeter hardening, real health sources or dependency maintenance as a separate phase.
+
+## Risks
+- The canonical vault summary is now more complete but must be kept in sync when Phase 13 changes the project boundary.
+- Because Phase 12.6c does not rerun the full smoke, it depends on the immediately previous Phase 12.6b evidence; acceptable because no runtime code changed in 12.6c.

--- a/openspec/phase-12-6c-block-closeout-canon.md
+++ b/openspec/phase-12-6c-block-closeout-canon.md
@@ -1,0 +1,63 @@
+# Phase 12.6c — Block closeout and canon refresh
+
+## Goal
+Close Phase 12 as a coherent read-only backend integration block and refresh the canonical project summary after the integration smoke/visual baseline evidence recorded in Phase 12.6b.
+
+## Why now
+Phase 12.1–12.5 moved the non-`skills` MVP surfaces behind safe backend-owned read-only APIs. Phase 12.6a closed targeted follow-ups, docs and guardrails; Phase 12.6b verified the integrated API/web runtime and visual baseline. The remaining work is not new runtime functionality, but durable closeout: summarize the block, keep the vault Project Summary aligned with reality, and leave the next track explicit.
+
+## Scope
+- Record Phase 12 block closeout in OpenSpec.
+- Refresh the canonical vault `Project Summary - Mugiwara Control Panel`.
+- Record project-local continuity in `.engram/phase-12-6c-closeout.md`.
+- Reconcile open GitHub issues for the block without hiding future hardening work.
+- Run lightweight closeout verification appropriate for documentation/canon changes.
+
+## Out of scope
+- New product functionality or route changes.
+- Additional backend connectors for live host health sources.
+- Dependency advisory remediation for #17.
+- Auth, deployment, write-surface changes, Playwright or automated visual regression infrastructure.
+- Re-running the full API/web smoke already captured in Phase 12.6b unless closeout edits touch runtime code.
+
+## Phase 12 outcome
+Phase 12 is considered functionally closed after 12.6c because the MVP routes now have these backend/frontend boundaries:
+
+| Surface | Backend/API state | Frontend state | Closeout note |
+| --- | --- | --- | --- |
+| `mugiwaras` | `GET /api/v1/mugiwaras` and detail endpoint are backend-owned, read-only and allowlisted. | `/mugiwaras` uses server-only backend config and remains dynamic. | Fixed AGENTS.md canonical excerpt is intentional approved read-only product content. |
+| `memory` | `GET /api/v1/memory` and detail endpoint expose sane memory summaries only. | `/memory` uses server-only backend config and dynamic rendering. | No raw prompts, observation IDs, sessions or memory dumps. |
+| `vault` | `GET /api/v1/vault` and document endpoint use allowlisted markdown reads with traversal/symlink rejection. | `/vault` uses server-only backend config and visible degraded fallback. | No write surface in MVP. |
+| `dashboard` | `GET /api/v1/dashboard` aggregates backend-owned safe summaries. | `/dashboard` uses server-only backend config and dynamic rendering. | Healthcheck not configured degrades to warning/stale, not healthy silence. |
+| `healthcheck` | `GET /api/v1/healthcheck` returns a sanitized backend-owned catalog. | `/healthcheck` uses server-only backend config and dynamic rendering. | No shell, Docker, systemd, logs, stdout/stderr or raw host reads yet. |
+| `skills` | Existing allowlisted read/preview/update backend remains the only MVP write surface. | `/skills` uses same-origin BFF route handlers; browser never receives backend base URL. | BFF is not a generic proxy. |
+
+## Verification basis
+Phase 12.6c relies on the Phase 12.6b runtime evidence for integration smoke and adds closeout/canon verification only:
+
+- Phase 12.6b passed all server-only guardrails.
+- Phase 12.6b passed frontend typecheck and production build.
+- Phase 12.6b passed full Phase 12 backend regression: 27 tests.
+- Phase 12.6b smoked API endpoints and canonical web routes in dev and production.
+- Phase 12.6b browser console review found no uncaught runtime errors.
+- Phase 12.6b visual baseline review found no blocking layout regression.
+
+## Issues after closeout
+- #16 remains open intentionally for future Healthcheck/Dashboard hardening that was not part of the Phase 12 closeout: real-source timestamp parsing, real `critical` severity aggregation and possible backend host allowlist.
+- #17 remains open intentionally as a separate dependency/security maintenance track for the existing Next/PostCSS moderate advisory.
+
+## Definition of done
+- This OpenSpec closeout exists and states the Phase 12 outcome clearly.
+- Vault Project Summary reflects Phase 12 as closed and names the current backend/server-only state.
+- `.engram/phase-12-6c-closeout.md` captures continuity for the next session.
+- GitHub issues are reconciled by comment/state rather than silently ignored.
+- `git diff --check` passes for repository changes.
+- Markdown/canon files contain no secrets, runtime dumps, `.env` content or sensitive logs.
+
+## Review routing
+Phase 12.6c is documentation/canon closeout, but it summarizes security and runtime surfaces. Request:
+
+- Franky: operational/runtime accuracy of the block closeout and next-step issues.
+- Chopper: security boundary accuracy and no unsafe public/canonical leakage.
+
+Usopp is not required unless reviewers flag a visual/UX documentation concern; Phase 12.6c does not change UI.

--- a/openspec/phase-12-6c-verify-checklist.md
+++ b/openspec/phase-12-6c-verify-checklist.md
@@ -1,0 +1,31 @@
+# Phase 12.6c verify checklist — Block closeout and canon refresh
+
+## Repository state
+- [x] Started from `main` at `1695f36` / PR #19 merge commit.
+- [x] Created branch `zoro/phase-12-6c-block-closeout`.
+- [x] Configured local Git identity for `zoro` with Mugiwara trailers hook.
+- [x] Confirmed open issues before closeout: #16 and #17.
+
+## Closeout artifacts
+- [x] Added `openspec/phase-12-6c-block-closeout-canon.md`.
+- [x] Added `.engram/phase-12-6c-closeout.md`.
+- [x] Refreshed vault canonical summary: `/srv/crew-core/vault/03-Projects/Project Summary - Mugiwara Control Panel.md`.
+
+## Issue reconciliation
+- [x] #16 reviewed: keep open for future Healthcheck/Dashboard hardening not included in Phase 12.6c.
+- [x] #16 commented again in closeout: https://github.com/asistentes-mugiwara/mugiwara-control-panel/issues/16#issuecomment-4315241023
+- [x] #17 reviewed: keep open as separate dependency/security maintenance track.
+- [x] #17 commented again in closeout: https://github.com/asistentes-mugiwara/mugiwara-control-panel/issues/17#issuecomment-4315241104
+- [ ] PR handoff comment links Phase 12.6c outcome and calls out both open issues.
+
+## Verification
+- [x] Phase 12.6b runtime evidence reused as integration basis: guardrails, build, backend regression, API/web smoke, browser console and visual baseline passed.
+- [x] `git diff --check` passed after initial closeout edits.
+- [x] Project repo status contains only intended Phase 12.6c files before commit.
+- [x] Vault repo status contains only intended Project Summary refresh before vault commit/sync.
+- [ ] PR/review handoff completed with Franky + Chopper.
+
+## Non-goals confirmed
+- [x] No runtime code changed.
+- [x] No new API route, write surface, filesystem capability, auth flow, dependency or deployment exposure added.
+- [x] No `.env`, logs, tokens, credentials, runtime dumps or sensitive smoke output added.

--- a/openspec/phase-12-6c-verify-checklist.md
+++ b/openspec/phase-12-6c-verify-checklist.md
@@ -16,14 +16,16 @@
 - [x] #16 commented again in closeout: https://github.com/asistentes-mugiwara/mugiwara-control-panel/issues/16#issuecomment-4315241023
 - [x] #17 reviewed: keep open as separate dependency/security maintenance track.
 - [x] #17 commented again in closeout: https://github.com/asistentes-mugiwara/mugiwara-control-panel/issues/17#issuecomment-4315241104
-- [ ] PR handoff comment links Phase 12.6c outcome and calls out both open issues.
+- [x] PR handoff comment links Phase 12.6c outcome and calls out both open issues: https://github.com/asistentes-mugiwara/mugiwara-control-panel/pull/20#issuecomment-4315247646
 
 ## Verification
 - [x] Phase 12.6b runtime evidence reused as integration basis: guardrails, build, backend regression, API/web smoke, browser console and visual baseline passed.
 - [x] `git diff --check` passed after initial closeout edits.
 - [x] Project repo status contains only intended Phase 12.6c files before commit.
 - [x] Vault repo status contains only intended Project Summary refresh before vault commit/sync.
-- [ ] PR/review handoff completed with Franky + Chopper.
+- [x] Franky PR comment: `approve` from operability, with formal review blocked by shared GitHub account limitation: https://github.com/asistentes-mugiwara/mugiwara-control-panel/pull/20#issuecomment-4315262238
+- [x] Chopper PR comment: `approve` from security, with formal review blocked by shared GitHub account limitation: https://github.com/asistentes-mugiwara/mugiwara-control-panel/pull/20#issuecomment-4315279831
+- [x] PR/review handoff completed with Franky + Chopper.
 
 ## Non-goals confirmed
 - [x] No runtime code changed.


### PR DESCRIPTION
## Summary
- closes Phase 12.6c as the final block closeout/canon refresh after Phase 12.6b integration smoke
- records Phase 12 outcome in OpenSpec and `.engram/`
- reconciles open issues #16 and #17 as intentional future tracks, not closeout blockers
- refreshes the canonical vault Project Summary separately in vault commit `228c16b`

## Scope
Documentation/canon only. No runtime code, no API route, no dependency, no auth/deploy change and no new filesystem/write surface.

## Verification
- `git diff --check` passed for project repo
- `git diff --check` passed for vault summary refresh before vault commit
- Phase 12.6b remains the runtime integration basis: server-only guardrails, frontend typecheck/build, full Phase 12 backend regression, API/web smoke, browser console and visual baseline all passed in PR #19

## Review requested
- Franky: operational/runtime accuracy of the closeout and issue framing
- Chopper: security boundary accuracy and no unsafe public/canonical leakage
