### PR TITLE
fix: harden backend api perimeter

### DIFF
--- a/.engram/phase-13-4-closeout.md
+++ b/.engram/phase-13-4-closeout.md
@@ -1,0 +1,31 @@
+# Phase 13.4 closeout — Backend/API perimeter hardening
+
+## Status
+Implemented locally on branch `zoro/phase-13-4-backend-api-perimeter-hardening`.
+
+## Summary
+Phase 13.4 hardens the FastAPI backend perimeter after the Skills BFF Origin boundary. The backend now applies private-control-plane security headers, explicitly rejects browser CORS preflight with a sanitized `403 cors_not_supported` response, and sanitizes FastAPI request-validation errors so invalid payloads are not echoed back.
+
+## Decisions
+- FastAPI remains non-CORS by default; no permissive CORS middleware was added.
+- Browser preflight requests (`OPTIONS` + `Origin` + `Access-Control-Request-Method`) fail closed with `403 cors_not_supported` and no reflected `Access-Control-Allow-Origin`.
+- API responses carry `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, `X-Frame-Options: DENY` and `Cache-Control: no-store`.
+- `RequestValidationError` now returns a stable sanitized `validation_error` envelope instead of Pydantic details that could include submitted bodies, hashes, host paths or field internals.
+- This does not make public internet exposure supported; auth/session/rate-limit remain future scope.
+
+## Verification
+Completed before PR:
+
+- `python -m pytest apps/api/tests/test_perimeter_api.py -q` — passed.
+- `python -m pytest apps/api/tests -q` — passed.
+- `npm run verify:perimeter-policy` — passed.
+- `npm run verify:skills-server-only` — passed.
+- `python -m py_compile apps/api/src/main.py` — passed.
+- `npm --prefix apps/web run typecheck` — passed.
+- `npm --prefix apps/web run build` — passed.
+- `git diff --check` — passed.
+- Directed scan for accidental secrets, permissive CORS snippets and public-exposure language — passed with only expected negative-test/guardrail references.
+
+## Follow-ups
+- Phase 13.5: block smoke and closeout.
+- #16 remains deferred until the Phase 13 perimeter block is closed.

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -1,4 +1,6 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 
 from .modules.skills.router import router as skills_router
 from .modules.mugiwaras.router import router as mugiwaras_router
@@ -7,7 +9,54 @@ from .modules.vault.router import router as vault_router
 from .modules.healthcheck.router import router as healthcheck_router
 from .modules.dashboard.router import router as dashboard_router
 
+SECURITY_HEADERS = {
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'no-referrer',
+    'X-Frame-Options': 'DENY',
+    'Cache-Control': 'no-store',
+}
+
 app = FastAPI(title='Mugiwara Control Panel API')
+
+
+def _apply_security_headers(response):
+    for name, value in SECURITY_HEADERS.items():
+        response.headers.setdefault(name, value)
+    return response
+
+
+@app.middleware('http')
+async def private_control_plane_perimeter(request: Request, call_next):
+    is_cors_preflight = (
+        request.method == 'OPTIONS'
+        and 'origin' in request.headers
+        and 'access-control-request-method' in request.headers
+    )
+    if is_cors_preflight:
+        return _apply_security_headers(
+            JSONResponse(
+                status_code=403,
+                content={
+                    'detail': {
+                        'code': 'cors_not_supported',
+                        'message': 'Cross-origin browser access is not supported.',
+                    }
+                },
+            )
+        )
+
+    response = await call_next(request)
+    return _apply_security_headers(response)
+
+
+@app.exception_handler(RequestValidationError)
+async def sanitized_request_validation_error(_request: Request, _exc: RequestValidationError):
+    return JSONResponse(
+        status_code=422,
+        content={'detail': {'code': 'validation_error', 'message': 'Request validation failed.'}},
+    )
+
+
 app.include_router(skills_router)
 app.include_router(mugiwaras_router)
 app.include_router(memory_router)

--- a/apps/api/tests/test_perimeter_api.py
+++ b/apps/api/tests/test_perimeter_api.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from apps.api.src.main import app
+
+client = TestClient(app)
+
+
+def test_api_responses_carry_private_control_plane_security_headers() -> None:
+    response = client.get('/health')
+
+    assert response.status_code == 200
+    assert response.headers['x-content-type-options'] == 'nosniff'
+    assert response.headers['referrer-policy'] == 'no-referrer'
+    assert response.headers['x-frame-options'] == 'DENY'
+    assert response.headers['cache-control'] == 'no-store'
+
+
+def test_cors_preflight_is_rejected_without_reflecting_origin() -> None:
+    response = client.options(
+        '/api/v1/skills/demo-skill',
+        headers={
+            'Origin': 'https://evil.example',
+            'Access-Control-Request-Method': 'PUT',
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()['detail']['code'] == 'cors_not_supported'
+    assert 'access-control-allow-origin' not in response.headers
+    assert 'https://evil.example' not in response.text
+
+
+def test_request_validation_errors_are_sanitized_without_payload_echo() -> None:
+    sensitive_content = 'SENSITIVE_MARKER=should-not-be-echoed\n/internal/private/path'
+    response = client.put(
+        '/api/v1/skills/demo-skill',
+        json={'actor': 'zoro', 'content': sensitive_content, 'expected_sha256': 'short'},
+    )
+
+    assert response.status_code == 422
+    assert response.json()['detail'] == {
+        'code': 'validation_error',
+        'message': 'Request validation failed.',
+    }
+    assert 'SENSITIVE_MARKER' not in response.text
+    assert '/internal/private/path' not in response.text
+    assert 'expected_sha256' not in response.text

--- a/docs/security-perimeter.md
+++ b/docs/security-perimeter.md
@@ -68,6 +68,12 @@ The Skills BFF remains same-origin and allowlisted:
 If future authentication uses cookies, add a separate CSRF token/session strategy before treating cookie-backed BFF write routes as protected. Phase 13.3 only enforces the current non-cookie MVP boundary with strict Origin validation.
 
 ## Error and logging policy
+Backend/API perimeter behavior added in Phase 13.4:
+
+- API responses carry private-control-plane hardening headers: `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, `X-Frame-Options: DENY` and `Cache-Control: no-store`.
+- FastAPI does not enable permissive CORS. Browser CORS preflight requests are rejected with `403 cors_not_supported` and no reflected `Access-Control-Allow-Origin`.
+- Request validation errors return a sanitized `validation_error` envelope instead of echoing raw Pydantic validation details, submitted bodies, hashes, host paths or secret-like payloads.
+
 Allowed in errors/logs:
 - route or module name;
 - HTTP status;

