### PR TITLE
docs: refresh canon after PostCSS advisory

### DIFF
--- a/.engram/phase-12-8-canon-after-advisory.md
+++ b/.engram/phase-12-8-canon-after-advisory.md
@@ -1,0 +1,17 @@
+# Phase 12.8 closeout — canon after #17
+
+Date: 2026-04-24
+
+## What changed
+- Added `openspec/phase-12-8-canon-after-advisory.md` to record the canonical state after issue #17 was closed.
+- Refreshed the vault `Project Summary - Mugiwara Control Panel` so it no longer lists #17 as open and points next work at Phase 13 perimeter/auth/BFF hardening.
+
+## Why
+Phase 12.6c intentionally left #17 open as a separate dependency/security maintenance track. PR #21 closed that track, so project canon needed a small follow-up to avoid stale guidance.
+
+## Current follow-ups
+- #16 remains open: future Healthcheck/Dashboard hardening for real sources.
+- #17 is closed: Next/PostCSS advisory mitigated via `overrides.postcss = 8.5.10` and reproducible `npm run audit:web`.
+
+## Recommended next block
+Phase 13 should plan and implement perimeter/auth/BFF hardening before connecting additional real host health sources.

--- a/openspec/phase-12-8-canon-after-advisory.md
+++ b/openspec/phase-12-8-canon-after-advisory.md
@@ -1,0 +1,39 @@
+# Phase 12.8 — Canon refresh after Next/PostCSS advisory
+
+## Goal
+Close the canonical documentation gap left after issue #17 was resolved by PR #21, without introducing runtime changes.
+
+## Why now
+Phase 12.6c deliberately left #17 open as a separate dependency/security maintenance track. PR #21 has now closed that track by mitigating the existing Next/PostCSS advisory, so the project canon must stop listing #17 as pending and should point the next implementation block at Phase 13.
+
+## Scope
+- Record that issue #17 is closed by PR #21.
+- Keep issue #16 open as the only known GitHub follow-up for future Healthcheck/Dashboard hardening.
+- Refresh the vault `Project Summary - Mugiwara Control Panel` so it reflects the current state after Phase 12.7.
+- Record project-local continuity in `.engram/phase-12-8-canon-after-advisory.md`.
+- Run lightweight verification suitable for documentation/canon edits.
+
+## Out of scope
+- Runtime code changes.
+- Dependency changes beyond the already-merged PR #21.
+- Healthcheck real-source implementation.
+- Auth, exposure, BFF hardening, CI or visual regression work.
+- Re-running the full Phase 12 smoke unless documentation edits unexpectedly touch runtime.
+
+## Canon updates
+- Phase 12 read-only backend integration remains closed.
+- Phase 12.7 dependency/security follow-up is closed: `postcss` is pinned to `8.5.10` via npm override while staying on `next@15.5.15` for Node `v18.19.1` compatibility.
+- #17 is closed and no longer belongs in open follow-ups.
+- #16 remains open for a future Healthcheck/Dashboard hardening track: explicit timestamp parsing for real sources, real `critical` severity aggregation and possible backend host allowlist.
+- Recommended next block remains Phase 13: perimeter/auth/BFF hardening before connecting more real host sources.
+
+## Definition of done
+- This OpenSpec note exists and states the canonical state after #17.
+- The vault Project Summary no longer lists #17 as open.
+- `.engram/phase-12-8-canon-after-advisory.md` captures continuity for the next session.
+- `git diff --check` passes in the project repo and vault repo.
+- `npm run audit:web` still reports zero vulnerabilities after the canon refresh baseline.
+- No secrets, `.env`, runtime dumps, logs or sensitive host details are introduced.
+
+## Review routing
+This is documentation/canon only and does not change runtime, dependencies, security boundaries or UI. External reviewer handoff is not required unless the diff expands beyond canon refresh.


### PR DESCRIPTION
## Objetivo

Cierre canon/documental tras la resolución de #17 en PR #21.

## Cambios

- Añade `openspec/phase-12-8-canon-after-advisory.md`.
- Añade `.engram/phase-12-8-canon-after-advisory.md`.
- Registra que #17 ya no es follow-up abierto y que #16 queda como único issue abierto de Healthcheck/Dashboard hardening.
- Apunta el siguiente bloque recomendado a Phase 13: perímetro/auth/BFF hardening.

## Fuera de alcance

- Sin cambios runtime.
- Sin cambios de dependencias.
- Sin UI.
- Sin modificación de superficie de seguridad.

## Verify de Zoro

- `git diff --check` en repo proyecto: OK.
- `npm run audit:web`: 0 vulnerabilidades.
- Scan dirigido de secretos en nuevos archivos: OK.

## Review

Cambio docs/canon de bajo riesgo. No requiere handoff externo porque no toca runtime, dependencias, seguridad efectiva ni UI. La actualización del vault relacionada ya está en `asistentes-mugiwara/vault@de8ec24`.
