### PR TITLE
fix: harden skills BFF trusted origins

### DIFF
--- a/.engram/phase-13-3-closeout.md
+++ b/.engram/phase-13-3-closeout.md
@@ -1,0 +1,30 @@
+# Phase 13.3 closeout — Skills BFF hardening
+
+## Status
+Implemented locally on branch `zoro/phase-13-3-skills-bff-hardening`.
+
+## Summary
+Phase 13.3 hardens the only write-capable MVP surface, `/skills`, by requiring a server-only trusted-origin allowlist for BFF write routes.
+
+## Decisions
+- `MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS` is the only trusted-origin configuration.
+- The allowlist is server-only; no `NEXT_PUBLIC_*` variant is allowed.
+- Missing allowlist fails closed with `403 trusted_origins_not_configured`.
+- Missing `Origin` fails closed with `403 origin_required`.
+- Invalid or non-allowlisted `Origin` fails closed with `403 origin_not_allowed`.
+- Since current MVP does not use browser cookie/session auth and does not forward browser credentials upstream, strict Origin validation is the Phase 13.3 CSRF/perimeter control. Future cookie-backed auth must add a separate CSRF token/session design.
+
+## Verification
+Completed before PR:
+
+- `npm run verify:perimeter-policy` — passed.
+- `npm run verify:skills-server-only` — passed.
+- `npm --prefix apps/web run typecheck` — passed.
+- `npm --prefix apps/web run build` — passed.
+- `git diff --check` — passed.
+- directed secret scan over changed docs/scripts/code — passed.
+
+## Follow-ups
+- Phase 13.4: backend/API perimeter headers and error hardening.
+- Phase 13.5: block smoke and closeout.
+- #16 remains deferred until perimeter hardening block closes.

