### PR TITLE
docs: define Phase 13.2 perimeter runtime policy

### DIFF
--- a/.engram/phase-13-2-closeout.md
+++ b/.engram/phase-13-2-closeout.md
@@ -1,0 +1,15 @@
+# Phase 13.2 closeout — perimeter runtime policy
+
+Date: 2026-04-25
+
+## What changed
+- Added `docs/security-perimeter.md` as the supported perimeter contract.
+- Updated `docs/runtime-config.md` to link the perimeter policy and declare `internet-public: unsupported`.
+- Added `scripts/check-perimeter-policy.mjs` and `npm run verify:perimeter-policy`.
+- Added `openspec/phase-13-2-perimeter-runtime-policy.md` and `openspec/phase-13-2-verify-checklist.md`.
+
+## Decision
+Phase 13.2 defines policy, not enforcement. The control panel remains local/private/Tailscale by default. Public internet exposure remains unsupported until explicit auth/session/CSRF/rate-limit design exists.
+
+## Next
+Phase 13.3 should enforce the write-route boundary for the Skills BFF using this policy: trusted origins, Origin/CSRF strategy and no browser credential/header forwarding.

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -7,11 +7,27 @@ El control plane distingue entre configuración pública de frontend y configura
 - Las variables sin prefijo `NEXT_PUBLIC_` deben leerse solo desde server loaders, adapters server-only o backend.
 - Cualquier URL o ruta que revele topología interna debe preferir configuración server-only cuando la página pueda cargar los datos desde servidor.
 
+## Perímetro soportado
+El contrato de perímetro vive en `docs/security-perimeter.md`.
+
+Resumen operativo:
+
+- acceso soportado: desarrollo local, red privada controlada y Tailscale/private access;
+- `internet-public: unsupported` hasta que existan decisiones explícitas de auth, sesión, CSRF y rate limiting;
+- `/skills` es la única superficie write-capable del MVP y debe endurecerse antes de conectar nuevas fuentes reales de Healthcheck;
+- los valores de topología interna no deben aparecer en UI, logs, errores, bundles cliente ni documentación con hostnames reales.
+
+Guardarraíl de este contrato:
+
+```bash
+npm run verify:perimeter-policy
+```
+
 ## Variables actuales
 
 | Variable | Consumidor | Exposición | Uso |
 | --- | --- | --- | --- |
-| `MUGIWARA_CONTROL_PANEL_API_URL` | `/memory`, `/mugiwaras`, `/skills` BFF/server loaders, `/vault`, `/dashboard`, `/healthcheck` | Server-only | Base URL del backend para superficies que deben resolver datos desde servidor o frontera BFF. |
+| `MUGIWARA_CONTROL_PANEL_API_URL` | `/memory`, `/mugiwaras`, `/skills` BFF/server loaders, `/vault`, `/dashboard`, `/healthcheck` | Server-only | Base URL del backend para superficies que deben resolver datos desde servidor o frontera BFF. Debe apuntar a loopback, red privada o Tailscale/private hostname; no es configuración pública de navegador. |
 
 ## Memory
 `/memory` usa el patrón server-only desde Phase 12.3c:

