### PR TITLE
feat: add health source vocabulary

### DIFF
--- a/.engram/phase-15-2a-implementation-closeout.md
+++ b/.engram/phase-15-2a-implementation-closeout.md
@@ -1,0 +1,27 @@
+# Phase 15.2a implementation closeout
+
+## Status
+Implemented on branch `zoro/phase-15-2a-health-source-vocabulary`.
+
+## What changed
+- Healthcheck domain now owns the Phase 15 source-family vocabulary and stable `check_id` mapping.
+- Healthcheck service validates source IDs, status, severity and freshness states before serializing module/signal output.
+- Signal IDs now resolve through the backend allowlist instead of `f'{module_id}-safe-signal'`.
+- Fixture-backed Healthcheck records were realigned to the Phase 15 families without adding live reads.
+- Tests cover allowed vocabulary, invalid-value rejection and dynamic/path-like source ID rejection.
+- `docs/read-models.md` and `docs/api-modules.md` document the vocabulary and no-live-read boundary.
+
+## Boundary preserved
+Phase 15.2a does not read manifests, filesystem, Git/GitHub, systemd, cronjobs, shell, Docker, subprocess or host logs. Phase 15.2b remains responsible for unsafe-field normalization/rejection from adapter-like payloads. Phase 15.2c remains responsible for anti host-console guardrails, manifest ownership/location and freshness thresholds.
+
+## Verification
+- `python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py`
+- `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q`
+- `npm run verify:health-dashboard-server-only`
+- `npm run verify:perimeter-policy`
+- `git diff --check`
+
+## Review routing
+PR should request Franky + Chopper:
+- Franky: source-family naming, operational feasibility and no accidental live adapter behavior.
+- Chopper: allowlist semantics, no dynamic ID derivation and no widened host/data exposure.

--- a/apps/api/src/modules/healthcheck/domain.py
+++ b/apps/api/src/modules/healthcheck/domain.py
@@ -2,6 +2,65 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+HEALTHCHECK_STATUS_VALUES: tuple[str, ...] = ('pass', 'warn', 'fail', 'stale', 'not_configured', 'unknown')
+HEALTHCHECK_SEVERITY_VALUES: tuple[str, ...] = ('low', 'medium', 'high', 'critical', 'unknown')
+HEALTHCHECK_FRESHNESS_STATES: tuple[str, ...] = ('fresh', 'stale', 'unknown')
+
+MUGIWARA_GATEWAY_SOURCE_IDS: tuple[str, ...] = (
+    'gateway.luffy',
+    'gateway.zoro',
+    'gateway.nami',
+    'gateway.usopp',
+    'gateway.sanji',
+    'gateway.chopper',
+    'gateway.robin',
+    'gateway.franky',
+    'gateway.brook',
+    'gateway.jinbe',
+)
+
+HEALTHCHECK_SOURCE_FAMILY_IDS: tuple[str, ...] = (
+    'vault-sync',
+    'project-health',
+    'backup-health',
+    'hermes-gateways',
+    *MUGIWARA_GATEWAY_SOURCE_IDS,
+    'cronjobs',
+)
+
+HEALTHCHECK_CHECK_ID_BY_SOURCE_ID: dict[str, str] = {
+    'vault-sync': 'vault-sync.last-sync',
+    'project-health': 'project-health.workspace',
+    'backup-health': 'backup-health.last-backup',
+    'hermes-gateways': 'hermes-gateways.global',
+    **{source_id: f'{source_id}.process' for source_id in MUGIWARA_GATEWAY_SOURCE_IDS},
+    'cronjobs': 'cronjobs.registry',
+}
+
+HEALTHCHECK_CHECK_IDS: tuple[str, ...] = tuple(HEALTHCHECK_CHECK_ID_BY_SOURCE_ID.values())
+
+
+def validate_healthcheck_status(status: str) -> None:
+    if status not in HEALTHCHECK_STATUS_VALUES:
+        raise ValueError(f'Unsupported healthcheck status: {status}')
+
+
+def validate_healthcheck_severity(severity: str) -> None:
+    if severity not in HEALTHCHECK_SEVERITY_VALUES:
+        raise ValueError(f'Unsupported healthcheck severity: {severity}')
+
+
+def validate_healthcheck_freshness_state(state: str) -> None:
+    if state not in HEALTHCHECK_FRESHNESS_STATES:
+        raise ValueError(f'Unsupported healthcheck freshness state: {state}')
+
+
+def resolve_healthcheck_check_id(source_id: str) -> str:
+    try:
+        return HEALTHCHECK_CHECK_ID_BY_SOURCE_ID[source_id]
+    except KeyError as exc:
+        raise ValueError(f'Unsupported healthcheck source id: {source_id}') from exc
+
 
 @dataclass(frozen=True)
 class HealthcheckFreshness:

