### PR TITLE
docs: split Phase 15.2 health source foundation

### DIFF
--- a/.engram/phase-15-2-split-planning-closeout.md
+++ b/.engram/phase-15-2-split-planning-closeout.md
@@ -1,0 +1,34 @@
+# Phase 15.2 split planning closeout
+
+## Status
+Planning split created for Phase 15.2 on branch `zoro/phase-15-2-split-plan`.
+
+## Decision
+Phase 15.2 should not be implemented as one broad PR. It is now split into:
+
+1. **15.2a — Source contract vocabulary and stable IDs**
+   - backend-owned source/check ID vocabulary;
+   - status/severity/freshness allowlists;
+   - no live reads.
+
+2. **15.2b — Registry normalization and unsafe-field rejection**
+   - registry/normalizer;
+   - absent/unreadable/unregistered semantics;
+   - negative tests against raw fields and client-provided path/url/method.
+
+3. **15.2c — Guardrails, manifest ownership and freshness policy**
+   - static guardrail/test against generic host adapters;
+   - manifest ownership/location policy;
+   - source-family freshness thresholds.
+
+## Rationale
+The merged Phase 15.1 plan correctly made Phase 15.2 the contracts/registry foundation before live source adapters. However, after inspecting current Healthcheck code and the absorbed Franky/Chopper follow-ups, the foundation still mixes too many safety responsibilities for one PR. Splitting improves reviewability, TDD focus and rollback safety before touching vault sync, backups, gateways or cronjobs.
+
+## Next implementation step
+Start with **Phase 15.2a** only. Keep the scope to backend contract vocabulary and docs. Do not implement manifests, filesystem/Git/systemd/shell reads, cronjob visibility or UI redesign.
+
+## Verification
+Planning-only verify:
+- `git diff --check` passed.
+
+Runtime tests were intentionally not run because no runtime code changed in this split-planning step.

--- a/.engram/phase-15-2-split-planning-closeout.md
+++ b/.engram/phase-15-2-split-planning-closeout.md
@@ -14,7 +14,7 @@ Phase 15.2 should not be implemented as one broad PR. It is now split into:
 2. **15.2b — Registry normalization and unsafe-field rejection**
    - registry/normalizer;
    - absent/unreadable/unregistered semantics;
-   - negative tests against raw fields and client-provided path/url/method.
+   - negative tests against raw fields, client-provided path/url/method, cookies/credentials, tracebacks, absolute host paths, Git diffs/untracked lists/internal remotes and delivery targets.
 
 3. **15.2c — Guardrails, manifest ownership and freshness policy**
    - static guardrail/test against generic host adapters;

--- a/openspec/phase-15-2-health-source-contracts-registry-split.md
+++ b/openspec/phase-15-2-health-source-contracts-registry-split.md
@@ -51,7 +51,7 @@ Out of scope:
 DoD:
 - Existing API payload shape remains compatible for `/api/v1/healthcheck` and `/api/v1/dashboard`.
 - Invalid status/severity/freshness values cannot silently become healthy output.
-- Source/check IDs are deterministic and not derived from client input.
+- Source/check IDs are deterministic and come only from backend-owned allowlists; they are never derived from client input, discovered paths or dynamically detected service names.
 - Tests cover allowed vocabulary and invalid-value degradation/rejection.
 
 Verify:
@@ -73,10 +73,12 @@ Scope:
 - Model absent, unreadable and unregistered source states explicitly as `not_configured`, `unknown` or `stale`, never `pass`.
 - Add tests that malicious/raw adapter-like input cannot leak fields such as:
   - client-provided `path`, `url`, `method`;
-  - `stdout`, `stderr`, `raw_output`, `command`;
+  - `stdout`, `stderr`, `raw_output`, `command`, `traceback`;
   - `pid`, `unit_content`, `journal`;
-  - `backup_path`, `included_path`;
-  - `prompt_body`, `chat_id`, `token`, `.env`.
+  - absolute host paths, `backup_path`, `included_path`;
+  - `prompt_body`, `chat_id`, delivery targets;
+  - `token`, cookies, credentials, `.env`;
+  - Git diffs, untracked file lists or internal remote details.
 
 Out of scope:
 - Real source adapters.