--- a/docs/security-perimeter.md
+++ b/docs/security-perimeter.md
@@ -1,0 +1,96 @@
+# Security perimeter and runtime policy
+
+## Purpose
+This document defines the supported perimeter for `mugiwara-control-panel` before Phase 13 implements enforcement changes.
+
+The panel is a private Mugiwara/Hermes control plane. It observes and edits local operational surfaces, including the write-capable Skills MVP surface. It is not designed as a public internet application in the current MVP.
+
+## Supported access model
+Supported today:
+
+| Mode | Status | Notes |
+| --- | --- | --- |
+| `localhost` / `127.0.0.1` development | supported | Default local development mode. |
+| Private LAN | conditionally supported | Acceptable only on a trusted private network controlled by Pablo. |
+| Tailscale private access | supported target | Preferred remote/private access model for real use. |
+| Reverse proxy inside the private perimeter | conditionally supported | Must preserve the same private-only assumption and avoid public internet exposure. |
+| Tailscale Funnel / public internet | unsupported | Unsupported until auth, session, CSRF and rate-limit policy exist. |
+
+`internet-public: unsupported` is intentional. Do not expose the control panel to the public internet by only relying on route naming, hidden URLs, browser UX, or assumed obscurity.
+
+## Trust boundary
+- FastAPI remains the backend security boundary for filesystem, allowlists, write policy and sanitized read models.
+- Next.js server-only adapters and BFF route handlers are exposure boundaries, not policy replacements.
+- Browser/client code is not trusted for authorization, filesystem paths, backend URLs, write permission or safety decisions.
+- `/skills` is the only MVP write-capable surface; it receives the strictest perimeter treatment.
+
+## Backend base URL policy
+`MUGIWARA_CONTROL_PANEL_API_URL` is server-only.
+
+Rules:
+- It must not be exposed through `NEXT_PUBLIC_*` variables.
+- It may use only `http:` or `https:` schemes.
+- It should normally point to loopback, private LAN or Tailscale/private hostnames.
+- It must not be rendered in the UI, docs examples with real hostnames, browser errors, logs or frontend bundles.
+- Invalid or missing values must degrade to sanitized `not_configured` / fallback states, never raw exceptions.
+
+Phase 13.2 does not add a hard backend host allowlist. That belongs to a later enforcement phase if deployment hardening needs it. This phase defines the contract and guardrails.
+
+## Trusted origins policy
+Before enforcing Origin/CSRF checks, Phase 13.2 defines the supported origin model:
+
+- local development origins: `http://localhost:<port>` and `http://127.0.0.1:<port>`;
+- private LAN origins: allowed only if explicitly configured for a trusted private network;
+- Tailscale origins: allowed only if explicitly configured for Pablo's private Tailnet hostnames/IPs;
+- public internet origins: unsupported until auth/session/rate-limit decisions exist.
+
+Phase 13.3 may implement a concrete trusted-origin configuration. Until then, write-route hardening must not invent a fragile hardcoded list.
+
+## Skills BFF policy
+The Skills BFF remains same-origin and allowlisted:
+
+- Browser code calls only `/api/control-panel/skills/**`.
+- BFF route handlers call exact FastAPI endpoints.
+- No route may accept arbitrary `path`, `url`, `target` or `method` from user input.
+- Browser cookies must not be forwarded upstream by default.
+- Browser `Authorization` headers must not be forwarded upstream by default.
+- Request bodies, diffs, hashes, skill contents and backend paths must not be logged or returned in sanitized errors.
+
+If future authentication uses cookies, Phase 13.3 must add Origin/CSRF validation before treating same-origin BFF write routes as protected.
+
+## Error and logging policy
+Allowed in errors/logs:
+- route or module name;
+- HTTP status;
+- sanitized error code;
+- duration;
+- validated skill id where required for audit.
+
+Forbidden in errors/logs:
+- backend base URL;
+- filesystem paths;
+- `.env` content;
+- tokens, cookies, credentials or API keys;
+- request bodies;
+- skill contents;
+- diff previews;
+- `expected_sha256` or hashes;
+- raw host command output, stdout/stderr, Docker/systemd/log excerpts.
+
+## Relationship with #16
+Issue #16, Healthcheck/Dashboard real-source hardening, stays after perimeter hardening. Real host health sources must not be connected until the control panel has a clearer perimeter and rejection model.
+
+## Verify
+Run this static policy guardrail after changes that touch perimeter docs, runtime config or Skills BFF boundaries:
+
+```bash
+npm run verify:perimeter-policy
+```
+
+When implementation changes touch Skills BFF, also run:
+
+```bash
+npm run verify:skills-server-only
+npm --prefix apps/web run typecheck
+npm --prefix apps/web run build
+```