--- a/openspec/phase-13-4-backend-api-perimeter-hardening.md
+++ b/openspec/phase-13-4-backend-api-perimeter-hardening.md
@@ -1,0 +1,82 @@
+# Phase 13.4 — Backend/API perimeter headers and error hardening
+
+## Goal
+Harden the FastAPI backend perimeter after the Skills BFF Origin boundary, keeping the control panel private-by-default and preventing backend/API errors from echoing sensitive request material.
+
+## Scope
+In scope:
+
+- FastAPI security headers suitable for a private control-plane API;
+- explicit rejection of browser CORS preflight instead of permissive CORS reflection;
+- sanitized FastAPI request-validation errors;
+- regression tests for backend rejection semantics;
+- perimeter-policy guardrail coverage for the backend hardening invariants;
+- documentation alignment in `docs/security-perimeter.md`.
+
+Out of scope:
+
+- user authentication, sessions or login UI;
+- cookie-backed CSRF token design;
+- rate limiting;
+- public internet support;
+- backend host allowlist enforcement;
+- Healthcheck/Dashboard real-source connectors or host introspection (#16).
+
+## Design
+
+### Security headers
+All backend responses receive these headers:
+
+- `X-Content-Type-Options: nosniff`;
+- `Referrer-Policy: no-referrer`;
+- `X-Frame-Options: DENY`;
+- `Cache-Control: no-store`.
+
+The intent is not to make public exposure supported. It is a defense-in-depth baseline for the private control plane.
+
+### CORS stance
+FastAPI remains non-CORS by default. Phase 13.4 adds a deterministic rejection for browser preflight requests:
+
+- request method `OPTIONS`;
+- has `Origin`;
+- has `Access-Control-Request-Method`.
+
+Such requests return `403 cors_not_supported`, without `Access-Control-Allow-Origin` reflection and without echoing the submitted origin.
+
+### Validation-error sanitization
+`RequestValidationError` responses now return a stable sanitized envelope:
+
+```json
+{"detail":{"code":"validation_error","message":"Request validation failed."}}
+```
+
+This prevents Pydantic/FastAPI validation details from echoing submitted bodies, sensitive-looking content, hashes, host paths or field-level internals. Module-level domain errors continue to use their existing sanitized `detail.code`/`detail.message` envelopes.
+
+## Files changed
+
+- `apps/api/src/main.py`
+  - adds private-control-plane security header middleware;
+  - rejects CORS preflight with `403 cors_not_supported`;
+  - adds sanitized `RequestValidationError` handler.
+- `apps/api/tests/test_perimeter_api.py`
+  - covers headers, CORS preflight rejection and validation-error sanitization.
+- `scripts/check-perimeter-policy.mjs`
+  - extends the static perimeter guardrail to assert backend hardening invariants.
+- `docs/security-perimeter.md`
+  - documents Phase 13.4 backend/API perimeter behavior.
+
+## Verify
+Required before PR:
+
+```bash
+python -m pytest apps/api/tests/test_perimeter_api.py -q
+python -m pytest apps/api/tests -q
+npm run verify:perimeter-policy
+npm run verify:skills-server-only
+python -m py_compile apps/api/src/main.py
+npm --prefix apps/web run typecheck
+npm --prefix apps/web run build
+git diff --check
+```
+
+Also run a directed scan over changed files for accidental secrets, raw host paths in error examples, permissive CORS snippets and public exposure language.

--- a/openspec/phase-13-4-verify-checklist.md
+++ b/openspec/phase-13-4-verify-checklist.md
@@ -1,0 +1,27 @@
+# Phase 13.4 planning/verify checklist — Backend/API perimeter headers and error hardening
+
+## Scope confirmation
+- [x] Based on Phase 13.1 plan and Phase 13.3 closeout.
+- [x] No auth/session/rate-limit implementation.
+- [x] No Healthcheck/Dashboard real-source connectors.
+- [x] No generic proxy, shell, Docker/systemd or arbitrary filesystem surface added.
+- [x] No public internet support introduced.
+
+## TDD evidence
+- [x] Added failing tests first for backend security headers, CORS preflight rejection and request-validation sanitization.
+- [x] Implemented only the perimeter behavior needed to satisfy those tests.
+
+## Verify evidence
+- [x] `python -m pytest apps/api/tests/test_perimeter_api.py -q`
+- [x] `python -m pytest apps/api/tests -q`
+- [x] `npm run verify:perimeter-policy`
+- [x] `npm run verify:skills-server-only`
+- [x] `python -m py_compile apps/api/src/main.py`
+- [x] `npm --prefix apps/web run typecheck`
+- [x] `npm --prefix apps/web run build`
+- [x] `git diff --check`
+- [x] Directed secret/permissive-CORS/public-exposure scan over changed files.
+
+## Review routing
+- Chopper: CORS/perimeter semantics, sanitized error behavior and no sensitive echo.
+- Franky: FastAPI middleware operability, headers, build/test impact and runtime compatibility.

--- a/scripts/check-perimeter-policy.mjs
+++ b/scripts/check-perimeter-policy.mjs
@@ -20,6 +20,7 @@ const paths = {
   skillsBffValidation: join(repoRoot, 'apps/web/src/modules/skills/api/skills-bff-validation.ts'),
   skillsDetailRoute: join(repoRoot, 'apps/web/src/app/api/control-panel/skills/[skillId]/route.ts'),
   skillsPreviewRoute: join(repoRoot, 'apps/web/src/app/api/control-panel/skills/[skillId]/preview/route.ts'),
+  apiMain: join(repoRoot, 'apps/api/src/main.py'),
 }
 
 const failures = []
@@ -41,6 +42,7 @@ const skillsServerAdapter = read(paths.skillsServerAdapter, 'skills server adapt
 const skillsBffValidation = read(paths.skillsBffValidation, 'skills BFF validation/perimeter module')
 const skillsDetailRoute = read(paths.skillsDetailRoute, 'skills detail/update route')
 const skillsPreviewRoute = read(paths.skillsPreviewRoute, 'skills preview route')
+const apiMain = read(paths.apiMain, 'FastAPI main perimeter module')
 const writeRoutes = [skillsDetailRoute, skillsPreviewRoute].join('\n')
 
 function mustInclude(text, snippet, label) {
@@ -57,6 +59,8 @@ mustInclude(perimeterDoc, 'MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS', 'security pe
 mustInclude(perimeterDoc, '403 trusted_origins_not_configured', 'security perimeter document')
 mustInclude(perimeterDoc, '403 origin_required', 'security perimeter document')
 mustInclude(perimeterDoc, '403 origin_not_allowed', 'security perimeter document')
+mustInclude(perimeterDoc, '403 cors_not_supported', 'security perimeter document')
+mustInclude(perimeterDoc, 'Request validation errors return a sanitized `validation_error` envelope', 'security perimeter document')
 mustInclude(perimeterDoc, 'Issue #16, Healthcheck/Dashboard real-source hardening, stays after perimeter hardening.', 'security perimeter document')
 mustInclude(runtimeConfig, 'docs/security-perimeter.md', 'runtime config document')
 mustInclude(runtimeConfig, 'internet-public: unsupported', 'runtime config document')
@@ -96,6 +100,14 @@ if (skillsBrowserAdapter.includes('MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS')) {
   failures.push('skills browser adapter must not read trusted origins configuration')
 }
 
+mustInclude(apiMain, 'SECURITY_HEADERS', 'FastAPI main perimeter module')
+mustInclude(apiMain, "'X-Content-Type-Options': 'nosniff'", 'FastAPI main perimeter module')
+mustInclude(apiMain, "'Referrer-Policy': 'no-referrer'", 'FastAPI main perimeter module')
+mustInclude(apiMain, "'X-Frame-Options': 'DENY'", 'FastAPI main perimeter module')
+mustInclude(apiMain, "'Cache-Control': 'no-store'", 'FastAPI main perimeter module')
+mustInclude(apiMain, 'cors_not_supported', 'FastAPI main perimeter module')
+mustInclude(apiMain, '@app.exception_handler(RequestValidationError)', 'FastAPI main perimeter module')
+mustInclude(apiMain, "'message': 'Request validation failed.'", 'FastAPI main perimeter module')
 
 
 const forbiddenTrustedOriginSnippets = [


### PR DESCRIPTION
## Summary
- Hardens FastAPI backend/API perimeter for Phase 13.4.
- Adds private-control-plane security headers on API responses.
- Rejects browser CORS preflight deterministically with sanitized `403 cors_not_supported` and no reflected origin.
- Sanitizes FastAPI `RequestValidationError` responses to avoid echoing submitted payloads, host paths, hashes or field internals.
- Extends backend tests, perimeter guardrail, OpenSpec and security-perimeter docs.

## Scope
In scope:
- `apps/api/src/main.py` middleware/error handler.
- Backend perimeter regression tests.
- `verify:perimeter-policy` backend invariants.
- Phase 13.4 OpenSpec/checklist/Engram closeout.

Out of scope:
- Auth/session/login/rate limiting.
- Public internet support.
- Backend host allowlist enforcement.
- Healthcheck/Dashboard real-source connectors (#16).

## Verification
- [x] `python -m pytest apps/api/tests/test_perimeter_api.py -q`
- [x] `python -m pytest apps/api/tests -q`
- [x] `npm run verify:perimeter-policy`
- [x] `npm run verify:skills-server-only`
- [x] `python -m py_compile apps/api/src/main.py`
- [x] `npm --prefix apps/web run typecheck`
- [x] `npm --prefix apps/web run build`
- [x] `git diff --check`
- [x] Directed scan for accidental secrets, permissive CORS snippets and public-exposure language.

## Risk / review requested
- Chopper: CORS/perimeter semantics, validation-error sanitization, no sensitive echo, no public-exposure regression.
- Franky: FastAPI middleware behavior, headers, operational compatibility and verify/build impact.

## Notes
This PR does **not** make public internet exposure supported. The documented supported model remains local/private LAN/Tailscale/private perimeter only.