--- a/openspec/phase-15-2-health-source-contracts-registry-split.md
+++ b/openspec/phase-15-2-health-source-contracts-registry-split.md
@@ -1,0 +1,161 @@
+# Phase 15.2 — Health source contracts and registry split
+
+## Decision
+Phase 15.2 **must be split into smaller subphases** before implementation.
+
+Phase 15.1 correctly defined Phase 15.2 as the safety foundation before live Healthcheck sources. After re-reading the merged plan, current Healthcheck backend code and reviewer follow-ups, the Phase 15.2 scope is still too broad for one implementation PR because it mixes:
+
+- new backend domain contracts and stable source/check IDs;
+- registry and normalization semantics;
+- negative security tests for unsafe client/raw fields;
+- guardrails against generic host adapters;
+- documentation updates;
+- manifest ownership/location decisions;
+- freshness threshold policy by source family.
+
+There are still **no live host reads** in Phase 15.2, but the foundation creates the rules that later live adapters will depend on. A mistake here would either block later adapters or create a host-leakage escape hatch. Split it.
+
+## Current baseline used
+- Branch baseline: `main` at merge commit `4e4f561` from PR #29.
+- Existing Healthcheck backend lives in `apps/api/src/modules/healthcheck/domain.py` and `service.py` with fixture-backed `HealthcheckRecord` values.
+- Existing tests are concentrated in `apps/api/tests/test_healthcheck_dashboard_api.py` and already cover sanitized workspace output, empty-source `not_configured`, stale visibility and timestamp aggregation.
+- `docs/api-modules.md` still says Healthcheck consumes only safe catalog sources and must not execute shell/systemd/Docker or read raw host output.
+- `docs/read-models.md` defines semantic states but does not yet describe the Phase 15 source registry/family model.
+- Phase 15.1 reviewer follow-ups require explicit absent/unreadable/unregistered semantics, negative tests for unsafe fields, generic adapter guardrails, manifest ownership/location and freshness thresholds.
+
+## Subphase cut
+
+### Phase 15.2a — Source contract vocabulary and stable IDs
+
+Scope:
+- Add or refine backend domain vocabulary for Healthcheck source families without adding live adapters.
+- Define stable family IDs and check IDs for Phase 15 source families:
+  - `vault-sync`
+  - `project-health`
+  - `backup-health`
+  - `hermes-gateways`
+  - `gateway.<mugiwara-slug>`
+  - `cronjobs`
+- Define allowed status/severity/freshness state vocabularies in one backend-owned place.
+- Keep current fixture-backed output compatible.
+- Update `docs/read-models.md` with the source-family vocabulary.
+
+Out of scope:
+- Manifest reading.
+- Filesystem reads.
+- Git/GitHub queries.
+- systemd queries.
+- cronjob runtime visibility.
+- New web UI layout.
+
+DoD:
+- Existing API payload shape remains compatible for `/api/v1/healthcheck` and `/api/v1/dashboard`.
+- Invalid status/severity/freshness values cannot silently become healthy output.
+- Source/check IDs are deterministic and not derived from client input.
+- Tests cover allowed vocabulary and invalid-value degradation/rejection.
+
+Verify:
+```bash
+python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py
+PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q
+npm run verify:health-dashboard-server-only
+npm run verify:perimeter-policy
+git diff --check
+```
+
+Review:
+- Chopper + Franky recommended because this becomes the safety contract for live host sources.
+
+### Phase 15.2b — Registry normalization and unsafe-field rejection
+
+Scope:
+- Introduce a small backend-owned source registry/normalizer for records supplied by future adapters.
+- Model absent, unreadable and unregistered source states explicitly as `not_configured`, `unknown` or `stale`, never `pass`.
+- Add tests that malicious/raw adapter-like input cannot leak fields such as:
+  - client-provided `path`, `url`, `method`;
+  - `stdout`, `stderr`, `raw_output`, `command`;
+  - `pid`, `unit_content`, `journal`;
+  - `backup_path`, `included_path`;
+  - `prompt_body`, `chat_id`, `token`, `.env`.
+
+Out of scope:
+- Real source adapters.
+- Calling subprocess, shell, systemd, GitHub API or filesystem globbing.
+- Deciding final thresholds if not needed by the normalizer API.
+
+DoD:
+- Registry output serializes only allowlisted Healthcheck fields.
+- Unknown/raw fields are dropped or rejected before API serialization.
+- Missing/unreadable/unregistered sources are visible as degraded/not-configured states.
+- Tests prove unsafe inputs do not appear in nested API/service output.
+
+Verify:
+```bash
+python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py
+PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q
+npm run verify:health-dashboard-server-only
+npm run verify:perimeter-policy
+git diff --check
+```
+
+Review:
+- Chopper mandatory.
+- Franky recommended.
+
+### Phase 15.2c — Guardrails, manifest ownership and freshness policy
+
+Scope:
+- Add a static guardrail or registry test that blocks generic host adapters in Healthcheck until explicitly reviewed.
+- Block suspicious patterns outside reviewed allowlisted files, for example `command`, `shell`, `exec`, `subprocess` and generic URL fetch usage in Healthcheck source code.
+- Document manifest ownership and safe locations before live adapters:
+  - vault sync status manifest/wrapper: Franky-owned operational source;
+  - backup status manifest/wrapper: Franky-owned operational source;
+  - cronjobs status manifest/registry: Franky-owned shared source, not inferred from Zoro profile-local `cronjob list`.
+- Define initial freshness thresholds by family before rendering pass/warn/fail in live adapters.
+- Wire the guardrail into package scripts if it is static and cheap.
+
+Out of scope:
+- Reading those manifests.
+- Implementing thresholds against live data.
+- Changing Dashboard aggregation beyond compatibility needs.
+
+DoD:
+- There is a reproducible guardrail command or test preventing accidental generic host-console growth.
+- Docs state owner, safe location class and sensitivity exclusions for each manifest family.
+- Freshness thresholds exist for vault sync, backup, cronjobs and gateways before Phase 15.3+ live reads.
+- `docs/api-modules.md` and/or a dedicated Healthcheck source doc reflect the policy.
+
+Verify:
+```bash
+python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py
+PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q
+npm run verify:health-dashboard-server-only
+npm run verify:perimeter-policy
+npm run verify:healthcheck-source-policy
+git diff --check
+```
+
+Review:
+- Franky mandatory for source ownership/runtime feasibility.
+- Chopper mandatory for guardrail and leakage risk.
+
+## Why not one Phase 15.2 PR
+A single PR would be technically possible, but worse operationally:
+
+1. The diff would mix domain model changes, safety semantics, guardrails and docs policy.
+2. Reviewers would have to validate both code-level leakage controls and ops ownership decisions at once.
+3. TDD would become less crisp: failures in vocabulary, normalizer semantics or guardrail scanning would be harder to isolate.
+4. Later live-source phases depend on the contract being stable; smaller subphases reduce rollback risk.
+
+## Numbering policy
+Keep the already-planned live-adapter phases stable:
+
+- 15.2a / 15.2b / 15.2c close the contracts/registry foundation.
+- 15.3 remains vault sync + local backup adapters.
+- 15.4 remains project health adapter.
+- 15.5 remains Hermes gateway adapters.
+- 15.6 remains cronjobs health adapter.
+- 15.7 remains integration smoke/canon refresh.
+
+## Recommended next action
+Start implementation with **Phase 15.2a** only. Do not touch manifests, shell/systemd/Git, cronjobs or live source reads in 15.2a.