--- a/apps/web/src/app/api/control-panel/skills/[skillId]/preview/route.ts
+++ b/apps/web/src/app/api/control-panel/skills/[skillId]/preview/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 
 import {
+  assertTrustedOriginForSkillsWrite,
   buildSkillsBffValidationErrorPayload,
   isSkillsBffValidationError,
   parseSkillPreviewPayload,
@@ -23,6 +24,7 @@ type SkillPreviewRouteContext = {
 
 export async function POST(request: Request, { params }: SkillPreviewRouteContext) {
   try {
+    assertTrustedOriginForSkillsWrite(request)
     const { skillId } = await params
     const safeSkillId = validateSkillId(skillId)
     const payload = await parseSkillPreviewPayload(request)

--- a/apps/web/src/app/api/control-panel/skills/[skillId]/route.ts
+++ b/apps/web/src/app/api/control-panel/skills/[skillId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 
 import {
+  assertTrustedOriginForSkillsWrite,
   buildSkillsBffValidationErrorPayload,
   isSkillsBffValidationError,
   parseSkillUpdatePayload,
@@ -39,6 +40,7 @@ export async function GET(_request: Request, { params }: SkillRouteContext) {
 
 export async function PUT(request: Request, { params }: SkillRouteContext) {
   try {
+    assertTrustedOriginForSkillsWrite(request)
     const { skillId } = await params
     const safeSkillId = validateSkillId(skillId)
     const payload = await parseSkillUpdatePayload(request)

--- a/apps/web/src/modules/skills/api/skills-bff-validation.ts
+++ b/apps/web/src/modules/skills/api/skills-bff-validation.ts
@@ -1,10 +1,19 @@
+import 'server-only'
+
 export const SKILLS_BFF_BODY_LIMIT_BYTES = 256 * 1024
 export const SKILLS_BFF_CONTENT_LIMIT_BYTES = 200_000
 
 const SKILL_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,79}$/
 const SHA256_PATTERN = /^[a-fA-F0-9]{64}$/
 
-type BffErrorCode = 'validation_error' | 'unsupported_media_type'
+export const SKILLS_BFF_TRUSTED_ORIGINS_ENV = 'MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS'
+
+type BffErrorCode =
+  | 'validation_error'
+  | 'unsupported_media_type'
+  | 'trusted_origins_not_configured'
+  | 'origin_required'
+  | 'origin_not_allowed'
 
 type BffErrorPayload = {
   detail: {
@@ -27,6 +36,60 @@ export class SkillsBffValidationError extends Error {
 
 function utf8Bytes(value: string) {
   return new TextEncoder().encode(value).length
+}
+
+
+function sanitizeOrigin(value: string) {
+  try {
+    const parsed = new URL(value)
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return null
+    }
+
+    return parsed.origin
+  } catch {
+    return null
+  }
+}
+
+function getTrustedOrigins() {
+  const value = process.env[SKILLS_BFF_TRUSTED_ORIGINS_ENV]
+
+  if (!value) {
+    return []
+  }
+
+  return Array.from(new Set(value.split(',').map((entry) => entry.trim()).map(sanitizeOrigin).filter(Boolean))) as string[]
+}
+
+export function assertTrustedOriginForSkillsWrite(request: Request) {
+  const trustedOrigins = getTrustedOrigins()
+
+  if (trustedOrigins.length === 0) {
+    throw new SkillsBffValidationError('La allowlist server-only de orígenes de Skills no está configurada.', {
+      status: 403,
+      code: 'trusted_origins_not_configured',
+    })
+  }
+
+  const origin = request.headers.get('origin')
+
+  if (!origin) {
+    throw new SkillsBffValidationError('La frontera BFF de Skills requiere Origin para rutas de escritura.', {
+      status: 403,
+      code: 'origin_required',
+    })
+  }
+
+  const safeOrigin = sanitizeOrigin(origin)
+
+  if (!safeOrigin || !trustedOrigins.includes(safeOrigin)) {
+    throw new SkillsBffValidationError('Origin no permitido para la frontera BFF de Skills.', {
+      status: 403,
+      code: 'origin_not_allowed',
+    })
+  }
 }
 
 export function validateSkillId(skillId: string) {

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -28,6 +28,7 @@ npm run verify:perimeter-policy
 | Variable | Consumidor | Exposición | Uso |
 | --- | --- | --- | --- |
 | `MUGIWARA_CONTROL_PANEL_API_URL` | `/memory`, `/mugiwaras`, `/skills` BFF/server loaders, `/vault`, `/dashboard`, `/healthcheck` | Server-only | Base URL del backend para superficies que deben resolver datos desde servidor o frontera BFF. Debe apuntar a loopback, red privada o Tailscale/private hostname; no es configuración pública de navegador. |
+| `MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS` | `/skills` BFF write routes | Server-only | Allowlist separada por comas de orígenes exactos `http:`/`https:` permitidos para `POST`/`PUT` de Skills. Debe contener solo orígenes privados/locales/Tailscale; si falta, las escrituras BFF devuelven `403 trusted_origins_not_configured`. |
 
 ## Memory
 `/memory` usa el patrón server-only desde Phase 12.3c:
@@ -82,9 +83,10 @@ npm run verify:mugiwaras-server-only
 3. La base URL se valida como `http:` o `https:` antes del fetch upstream.
 4. Los route handlers de Next.js usan `cache: 'no-store'`, `force-dynamic` y endpoints allowlisted, no proxy genérico.
 5. Las rutas BFF validan `skillId`, método, `Content-Type`, tamaño y schema antes de reenviar preview/update.
-6. Los errores devueltos al navegador están saneados y no incluyen backend URL, stack traces, bodies, diffs ni secretos.
-7. FastAPI sigue siendo fuente de verdad para allowlist, path safety, stale hash, edición y auditoría.
-8. Los endpoints `/api/control-panel/skills/**`, especialmente `PUT`, pertenecen al control plane privado: no deben exponerse fuera de Tailscale/perímetro autenticado sin añadir auth/autorización server-side y rate limiting.
+6. Las rutas write-capable (`POST` preview y `PUT` update) exigen `MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS` y rechazan `Origin` ausente o no confiable antes de procesar el cuerpo.
+7. Los errores devueltos al navegador están saneados y no incluyen backend URL, stack traces, bodies, diffs ni secretos.
+8. FastAPI sigue siendo fuente de verdad para allowlist, path safety, stale hash, edición y auditoría.
+9. Los endpoints `/api/control-panel/skills/**`, especialmente `PUT`, pertenecen al control plane privado: no deben exponerse fuera de Tailscale/perímetro autenticado sin añadir auth/autorización server-side y rate limiting.
 
 Antes de cerrar cambios que toquen Skills config o BFF, ejecutar:
 

--- a/docs/security-perimeter.md
+++ b/docs/security-perimeter.md
@@ -37,14 +37,23 @@ Rules:
 Phase 13.2 does not add a hard backend host allowlist. That belongs to a later enforcement phase if deployment hardening needs it. This phase defines the contract and guardrails.
 
 ## Trusted origins policy
-Before enforcing Origin/CSRF checks, Phase 13.2 defines the supported origin model:
+Phase 13.3 enforces a configurable trusted-origin allowlist for write-capable Skills BFF routes.
 
-- local development origins: `http://localhost:<port>` and `http://127.0.0.1:<port>`;
-- private LAN origins: allowed only if explicitly configured for a trusted private network;
-- Tailscale origins: allowed only if explicitly configured for Pablo's private Tailnet hostnames/IPs;
-- public internet origins: unsupported until auth/session/rate-limit decisions exist.
+Configuration:
 
-Phase 13.3 may implement a concrete trusted-origin configuration. Until then, write-route hardening must not invent a fragile hardcoded list.
+- `MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS` is server-only.
+- The value is a comma-separated list of exact `http:` / `https:` origins, for example local/private origins without paths.
+- Public internet origins remain unsupported until auth/session/rate-limit decisions exist.
+- Wildcards, arbitrary reflected origins and browser-controlled allowlists are not supported.
+
+Enforcement for `/api/control-panel/skills/**` write routes:
+
+- missing allowlist -> `403 trusted_origins_not_configured`;
+- missing `Origin` -> `403 origin_required`;
+- invalid or non-allowlisted `Origin` -> `403 origin_not_allowed`;
+- allowed `Origin` -> request may continue to the existing schema/body/skill-id validation and backend write policy.
+
+The current CSRF strategy is Origin-based because the MVP has no browser cookie/session auth yet and the BFF does not forward browser cookies or `Authorization` upstream. If future authentication uses cookies, add a separate CSRF token/session strategy before treating cookie-backed writes as protected.
 
 ## Skills BFF policy
 The Skills BFF remains same-origin and allowlisted:
@@ -56,7 +65,7 @@ The Skills BFF remains same-origin and allowlisted:
 - Browser `Authorization` headers must not be forwarded upstream by default.
 - Request bodies, diffs, hashes, skill contents and backend paths must not be logged or returned in sanitized errors.
 
-If future authentication uses cookies, Phase 13.3 must add Origin/CSRF validation before treating same-origin BFF write routes as protected.
+If future authentication uses cookies, add a separate CSRF token/session strategy before treating cookie-backed BFF write routes as protected. Phase 13.3 only enforces the current non-cookie MVP boundary with strict Origin validation.
 
 ## Error and logging policy
 Allowed in errors/logs:

--- a/openspec/phase-13-3-skills-bff-hardening.md
+++ b/openspec/phase-13-3-skills-bff-hardening.md
@@ -1,0 +1,86 @@
+# Phase 13.3 — Skills BFF hardening
+
+## Goal
+Harden the write-capable `/skills` BFF boundary before connecting additional real operational sources.
+
+## Scope
+In scope:
+
+- server-only trusted-origin configuration for Skills write routes;
+- Origin-based CSRF/perimeter rejection for `/api/control-panel/skills/**` write endpoints;
+- deterministic guardrails that prevent regression to browser-exposed config or open proxy patterns;
+- runtime docs describing the new required configuration.
+
+Out of scope:
+
+- full user authentication/session management;
+- cookie-backed CSRF token design;
+- public internet support;
+- healthcheck/dashboard real-source hardening (#16);
+- backend host allowlist beyond existing `http:`/`https:` validation.
+
+## Design
+
+### Configuration
+`MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS` is a server-only comma-separated allowlist of exact `http:`/`https:` origins.
+
+Examples of valid classes of values:
+
+- local development origin;
+- controlled private LAN origin;
+- private Tailscale origin.
+
+No `NEXT_PUBLIC_*` variant is allowed.
+
+### Enforcement
+Write-capable Skills BFF routes now call `assertTrustedOriginForSkillsWrite(request)` before reading or parsing request bodies.
+
+Rejection model:
+
+- no configured trusted origins -> `403 trusted_origins_not_configured`;
+- missing `Origin` -> `403 origin_required`;
+- invalid/non-allowlisted `Origin` -> `403 origin_not_allowed`.
+
+The allowed path continues into the existing validations:
+
+- exact BFF endpoints only;
+- `skillId` validation;
+- `application/json` validation;
+- body size/content/schema validation;
+- FastAPI remains source of truth for allowlist/path/write/audit policy.
+
+### CSRF stance
+The current MVP has no browser cookie/session auth and the BFF does not forward browser `Cookie` or `Authorization` upstream. Phase 13.3 therefore uses strict Origin validation as the CSRF/perimeter control for write routes.
+
+If future auth uses browser cookies, add a separate CSRF token/session strategy before treating cookie-backed writes as protected.
+
+## Files changed
+
+- `apps/web/src/modules/skills/api/skills-bff-validation.ts`
+  - adds server-only trusted-origin parsing and rejection helper;
+  - keeps existing BFF validation payload shape.
+- `apps/web/src/app/api/control-panel/skills/[skillId]/route.ts`
+  - enforces trusted Origin before `PUT` body parsing/upstream update.
+- `apps/web/src/app/api/control-panel/skills/[skillId]/preview/route.ts`
+  - enforces trusted Origin before `POST` body parsing/upstream preview.
+- `scripts/check-perimeter-policy.mjs`
+  - extends perimeter guardrail to cover trusted origins and write-route enforcement.
+- `scripts/check-skills-server-only.mjs`
+  - extends Skills BFF guardrail to require server-only perimeter module and write-route Origin checks.
+- `docs/security-perimeter.md`
+  - records Phase 13.3 enforcement model.
+- `docs/runtime-config.md`
+  - documents `MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS`.
+
+## Verify
+Required before PR:
+
+```bash
+npm run verify:perimeter-policy
+npm run verify:skills-server-only
+npm --prefix apps/web run typecheck
+npm --prefix apps/web run build
+git diff --check
+```
+
+Also scan changed docs/scripts for accidental secrets before commit.

--- a/openspec/phase-13-3-verify-checklist.md
+++ b/openspec/phase-13-3-verify-checklist.md
@@ -1,0 +1,25 @@
+# Phase 13.3 verify checklist — Skills BFF hardening
+
+## Static guardrails
+- [ ] `npm run verify:perimeter-policy`
+- [ ] `npm run verify:skills-server-only`
+
+## Type/build
+- [ ] `npm --prefix apps/web run typecheck`
+- [ ] `npm --prefix apps/web run build`
+
+## Security review points
+- [ ] `MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS` is server-only only.
+- [ ] No `NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS` exists.
+- [ ] `PUT /api/control-panel/skills/[skillId]` rejects before body parsing when Origin is absent/untrusted/unconfigured.
+- [ ] `POST /api/control-panel/skills/[skillId]/preview` rejects before body parsing when Origin is absent/untrusted/unconfigured.
+- [ ] Browser adapter remains same-origin BFF only.
+- [ ] BFF does not forward browser `Cookie` or `Authorization` upstream.
+- [ ] No generic proxy pattern was introduced.
+- [ ] Docs still mark `internet-public` as unsupported.
+
+## Repository hygiene
+- [ ] `git diff --check`
+- [ ] Changed docs/scripts scanned for secrets.
+- [ ] Commit uses Zoro trailers.
+- [ ] PR requests Chopper + Franky review.

--- a/scripts/check-perimeter-policy.mjs
+++ b/scripts/check-perimeter-policy.mjs
@@ -17,6 +17,7 @@ const paths = {
   packageJson: join(repoRoot, 'package.json'),
   skillsBrowserAdapter: join(repoRoot, 'apps/web/src/modules/skills/api/skills-http.ts'),
   skillsServerAdapter: join(repoRoot, 'apps/web/src/modules/skills/api/skills-server-http.ts'),
+  skillsBffValidation: join(repoRoot, 'apps/web/src/modules/skills/api/skills-bff-validation.ts'),
   skillsDetailRoute: join(repoRoot, 'apps/web/src/app/api/control-panel/skills/[skillId]/route.ts'),
   skillsPreviewRoute: join(repoRoot, 'apps/web/src/app/api/control-panel/skills/[skillId]/preview/route.ts'),
 }
@@ -37,6 +38,7 @@ const runtimeConfig = read(paths.runtimeConfig, 'runtime config document')
 const packageJsonText = read(paths.packageJson, 'package.json')
 const skillsBrowserAdapter = read(paths.skillsBrowserAdapter, 'skills browser adapter')
 const skillsServerAdapter = read(paths.skillsServerAdapter, 'skills server adapter')
+const skillsBffValidation = read(paths.skillsBffValidation, 'skills BFF validation/perimeter module')
 const skillsDetailRoute = read(paths.skillsDetailRoute, 'skills detail/update route')
 const skillsPreviewRoute = read(paths.skillsPreviewRoute, 'skills preview route')
 const writeRoutes = [skillsDetailRoute, skillsPreviewRoute].join('\n')
@@ -51,11 +53,15 @@ mustInclude(perimeterDoc, 'internet-public: unsupported', 'security perimeter do
 mustInclude(perimeterDoc, 'Tailscale private access', 'security perimeter document')
 mustInclude(perimeterDoc, 'Browser cookies must not be forwarded upstream by default.', 'security perimeter document')
 mustInclude(perimeterDoc, 'Browser `Authorization` headers must not be forwarded upstream by default.', 'security perimeter document')
-mustInclude(perimeterDoc, 'Phase 13.3 may implement a concrete trusted-origin configuration.', 'security perimeter document')
+mustInclude(perimeterDoc, 'MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS', 'security perimeter document')
+mustInclude(perimeterDoc, '403 trusted_origins_not_configured', 'security perimeter document')
+mustInclude(perimeterDoc, '403 origin_required', 'security perimeter document')
+mustInclude(perimeterDoc, '403 origin_not_allowed', 'security perimeter document')
 mustInclude(perimeterDoc, 'Issue #16, Healthcheck/Dashboard real-source hardening, stays after perimeter hardening.', 'security perimeter document')
 mustInclude(runtimeConfig, 'docs/security-perimeter.md', 'runtime config document')
 mustInclude(runtimeConfig, 'internet-public: unsupported', 'runtime config document')
 mustInclude(runtimeConfig, 'npm run verify:perimeter-policy', 'runtime config document')
+mustInclude(runtimeConfig, 'MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS', 'runtime config document')
 
 let packageJson
 try {
@@ -74,6 +80,35 @@ if (skillsBrowserAdapter.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL') 
 
 if (!skillsBrowserAdapter.includes("const SKILLS_BFF_BASE_PATH = '/api/control-panel/skills'")) {
   failures.push('skills browser adapter must use the same-origin Skills BFF base path')
+}
+
+
+mustInclude(skillsBffValidation, "import 'server-only'", 'skills BFF validation/perimeter module')
+mustInclude(skillsBffValidation, 'MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS', 'skills BFF validation/perimeter module')
+mustInclude(skillsBffValidation, 'assertTrustedOriginForSkillsWrite', 'skills BFF validation/perimeter module')
+mustInclude(skillsBffValidation, 'trusted_origins_not_configured', 'skills BFF validation/perimeter module')
+mustInclude(skillsBffValidation, 'origin_required', 'skills BFF validation/perimeter module')
+mustInclude(skillsBffValidation, 'origin_not_allowed', 'skills BFF validation/perimeter module')
+mustInclude(skillsDetailRoute, 'assertTrustedOriginForSkillsWrite(request)', 'skills update route')
+mustInclude(skillsPreviewRoute, 'assertTrustedOriginForSkillsWrite(request)', 'skills preview route')
+
+if (skillsBrowserAdapter.includes('MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS')) {
+  failures.push('skills browser adapter must not read trusted origins configuration')
+}
+
+
+
+const forbiddenTrustedOriginSnippets = [
+  'NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS',
+  'Access-Control-Allow-Origin: *',
+  "'Access-Control-Allow-Origin': '*'",
+  '"Access-Control-Allow-Origin": "*"',
+]
+
+for (const snippet of forbiddenTrustedOriginSnippets) {
+  if (writeRoutes.includes(snippet) || skillsBrowserAdapter.includes(snippet) || skillsBffValidation.includes(snippet)) {
+    failures.push(`trusted origins must stay server-only and exact, forbidden snippet: ${snippet}`)
+  }
 }
 
 const forbiddenWriteRouteSnippets = [

--- a/scripts/check-skills-server-only.mjs
+++ b/scripts/check-skills-server-only.mjs
@@ -128,6 +128,28 @@ if (!validation.includes('assertJsonContentType')) {
   failures.push('BFF validation must enforce application/json for write routes')
 }
 
+if (!validation.includes("import 'server-only'")) {
+  failures.push('BFF validation/perimeter module must be guarded with server-only')
+}
+
+if (!validation.includes('MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS')) {
+  failures.push('BFF validation/perimeter module must use server-only trusted origins config')
+}
+
+for (const [name, route] of Object.entries({ detailRoute, previewRoute })) {
+  if (!route.includes('assertTrustedOriginForSkillsWrite(request)')) {
+    failures.push(`${name} must enforce trusted Origin before Skills writes`)
+  }
+}
+
+if (browserAdapter.includes('MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS')) {
+  failures.push('browser-side skills adapter must not read trusted origins config')
+}
+
+if (allRoutes.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS') || validation.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS')) {
+  failures.push('trusted origins config must not use NEXT_PUBLIC_*')
+}
+
 const forbiddenGenericProxySnippets = [
   'searchParams.get(\'path\')',
   'searchParams.get("path")',


### PR DESCRIPTION
## Summary
- add server-only MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS enforcement for Skills BFF write routes
- reject unconfigured, missing, invalid or non-allowlisted Origin before body parsing/upstream writes
- extend perimeter/skills guardrails and runtime docs for the Phase 13.3 boundary

## Verification
- npm run verify:perimeter-policy
- npm run verify:skills-server-only
- npm --prefix apps/web run typecheck
- npm --prefix apps/web run build
- git diff --check
- directed secret scan over changed docs/scripts/code

## Review
Security/perimeter change: requesting Chopper + Franky review before merge.