--- a/apps/api/src/modules/healthcheck/service.py
+++ b/apps/api/src/modules/healthcheck/service.py
@@ -10,22 +10,26 @@ from .domain import (
     HealthcheckRecord,
     HealthcheckSummaryBar,
     HealthcheckSummaryItem,
+    resolve_healthcheck_check_id,
+    validate_healthcheck_freshness_state,
+    validate_healthcheck_severity,
+    validate_healthcheck_status,
 )
 
 SAFE_HEALTHCHECK_RECORDS: tuple[HealthcheckRecord, ...] = (
     HealthcheckRecord('cronjobs', 'Cronjobs', 'warn', 'medium', '2026-04-24T07:41:00Z', 'La revisión nocturna ejecutó, pero queda una advertencia operativa menor en skills del job.', 'Quedan referencias de skills a normalizar.', 'Cron safe summary', 'Actualizado hace 5 min'),
-    HealthcheckRecord('backups', 'Backups', 'pass', 'low', '2026-04-24T07:35:00Z', 'Último backup local completado y checksum disponible.', 'Sin alerta activa.', 'Backup safe summary', 'Actualizado hace 11 min'),
-    HealthcheckRecord('gateways', 'Gateways', 'warn', 'medium', '2026-04-24T07:44:00Z', 'Latencia por encima del umbral recomendado en la puerta principal.', 'Latencia por encima del umbral recomendado.', 'Gateway safe summary', 'Actualizado hace 2 min'),
-    HealthcheckRecord('honcho', 'Honcho', 'stale', 'medium', '2026-04-24T07:22:00Z', 'Parte del contexto relacional está disponible, pero algunos resúmenes necesitan refresco.', 'Resumen relacional pendiente de refresco.', 'Honcho safe summary', 'Actualizado hace 24 min'),
-    HealthcheckRecord('docker', 'Docker', 'pass', 'low', '2026-04-24T07:32:00Z', 'Servicios contenedorizados sin incidencias visibles en este corte.', 'Sin alerta activa.', 'Docker safe summary', 'Actualizado hace 14 min'),
-    HealthcheckRecord('system', 'System', 'fail', 'high', '2026-04-24T07:39:00Z', 'Se detectó una incidencia abierta de capacidad que requiere revisión prioritaria.', 'Incidencia de capacidad marcada para revisión.', 'System safe summary', 'Actualizado hace 7 min'),
+    HealthcheckRecord('backup-health', 'Backups', 'pass', 'low', '2026-04-24T07:35:00Z', 'Último backup local completado y checksum disponible.', 'Sin alerta activa.', 'Backup safe summary', 'Actualizado hace 11 min'),
+    HealthcheckRecord('hermes-gateways', 'Gateways', 'warn', 'medium', '2026-04-24T07:44:00Z', 'Latencia por encima del umbral recomendado en la puerta principal.', 'Latencia por encima del umbral recomendado.', 'Gateway safe summary', 'Actualizado hace 2 min'),
+    HealthcheckRecord('vault-sync', 'Vault sync', 'stale', 'medium', '2026-04-24T07:22:00Z', 'Parte del estado documental está disponible, pero algunos resúmenes necesitan refresco.', 'Resumen documental pendiente de refresco.', 'Vault sync safe summary', 'Actualizado hace 24 min'),
+    HealthcheckRecord('project-health', 'Project health', 'pass', 'low', '2026-04-24T07:32:00Z', 'Workspace de proyecto sin incidencias visibles en este corte.', 'Sin alerta activa.', 'Project safe summary', 'Actualizado hace 14 min'),
+    HealthcheckRecord('gateway.zoro', 'Zoro gateway', 'fail', 'high', '2026-04-24T07:39:00Z', 'Se detectó una incidencia abierta de capacidad que requiere revisión prioritaria.', 'Incidencia de capacidad marcada para revisión.', 'Gateway safe summary', 'Actualizado hace 7 min'),
 )
 
 SAFE_EVENTS: tuple[HealthcheckEvent, ...] = (
     HealthcheckEvent('evt-cron-nightly', 'cronjobs', 'warn', '2026-04-24T01:33:40+02:00', 'Ejecución nocturna completada con advertencia saneada pendiente de revisión.'),
-    HealthcheckEvent('evt-gateway-latency', 'gateways', 'warn', '2026-04-24T07:44:00Z', 'Latencia sostenida por encima del umbral objetivo durante la última ventana de observación.'),
-    HealthcheckEvent('evt-system-capacity', 'system', 'fail', '2026-04-24T07:39:00Z', 'Capacidad degradada en un componente operativo; se ha marcado como incidencia para revisión.'),
-    HealthcheckEvent('evt-backup-checksum', 'backups', 'pass', '2026-04-24T07:35:00Z', 'Backup reciente validado con checksum sin desviaciones visibles.'),
+    HealthcheckEvent('evt-gateway-latency', 'hermes-gateways', 'warn', '2026-04-24T07:44:00Z', 'Latencia sostenida por encima del umbral objetivo durante la última ventana de observación.'),
+    HealthcheckEvent('evt-zoro-gateway-capacity', 'gateway.zoro', 'fail', '2026-04-24T07:39:00Z', 'Capacidad degradada en un componente operativo; se ha marcado como incidencia para revisión.'),
+    HealthcheckEvent('evt-backup-checksum', 'backup-health', 'pass', '2026-04-24T07:35:00Z', 'Backup reciente validado con checksum sin desviaciones visibles.'),
 )
 
 SAFE_PRINCIPLES: tuple[str, ...] = (
@@ -36,13 +40,20 @@ SAFE_PRINCIPLES: tuple[str, ...] = (
     'Sin shell remoto',
 )
 
-_STATUS_ORDER = {'fail': 4, 'warn': 3, 'stale': 2, 'pass': 1}
+_STATUS_ORDER = {'fail': 5, 'warn': 4, 'stale': 3, 'unknown': 2, 'not_configured': 2, 'pass': 1}
 
 
 class HealthcheckService:
-    def __init__(self, *, records: tuple[HealthcheckRecord, ...] = SAFE_HEALTHCHECK_RECORDS, events: tuple[HealthcheckEvent, ...] = SAFE_EVENTS) -> None:
+    def __init__(
+        self,
+        *,
+        records: tuple[HealthcheckRecord, ...] = SAFE_HEALTHCHECK_RECORDS,
+        events: tuple[HealthcheckEvent, ...] = SAFE_EVENTS,
+        freshness_state_by_module: dict[str, str] | None = None,
+    ) -> None:
         self._records = records
         self._events = events
+        self._freshness_state_by_module = freshness_state_by_module or {}
 
     def workspace_status(self) -> str:
         return 'ready' if self._records else 'not_configured'
@@ -64,7 +75,7 @@ class HealthcheckService:
         if not modules:
             return HealthcheckSummaryBar('stale', 0, 0, 0, None)
         incidents = sum(1 for module in modules if module.status == 'fail')
-        warnings = sum(1 for module in modules if module.status in {'warn', 'stale'})
+        warnings = sum(1 for module in modules if module.status in {'warn', 'stale', 'unknown', 'not_configured'})
         overall = max(modules, key=lambda module: _STATUS_ORDER[module.status]).status
         updated_at = self._latest_updated_at(modules)
         return HealthcheckSummaryBar(overall, len(modules), warnings, incidents, updated_at)
@@ -80,18 +91,27 @@ class HealthcheckService:
         return latest[1] if latest else None
 
     def _to_module(self, record: HealthcheckRecord) -> HealthcheckModuleCard:
+        self._validate_record(record)
         return HealthcheckModuleCard(record.module_id, record.label, record.status, record.severity, record.updated_at, record.summary)
 
     def _to_signal(self, record: HealthcheckRecord) -> HealthcheckSummaryItem:
+        self._validate_record(record)
+        freshness_state = self._freshness_state_by_module.get(record.module_id, 'stale' if record.status == 'stale' else 'fresh')
+        validate_healthcheck_freshness_state(freshness_state)
         return HealthcheckSummaryItem(
-            check_id=f'{record.module_id}-safe-signal',
+            check_id=resolve_healthcheck_check_id(record.module_id),
             label=record.label,
             severity=record.severity,
             status=record.status,
-            freshness=HealthcheckFreshness(updated_at=record.updated_at, label=record.freshness_label, state='stale' if record.status == 'stale' else 'fresh'),
+            freshness=HealthcheckFreshness(updated_at=record.updated_at, label=record.freshness_label, state=freshness_state),
             warning_text=record.warning_text,
             source_label=record.source_label,
         )
+
+    def _validate_record(self, record: HealthcheckRecord) -> None:
+        resolve_healthcheck_check_id(record.module_id)
+        validate_healthcheck_status(record.status)
+        validate_healthcheck_severity(record.severity)
 
 
 def _parse_timestamp(value: str) -> datetime | None:

--- a/apps/api/tests/test_healthcheck_dashboard_api.py
+++ b/apps/api/tests/test_healthcheck_dashboard_api.py
@@ -1,7 +1,16 @@
 from fastapi.testclient import TestClient
 
 from apps.api.src.main import app
-from apps.api.src.modules.healthcheck.domain import HealthcheckRecord
+import pytest
+
+from apps.api.src.modules.healthcheck.domain import (
+    HEALTHCHECK_CHECK_IDS,
+    HEALTHCHECK_FRESHNESS_STATES,
+    HEALTHCHECK_SEVERITY_VALUES,
+    HEALTHCHECK_SOURCE_FAMILY_IDS,
+    HEALTHCHECK_STATUS_VALUES,
+    HealthcheckRecord,
+)
 from apps.api.src.modules.healthcheck.service import HealthcheckService
 from apps.api.src.modules.dashboard.service import DashboardService
 
@@ -34,6 +43,70 @@ def _assert_no_sensitive_host_output(value):
     elif isinstance(value, str):
         lowered = value.lower()
         assert all(term not in lowered for term in forbidden)
+
+
+def test_healthcheck_contract_vocabulary_is_backend_owned():
+    assert set(HEALTHCHECK_STATUS_VALUES) == {'pass', 'warn', 'fail', 'stale', 'not_configured', 'unknown'}
+    assert set(HEALTHCHECK_SEVERITY_VALUES) == {'low', 'medium', 'high', 'critical', 'unknown'}
+    assert set(HEALTHCHECK_FRESHNESS_STATES) == {'fresh', 'stale', 'unknown'}
+    assert set(HEALTHCHECK_SOURCE_FAMILY_IDS) == {
+        'vault-sync',
+        'project-health',
+        'backup-health',
+        'hermes-gateways',
+        'gateway.luffy',
+        'gateway.zoro',
+        'gateway.nami',
+        'gateway.usopp',
+        'gateway.sanji',
+        'gateway.chopper',
+        'gateway.robin',
+        'gateway.franky',
+        'gateway.brook',
+        'gateway.jinbe',
+        'cronjobs',
+    }
+    assert set(HEALTHCHECK_CHECK_IDS) == {
+        'vault-sync.last-sync',
+        'project-health.workspace',
+        'backup-health.last-backup',
+        'hermes-gateways.global',
+        'gateway.luffy.process',
+        'gateway.zoro.process',
+        'gateway.nami.process',
+        'gateway.usopp.process',
+        'gateway.sanji.process',
+        'gateway.chopper.process',
+        'gateway.robin.process',
+        'gateway.franky.process',
+        'gateway.brook.process',
+        'gateway.jinbe.process',
+        'cronjobs.registry',
+    }
+
+
+def test_healthcheck_rejects_invalid_status_severity_and_freshness():
+    valid_record = _record('cronjobs', 'Cronjobs', 'warn', 'medium', '2026-04-24T07:41:00Z')
+    with pytest.raises(ValueError, match='Unsupported healthcheck status'):
+        HealthcheckService(records=(valid_record, _record('backup-health', 'Backups', 'healthy', 'low', '2026-04-24T07:35:00Z'))).get_workspace()
+    with pytest.raises(ValueError, match='Unsupported healthcheck severity'):
+        HealthcheckService(records=(valid_record, _record('backup-health', 'Backups', 'pass', 'minor', '2026-04-24T07:35:00Z'))).get_workspace()
+    with pytest.raises(ValueError, match='Unsupported healthcheck freshness state'):
+        HealthcheckService(records=(valid_record,), freshness_state_by_module={'cronjobs': 'current'}).get_workspace()
+
+
+def test_healthcheck_signal_check_ids_do_not_derive_from_client_or_dynamic_input():
+    payload = HealthcheckService(
+        records=(
+            _record('cronjobs', 'Cronjobs', 'warn', 'medium', '2026-04-24T07:41:00Z'),
+            _record('gateway.zoro', 'Zoro gateway', 'warn', 'medium', '2026-04-24T07:44:00Z'),
+        )
+    ).get_workspace()
+
+    assert {signal['check_id'] for signal in payload['signals']} == {'cronjobs.registry', 'gateway.zoro.process'}
+
+    with pytest.raises(ValueError, match='Unsupported healthcheck source id'):
+        HealthcheckService(records=(_record('gateway../../etc/passwd', 'Injected gateway', 'warn', 'high', '2026-04-24T07:44:00Z'),)).get_workspace()
 
 
 def test_healthcheck_returns_sanitized_workspace():
@@ -81,8 +154,8 @@ def test_healthcheck_uses_explicit_timestamp_parsing_for_latest_update():
     service = HealthcheckService(
         records=(
             # Lexically larger, but older once the +02:00 offset is parsed.
-            _record('local-offset', 'Local offset', 'warn', 'medium', '2026-04-24T09:00:00+02:00'),
-            _record('utc-latest', 'UTC latest', 'pass', 'low', '2026-04-24T07:30:00Z'),
+            _record('cronjobs', 'Local offset', 'warn', 'medium', '2026-04-24T09:00:00+02:00'),
+            _record('backup-health', 'UTC latest', 'pass', 'low', '2026-04-24T07:30:00Z'),
         )
     )
 
@@ -92,8 +165,8 @@ def test_healthcheck_uses_explicit_timestamp_parsing_for_latest_update():
 def test_healthcheck_invalid_timestamp_does_not_win_freshness_aggregation():
     service = HealthcheckService(
         records=(
-            _record('bad-clock', 'Bad clock', 'warn', 'medium', 'not-a-timestamp'),
-            _record('valid-clock', 'Valid clock', 'pass', 'low', '2026-04-24T07:30:00Z'),
+            _record('cronjobs', 'Bad clock', 'warn', 'medium', 'not-a-timestamp'),
+            _record('backup-health', 'Valid clock', 'pass', 'low', '2026-04-24T07:30:00Z'),
         )
     )
 
@@ -103,8 +176,8 @@ def test_healthcheck_invalid_timestamp_does_not_win_freshness_aggregation():
 def test_healthcheck_naive_timestamp_is_normalized_for_safe_comparison():
     service = HealthcheckService(
         records=(
-            _record('naive-clock', 'Naive clock', 'warn', 'medium', '2026-04-24T07:45:00'),
-            _record('aware-clock', 'Aware clock', 'pass', 'low', '2026-04-24T07:30:00Z'),
+            _record('cronjobs', 'Naive clock', 'warn', 'medium', '2026-04-24T07:45:00'),
+            _record('backup-health', 'Aware clock', 'pass', 'low', '2026-04-24T07:30:00Z'),
         )
     )
 
@@ -145,8 +218,8 @@ def test_dashboard_handles_unavailable_health_source_explicitly():
 def test_dashboard_uses_record_severity_for_critical_aggregation():
     healthcheck = HealthcheckService(
         records=(
-            _record('critical-warning', 'Critical warning', 'warn', 'critical', '2026-04-24T07:30:00Z'),
-            _record('failed-high', 'Failed high', 'fail', 'high', '2026-04-24T07:20:00Z'),
+            _record('cronjobs', 'Critical warning', 'warn', 'critical', '2026-04-24T07:30:00Z'),
+            _record('backup-health', 'Failed high', 'fail', 'high', '2026-04-24T07:20:00Z'),
         )
     )
     dashboard = DashboardService(healthcheck_service=healthcheck)

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -41,10 +41,11 @@
 
 ### `healthcheck`
 - exponer `GET /api/v1/healthcheck` como workspace read-only saneado
-- resumir cronjobs, backups, gateways, honcho, docker y checks operativos desde catálogo seguro backend-owned
+- resumir `vault-sync`, `project-health`, `backup-health`, `hermes-gateways`, `gateway.<mugiwara-slug>` y `cronjobs` desde catálogo seguro backend-owned
+- mantener vocabulario allowlisted de `status`, `severity`, `freshness.state`, source IDs y check IDs en el dominio backend
 - consumir solo fuentes saneadas y timestamps de frescura
 - no ejecutar shell, Docker, systemd ni leer logs/salidas crudas del host en esta fase
-- representar `stale`/`not_configured` de forma explícita
+- representar `stale`/`not_configured`/`unknown` de forma explícita
 
 ### `dashboard`
 - exponer `GET /api/v1/dashboard` como agregación read-only para la home operativa

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -46,6 +46,24 @@ Uso:
 - panorama de checks saneados
 - drilldown controlado sin exponer salidas crudas
 
+#### Vocabulario backend-owned de fuentes Healthcheck
+Phase 15.2a fija el vocabulario de contratos antes de conectar fuentes vivas. Los IDs de fuente y `check_id` salen de allowlists del backend, nunca de input cliente, paths descubiertos ni servicios detectados dinámicamente.
+
+Estados permitidos:
+- `status`: `pass`, `warn`, `fail`, `stale`, `not_configured`, `unknown`
+- `severity`: `low`, `medium`, `high`, `critical`, `unknown`
+- `freshness.state`: `fresh`, `stale`, `unknown`
+
+Familias/fuentes estables para el bloque Phase 15:
+- `vault-sync` -> `vault-sync.last-sync`
+- `project-health` -> `project-health.workspace`
+- `backup-health` -> `backup-health.last-backup`
+- `hermes-gateways` -> `hermes-gateways.global`
+- `gateway.<mugiwara-slug>` -> `gateway.<mugiwara-slug>.process`, para `luffy`, `zoro`, `nami`, `usopp`, `sanji`, `chopper`, `robin`, `franky`, `brook`, `jinbe`
+- `cronjobs` -> `cronjobs.registry`
+
+Phase 15.2a no añade lecturas vivas: no lee manifiestos, filesystem, Git/GitHub, systemd ni cronjobs reales. La compatibilidad actual se mantiene como catálogo saneado fixture-backed con IDs ya alineados a este vocabulario.
+
 ### `memory.agent_summary`
 Campos esperados:
 - `mugiwara_slug`

--- a/openspec/phase-15-2a-health-source-vocabulary.md
+++ b/openspec/phase-15-2a-health-source-vocabulary.md
@@ -1,0 +1,46 @@
+# Phase 15.2a — Health source vocabulary and stable IDs
+
+## Goal
+Close the first implementation slice of the Phase 15.2 Healthcheck foundation by moving source-family vocabulary, status/severity/freshness values and signal `check_id` resolution into backend-owned allowlists.
+
+## Scope delivered
+- Added backend-owned Healthcheck source family IDs for:
+  - `vault-sync`
+  - `project-health`
+  - `backup-health`
+  - `hermes-gateways`
+  - `gateway.<mugiwara-slug>` for all current Mugiwara slugs
+  - `cronjobs`
+- Added stable `check_id` mapping for the Phase 15 source families.
+- Added allowed vocabularies for:
+  - status: `pass`, `warn`, `fail`, `stale`, `not_configured`, `unknown`
+  - severity: `low`, `medium`, `high`, `critical`, `unknown`
+  - freshness state: `fresh`, `stale`, `unknown`
+- Changed Healthcheck signal generation so `check_id` is resolved from the backend allowlist rather than derived from arbitrary record IDs.
+- Kept current output shape compatible: `/api/v1/healthcheck` still returns `summary_bar`, `modules`, `events`, `principles` and `signals`; `/api/v1/dashboard` continues aggregating the same safe shape.
+- Updated docs with the Phase 15.2a vocabulary.
+
+## Explicitly out of scope
+- No manifest reads.
+- No filesystem reads.
+- No Git/GitHub queries.
+- No systemd, shell, Docker or subprocess access.
+- No cronjob runtime visibility.
+- No UI layout change.
+- No unsafe raw-field normalizer yet; that remains Phase 15.2b.
+- No host-console guardrail/freshness thresholds yet; that remains Phase 15.2c.
+
+## TDD notes
+Added tests first for:
+- backend-owned vocabulary constants;
+- invalid status/severity/freshness rejection;
+- stable signal `check_id` allowlist resolution;
+- rejection of dynamic/path-like source IDs.
+
+The first targeted run failed on missing constants, then the implementation made the suite pass.
+
+## Security boundary
+This phase tightens contracts but does not broaden host visibility. The Healthcheck fixture catalog remains safe and public-repo compatible. Source IDs and check IDs are now explicit backend code, not client-provided strings, dynamic service discovery or filesystem-derived values.
+
+## Verify checklist
+See `openspec/phase-15-2a-verify-checklist.md`.

--- a/openspec/phase-15-2a-verify-checklist.md
+++ b/openspec/phase-15-2a-verify-checklist.md
@@ -1,0 +1,16 @@
+# Phase 15.2a verify checklist
+
+- [x] Branch created from current `main`: `zoro/phase-15-2a-health-source-vocabulary`.
+- [x] TDD red run observed: `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` failed on missing Phase 15.2a constants before implementation.
+- [x] Backend-owned source family vocabulary exists in `apps/api/src/modules/healthcheck/domain.py`.
+- [x] Stable `check_id` mapping exists in backend-owned code and Healthcheck signals use it.
+- [x] Invalid `status`, `severity` and `freshness.state` cannot silently become healthy output.
+- [x] Dynamic/path-like source IDs are rejected by service conversion.
+- [x] No live source reads added: no manifest, filesystem, Git/GitHub, systemd, cronjob runtime, shell, Docker or subprocess integration.
+- [x] `docs/read-models.md` documents the source-family vocabulary.
+- [x] `docs/api-modules.md` reflects the backend-owned Healthcheck vocabulary.
+- [x] `python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py`
+- [x] `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q`
+- [x] `npm run verify:health-dashboard-server-only`
+- [x] `npm run verify:perimeter-policy`
+- [x] `git diff --check`


### PR DESCRIPTION
## Summary
- Adds backend-owned Healthcheck source-family vocabulary for Phase 15.2a.
- Adds stable `check_id` mapping and uses it for Healthcheck signals instead of deriving IDs from arbitrary record IDs.
- Validates allowed `status`, `severity` and `freshness.state` values before serializing Healthcheck output.
- Realigns the fixture-backed safe catalog to the Phase 15 source family IDs without adding live reads.
- Updates OpenSpec, docs and Engram closeout.

## Scope boundaries
No live source reads were added. This PR does not read manifests, filesystem, Git/GitHub, systemd, cronjobs, shell, Docker, subprocess, host logs or raw outputs.

Still deferred:
- Phase 15.2b: registry normalizer and unsafe-field rejection for adapter-like payloads.
- Phase 15.2c: anti host-console guardrail, manifest ownership/location and freshness thresholds.

## Verification
- `python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py`
- `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` → 12 passed
- `npm run verify:health-dashboard-server-only`
- `npm run verify:perimeter-policy`
- `git diff --check`

## Review requested
Franky + Chopper requested.
- Franky: operational feasibility of source-family names and confirmation that no accidental live adapter behavior was introduced.
- Chopper: allowlist semantics, rejection of dynamic source IDs, and no widened host/data exposure.