--- a/openspec/phase-15-2-split-planning-verify-checklist.md
+++ b/openspec/phase-15-2-split-planning-verify-checklist.md
@@ -18,7 +18,8 @@
 
 ## Safety checks included in the plan
 - [x] Client-provided `path`, `url`, `method` must be rejected/ignored before serialization.
-- [x] Raw/sensitive fields must not serialize: `stdout`, `stderr`, `raw_output`, `command`, `pid`, `unit_content`, `journal`, `backup_path`, `included_path`, `prompt_body`, `chat_id`, `token`, `.env`.
+- [x] Raw/sensitive fields must not serialize: `stdout`, `stderr`, `raw_output`, `command`, `traceback`, `pid`, `unit_content`, `journal`, absolute host paths, `backup_path`, `included_path`, `prompt_body`, `chat_id`, delivery targets, `token`, cookies, credentials, `.env`, Git diffs, untracked file lists or internal remote details.
+- [x] Source/check IDs must come only from backend-owned allowlists, never client input or dynamically discovered host/service names.
 - [x] Missing/unreadable/unregistered sources must map to `not_configured`, `unknown` or `stale`, never healthy.
 - [x] Generic host adapters must be blocked unless explicitly reviewed.
 - [x] Manifest ownership/location and freshness thresholds remain required before live adapters.