--- a/openspec/phase-13-2-perimeter-runtime-policy.md
+++ b/openspec/phase-13-2-perimeter-runtime-policy.md
@@ -1,0 +1,58 @@
+# Phase 13.2 — Perimeter contract and runtime policy
+
+## Goal
+Materialize the Phase 13 perimeter contract before enforcing Origin/CSRF or backend hardening in later phases.
+
+## Why now
+Phase 13.1 established that perimeter hardening must start with contract and runtime policy. Without this step, Phase 13.3 could add brittle Origin/CSRF checks without a clear trusted-origin model for local/private/Tailscale deployments.
+
+## Scope
+- Add `docs/security-perimeter.md` as the source document for the supported access model.
+- Update `docs/runtime-config.md` to link the perimeter contract and make `internet-public: unsupported` explicit.
+- Add `npm run verify:perimeter-policy` as a static guardrail for the contract.
+- Keep runtime behavior unchanged.
+- Record closeout continuity in `.engram/phase-13-2-closeout.md`.
+
+## Contract decisions
+- Supported access is private by default: local development, trusted private LAN and Tailscale/private access.
+- Public internet exposure is unsupported until auth, session, CSRF and rate-limit decisions exist.
+- `MUGIWARA_CONTROL_PANEL_API_URL` remains server-only and may only target loopback/private/Tailscale style backends; it must not leak into browser code or UI.
+- Phase 13.2 does not implement a backend host allowlist. It defines the future decision point.
+- Trusted origins are defined as a policy model now; enforcement belongs to Phase 13.3.
+- `/skills` remains the only MVP write-capable surface and the first enforcement target.
+- #16 Healthcheck real-source work remains after perimeter hardening.
+
+## Guardrail
+`npm run verify:perimeter-policy` checks that:
+- `docs/security-perimeter.md` contains private-by-default, Tailscale and `internet-public: unsupported` policy;
+- `docs/runtime-config.md` links the perimeter contract and verify command;
+- `package.json` exposes the guardrail;
+- Skills browser adapter still uses same-origin BFF and no backend env;
+- Skills write BFF routes do not contain obvious browser credential/header forwarding snippets;
+- Skills server adapter does not forward arbitrary caller headers upstream;
+- Skills BFF does not contain obvious generic-proxy snippets.
+
+## Non-goals
+- No auth implementation.
+- No Origin/CSRF enforcement yet.
+- No CORS/header changes.
+- No backend host allowlist implementation.
+- No UI changes.
+- No Healthcheck real-source connectors.
+
+## Verify expected
+```bash
+npm run verify:perimeter-policy
+npm run verify:skills-server-only
+npm --prefix apps/web run typecheck
+npm --prefix apps/web run build
+git diff --check
+```
+
+## Review routing
+- **Chopper:** required. The PR defines security boundary, unsupported public exposure, trusted origins policy and no credential forwarding assumptions.
+- **Franky:** required. The PR defines runtime/private deployment policy and adds a static guardrail.
+- **Usopp:** not required because there is no UI/copy surface beyond internal docs.
+
+## Follow-up handoff
+Phase 13.3 should implement enforcement for write-capable Skills BFF routes using the policy defined here. It must not hardcode fragile origins without a config strategy; it should convert this contract into deterministic tests/guardrails.

--- a/openspec/phase-13-2-verify-checklist.md
+++ b/openspec/phase-13-2-verify-checklist.md
@@ -1,0 +1,22 @@
+# Phase 13.2 verify checklist
+
+## Scope checks
+- [x] `docs/security-perimeter.md` added as perimeter contract.
+- [x] `docs/runtime-config.md` links the perimeter contract.
+- [x] `scripts/check-perimeter-policy.mjs` added as static guardrail.
+- [x] `package.json` exposes `npm run verify:perimeter-policy`.
+- [x] No runtime behavior changes intended.
+- [x] No auth/Origin/CSRF enforcement implemented in this phase.
+
+## Verify commands
+- [x] `npm run verify:perimeter-policy`
+- [x] `npm run verify:skills-server-only`
+- [x] `npm --prefix apps/web run typecheck`
+- [x] `npm --prefix apps/web run build`
+- [x] `git diff --check`
+- [x] targeted sensitive-content scan for changed docs/scripts
+
+## Review routing
+- [x] Chopper required.
+- [x] Franky required.
+- [x] Usopp not required unless visible UI/copy changes are added.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:web": "npm --prefix apps/web run build",
     "typecheck:web": "npm --prefix apps/web run typecheck",
     "verify:visual-baseline": "node scripts/visual-verify-baseline.mjs",