--- a/openspec/phase-15-2-split-planning-verify-checklist.md
+++ b/openspec/phase-15-2-split-planning-verify-checklist.md
@@ -1,0 +1,31 @@
+# Phase 15.2 split planning verify checklist
+
+## Context checked
+- [x] `git status --short --branch` from repo root.
+- [x] Recent Git history through merged Phase 15.1 PR #29.
+- [x] Merged `openspec/phase-15-1-healthcheck-real-sources-plan.md`.
+- [x] `.engram/phase-15-1-planning-closeout.md` reviewer follow-ups.
+- [x] Current Healthcheck backend domain/service code.
+- [x] Current Healthcheck/Dashboard backend tests.
+- [x] Relevant docs: `docs/api-modules.md`, `docs/read-models.md`.
+
+## Decision checks
+- [x] Phase 15.2 was evaluated against current code and reviewer follow-ups, not only memory.
+- [x] Decision is explicit: split Phase 15.2 into 15.2a, 15.2b and 15.2c.
+- [x] Split avoids live host reads in all 15.2 subphases.
+- [x] Existing Phase 15.3+ numbering remains stable.
+- [x] Chopper + Franky review need is preserved for the sensitive foundation.
+
+## Safety checks included in the plan
+- [x] Client-provided `path`, `url`, `method` must be rejected/ignored before serialization.
+- [x] Raw/sensitive fields must not serialize: `stdout`, `stderr`, `raw_output`, `command`, `pid`, `unit_content`, `journal`, `backup_path`, `included_path`, `prompt_body`, `chat_id`, `token`, `.env`.
+- [x] Missing/unreadable/unregistered sources must map to `not_configured`, `unknown` or `stale`, never healthy.
+- [x] Generic host adapters must be blocked unless explicitly reviewed.
+- [x] Manifest ownership/location and freshness thresholds remain required before live adapters.
+
+## Verification run for this planning split
+- [x] `git diff --check`
+
+## Not run
+- [ ] Backend/web test suite — not required for planning-only docs, no runtime code changed.
+- [ ] Browser visual smoke — not required, no UI changed.


### PR DESCRIPTION
## Summary
- Decides Phase 15.2 should be split before implementation.
- Adds OpenSpec split plan, planning verify checklist and Engram closeout.
- Keeps Phase 15.3+ numbering stable and defines 15.2a/15.2b/15.2c.

## Why
The merged Phase 15.1 plan made Phase 15.2 the safety foundation before live Healthcheck sources. Re-reading current code and Franky/Chopper follow-ups shows the scope still mixes contracts, registry semantics, unsafe-field rejection, guardrails, manifest ownership and freshness thresholds. Splitting reduces review and rollback risk before any host-adjacent source work.

## Verification
- git diff --check

Runtime tests not run: planning/docs-only change, no runtime code changed.

## Review requested
- Franky: operational feasibility and source ownership/freshness split.
- Chopper: security boundary, leakage guardrails and unsafe-field rejection split.