+    "verify:perimeter-policy": "node scripts/check-perimeter-policy.mjs",
     "verify:memory-server-only": "node scripts/check-memory-server-only.mjs",
     "verify:mugiwaras-server-only": "node scripts/check-mugiwaras-server-only.mjs",
     "verify:skills-server-only": "node scripts/check-skills-server-only.mjs",

--- a/scripts/check-perimeter-policy.mjs
+++ b/scripts/check-perimeter-policy.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Static guardrail for the Phase 13 perimeter contract.
+ *
+ * Inputs: docs/security-perimeter.md, docs/runtime-config.md, package.json and
+ * Skills BFF boundary files.
+ * Output: exits non-zero if the private-by-default contract or obvious BFF
+ * exposure guardrails regress. Read-only.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = process.cwd()
+const paths = {
+  perimeterDoc: join(repoRoot, 'docs/security-perimeter.md'),
+  runtimeConfig: join(repoRoot, 'docs/runtime-config.md'),
+  packageJson: join(repoRoot, 'package.json'),
+  skillsBrowserAdapter: join(repoRoot, 'apps/web/src/modules/skills/api/skills-http.ts'),
+  skillsServerAdapter: join(repoRoot, 'apps/web/src/modules/skills/api/skills-server-http.ts'),
+  skillsDetailRoute: join(repoRoot, 'apps/web/src/app/api/control-panel/skills/[skillId]/route.ts'),
+  skillsPreviewRoute: join(repoRoot, 'apps/web/src/app/api/control-panel/skills/[skillId]/preview/route.ts'),
+}
+
+const failures = []
+
+function read(pathName, label) {
+  if (!existsSync(pathName)) {
+    failures.push(`missing ${label} at ${pathName}`)
+    return ''
+  }
+
+  return readFileSync(pathName, 'utf8')
+}
+
+const perimeterDoc = read(paths.perimeterDoc, 'security perimeter document')
+const runtimeConfig = read(paths.runtimeConfig, 'runtime config document')
+const packageJsonText = read(paths.packageJson, 'package.json')
+const skillsBrowserAdapter = read(paths.skillsBrowserAdapter, 'skills browser adapter')
+const skillsServerAdapter = read(paths.skillsServerAdapter, 'skills server adapter')
+const skillsDetailRoute = read(paths.skillsDetailRoute, 'skills detail/update route')
+const skillsPreviewRoute = read(paths.skillsPreviewRoute, 'skills preview route')
+const writeRoutes = [skillsDetailRoute, skillsPreviewRoute].join('\n')
+
+function mustInclude(text, snippet, label) {
+  if (!text.includes(snippet)) {
+    failures.push(`${label} must include: ${snippet}`)
+  }
+}
+
+mustInclude(perimeterDoc, 'internet-public: unsupported', 'security perimeter document')
+mustInclude(perimeterDoc, 'Tailscale private access', 'security perimeter document')
+mustInclude(perimeterDoc, 'Browser cookies must not be forwarded upstream by default.', 'security perimeter document')
+mustInclude(perimeterDoc, 'Browser `Authorization` headers must not be forwarded upstream by default.', 'security perimeter document')
+mustInclude(perimeterDoc, 'Phase 13.3 may implement a concrete trusted-origin configuration.', 'security perimeter document')
+mustInclude(perimeterDoc, 'Issue #16, Healthcheck/Dashboard real-source hardening, stays after perimeter hardening.', 'security perimeter document')
+mustInclude(runtimeConfig, 'docs/security-perimeter.md', 'runtime config document')
+mustInclude(runtimeConfig, 'internet-public: unsupported', 'runtime config document')
+mustInclude(runtimeConfig, 'npm run verify:perimeter-policy', 'runtime config document')
+
+let packageJson
+try {
+  packageJson = JSON.parse(packageJsonText)
+} catch {
+  failures.push('package.json must be valid JSON')
+}
+
+if (packageJson && packageJson.scripts?.['verify:perimeter-policy'] !== 'node scripts/check-perimeter-policy.mjs') {
+  failures.push('package.json must expose verify:perimeter-policy')
+}
+
+if (skillsBrowserAdapter.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL') || skillsBrowserAdapter.includes('process.env')) {
+  failures.push('skills browser adapter must not read backend environment variables')
+}
+
+if (!skillsBrowserAdapter.includes("const SKILLS_BFF_BASE_PATH = '/api/control-panel/skills'")) {
+  failures.push('skills browser adapter must use the same-origin Skills BFF base path')
+}
+
+const forbiddenWriteRouteSnippets = [
+  'request.headers',
+  "headers.get('authorization')",
+  'headers.get("authorization")',
+  "headers.get('cookie')",
+  'headers.get("cookie")',
+  'Authorization',
+  'Cookie',
+  'credentials: \'include\'',
+  'credentials: "include"',
+]
+
+for (const snippet of forbiddenWriteRouteSnippets) {
+  if (writeRoutes.includes(snippet)) {
+    failures.push(`skills write BFF routes must not forward browser credentials/header snippet: ${snippet}`)
+  }
+}
+
+if (skillsServerAdapter.includes('...init?.headers') || skillsServerAdapter.includes('headers: init?.headers')) {
+  failures.push('skills server adapter must not forward arbitrary caller headers upstream')
+}
+
+const forbiddenGenericProxySnippets = [
+  'searchParams.get(\'path\')',
+  'searchParams.get("path")',
+  'searchParams.get(\'url\')',
+  'searchParams.get("url")',
+  'searchParams.get(\'target\')',
+  'searchParams.get("target")',
+  'request.nextUrl.searchParams',
+  'params.path',
+  'params.url',
+  'params.target',
+]
+
+for (const snippet of forbiddenGenericProxySnippets) {
+  if (writeRoutes.includes(snippet) || skillsServerAdapter.includes(snippet)) {
+    failures.push(`skills BFF must not contain generic-proxy snippet: ${snippet}`)
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Perimeter policy check failed:')
+  for (const failure of failures) {
+    console.error(`- ${failure}`)
+  }
+  process.exit(1)
+}
+
+console.log('Perimeter policy check passed')


### PR DESCRIPTION
## Objetivo

Implementa Phase 13.2: contrato de perímetro y runtime policy antes de endurecer `/skills` BFF en Phase 13.3.

## Cambios

- Añade `docs/security-perimeter.md` como contrato private-by-default.
- Actualiza `docs/runtime-config.md` con el perímetro soportado y `internet-public: unsupported`.
- Añade `scripts/check-perimeter-policy.mjs`.
- Añade `npm run verify:perimeter-policy`.
- Añade OpenSpec/checklist/Engram de Phase 13.2.

## Decisiones

- Acceso soportado: local, red privada controlada, Tailscale/private access.
- Internet público: unsupported hasta auth/session/CSRF/rate-limit.
- `MUGIWARA_CONTROL_PANEL_API_URL` sigue siendo server-only.
- Phase 13.2 no implementa allowlist de host ni Origin/CSRF; define el contrato para Phase 13.3.
- #16 Healthcheck real-source queda después del perímetro.

## Verificación de Zoro

- `npm run verify:perimeter-policy` → OK.
- `npm run verify:skills-server-only` → OK.
- `npm --prefix apps/web run typecheck` → OK.
- `npm --prefix apps/web run build` → OK.
- `git diff --check` → OK.
- Scan dirigido de secretos en docs/scripts cambiados → OK.

## Review solicitada

- Chopper: seguridad/perímetro, trusted origins policy, no-forwarding credentials, internet-public unsupported.
- Franky: operabilidad/runtime, Tailscale/private deployment, guardrail y verify strategy.
