### PR TITLE
feat: add health source registry normalizer

### DIFF
--- a/.engram/phase-15-2b-implementation-closeout.md
+++ b/.engram/phase-15-2b-implementation-closeout.md
@@ -1,0 +1,26 @@
+# Phase 15.2b implementation closeout
+
+## Result
+Phase 15.2b added a backend-owned Healthcheck source registry/normalizer for future adapter-like records without adding any live host reads.
+
+## Key technical points
+- `apps/api/src/modules/healthcheck/registry.py` defines `HealthcheckSourceRegistry` and `HealthcheckSourceSnapshot`.
+- The registry validates source IDs through the existing backend-owned allowlist and copies only a minimal output field allowlist.
+- Unsafe/raw fields such as paths, URLs, commands, stdout/stderr, journals, prompts, chat IDs, credentials, cookies, `.env`, git diffs, untracked files and internal remotes are ignored before service serialization.
+- Absent/unreadable/unregistered source conditions are explicit degraded states (`not_configured` or `unknown`), never `pass`.
+- Unsupported source ID errors no longer echo the rejected value.
+
+## TDD/verify
+- Red run: `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` failed on missing `apps.api.src.modules.healthcheck.registry`.
+- Green verify:
+  - `python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/registry.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py`
+  - `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q`
+  - `npm run verify:health-dashboard-server-only`
+  - `npm run verify:perimeter-policy`
+  - `git diff --check`
+
+## Out of scope kept
+No manifests, filesystem reads, Git/GitHub queries, systemd, cronjob runtime, shell, Docker, subprocess, live adapters or final freshness threshold policy.
+
+## Next
+Phase 15.2c should add static guardrails, manifest ownership/location documentation and freshness thresholds before Phase 15.3 live-source work.

--- a/apps/api/src/modules/healthcheck/domain.py
+++ b/apps/api/src/modules/healthcheck/domain.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping
 
 HEALTHCHECK_STATUS_VALUES: tuple[str, ...] = ('pass', 'warn', 'fail', 'stale', 'not_configured', 'unknown')
 HEALTHCHECK_SEVERITY_VALUES: tuple[str, ...] = ('low', 'medium', 'high', 'critical', 'unknown')
@@ -39,6 +41,26 @@ HEALTHCHECK_CHECK_ID_BY_SOURCE_ID: dict[str, str] = {
 
 HEALTHCHECK_CHECK_IDS: tuple[str, ...] = tuple(HEALTHCHECK_CHECK_ID_BY_SOURCE_ID.values())
 
+HEALTHCHECK_SOURCE_LABELS: Mapping[str, str] = MappingProxyType(
+    {
+        'vault-sync': 'Vault sync',
+        'project-health': 'Project health',
+        'backup-health': 'Backups',
+        'hermes-gateways': 'Gateways',
+        'gateway.luffy': 'Luffy gateway',
+        'gateway.zoro': 'Zoro gateway',
+        'gateway.nami': 'Nami gateway',
+        'gateway.usopp': 'Usopp gateway',
+        'gateway.sanji': 'Sanji gateway',
+        'gateway.chopper': 'Chopper gateway',
+        'gateway.robin': 'Robin gateway',
+        'gateway.franky': 'Franky gateway',
+        'gateway.brook': 'Brook gateway',
+        'gateway.jinbe': 'Jinbe gateway',
+        'cronjobs': 'Cronjobs',
+    }
+)
+
 
 def validate_healthcheck_status(status: str) -> None:
     if status not in HEALTHCHECK_STATUS_VALUES:
@@ -59,7 +81,7 @@ def resolve_healthcheck_check_id(source_id: str) -> str:
     try:
         return HEALTHCHECK_CHECK_ID_BY_SOURCE_ID[source_id]
     except KeyError as exc:
-        raise ValueError(f'Unsupported healthcheck source id: {source_id}') from exc
+        raise ValueError('Unsupported healthcheck source id') from exc
 
 
 @dataclass(frozen=True)

--- a/apps/api/src/modules/healthcheck/registry.py
+++ b/apps/api/src/modules/healthcheck/registry.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from .domain import (
+    HEALTHCHECK_SOURCE_LABELS,
+    HealthcheckRecord,
+    resolve_healthcheck_check_id,
+    validate_healthcheck_freshness_state,
+    validate_healthcheck_severity,
+    validate_healthcheck_status,
+)
+
+_ALLOWED_SOURCE_FIELDS = frozenset(
+    {
+        'label',
+        'status',
+        'severity',
+        'updated_at',
+        'summary',
+        'warning_text',
+        'source_label',
+        'freshness_label',
+        'freshness_state',
+    }
+)
+
+
+@dataclass(frozen=True)
+class HealthcheckSourceSnapshot:
+    record: HealthcheckRecord
+    freshness_state: str
+
+
+class HealthcheckSourceRegistry:
+    """Backend-owned normalizer for future Healthcheck adapter records.
+
+    The registry only accepts stable source IDs from the Healthcheck allowlist and
+    copies a minimal field allowlist into the public read model. Unknown adapter
+    fields are intentionally ignored here so raw host values cannot reach API
+    serialization by accident.
+    """
+
+    def normalize(self, source_id: str, raw: Mapping[str, object] | None) -> HealthcheckSourceSnapshot:
+        self._validate_source_id(source_id)
+        if raw is None:
+            return self.normalize_absent(source_id)
+
+        allowed = {key: raw[key] for key in _ALLOWED_SOURCE_FIELDS if key in raw}
+        record = HealthcheckRecord(
+            module_id=source_id,
+            label=self._string_field(allowed, 'label', HEALTHCHECK_SOURCE_LABELS[source_id]),
+            status=self._string_field(allowed, 'status', 'unknown'),
+            severity=self._string_field(allowed, 'severity', 'unknown'),
+            updated_at=self._string_field(allowed, 'updated_at', ''),
+            summary=self._string_field(allowed, 'summary', 'Estado disponible con resumen saneado.'),
+            warning_text=self._string_field(allowed, 'warning_text', 'Estado degradado pendiente de revisión.'),
+            source_label=self._string_field(allowed, 'source_label', 'Healthcheck source registry'),
+            freshness_label=self._string_field(allowed, 'freshness_label', 'Frescura desconocida'),
+        )
+        validate_healthcheck_status(record.status)
+        validate_healthcheck_severity(record.severity)
+        freshness_state = self._string_field(allowed, 'freshness_state', 'unknown')
+        validate_healthcheck_freshness_state(freshness_state)
+        return HealthcheckSourceSnapshot(record=record, freshness_state=freshness_state)
+
+    def normalize_absent(self, source_id: str) -> HealthcheckSourceSnapshot:
+        return self._degraded_snapshot(
+            source_id,
+            status='not_configured',
+            severity='unknown',
+            summary='Fuente Healthcheck ausente o todavía no configurada.',
+            warning_text='Fuente no configurada.',
+            freshness_state='unknown',
+        )
+
+    def normalize_unreadable(self, source_id: str) -> HealthcheckSourceSnapshot:
+        return self._degraded_snapshot(
+            source_id,
+            status='unknown',
+            severity='unknown',
+            summary='Fuente Healthcheck no legible; no se expone salida cruda.',
+            warning_text='Fuente no legible.',
+            freshness_state='unknown',
+        )
+
+    def normalize_unregistered(self, source_id: str) -> HealthcheckSourceSnapshot:
+        return self._degraded_snapshot(
+            source_id,
+            status='not_configured',
+            severity='unknown',
+            summary='Fuente Healthcheck sin adaptador registrado.',
+            warning_text='Adaptador no registrado.',
+            freshness_state='unknown',
+        )
+
+    def _degraded_snapshot(
+        self,
+        source_id: str,
+        *,
+        status: str,
+        severity: str,
+        summary: str,
+        warning_text: str,
+        freshness_state: str,
+    ) -> HealthcheckSourceSnapshot:
+        self._validate_source_id(source_id)
+        return HealthcheckSourceSnapshot(
+            record=HealthcheckRecord(
+                module_id=source_id,
+                label=HEALTHCHECK_SOURCE_LABELS[source_id],
+                status=status,
+                severity=severity,
+                updated_at='',
+                summary=summary,
+                warning_text=warning_text,
+                source_label='Healthcheck source registry',
+                freshness_label='Frescura desconocida',
+            ),
+            freshness_state=freshness_state,
+        )
+
+    def _validate_source_id(self, source_id: str) -> None:
+        resolve_healthcheck_check_id(source_id)
+
+    def _string_field(self, values: Mapping[str, object], key: str, default: str) -> str:
+        value = values.get(key, default)
+        if isinstance(value, str):
+            return value
+        return default

--- a/apps/api/src/modules/healthcheck/service.py
+++ b/apps/api/src/modules/healthcheck/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import asdict
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from .domain import (
     HealthcheckEvent,
@@ -15,6 +16,9 @@ from .domain import (
     validate_healthcheck_severity,
     validate_healthcheck_status,
 )
+
+if TYPE_CHECKING:
+    from .registry import HealthcheckSourceSnapshot
 
 SAFE_HEALTHCHECK_RECORDS: tuple[HealthcheckRecord, ...] = (
     HealthcheckRecord('cronjobs', 'Cronjobs', 'warn', 'medium', '2026-04-24T07:41:00Z', 'La revisión nocturna ejecutó, pero queda una advertencia operativa menor en skills del job.', 'Quedan referencias de skills a normalizar.', 'Cron safe summary', 'Actualizado hace 5 min'),
@@ -55,12 +59,19 @@ class HealthcheckService:
         self._events = events
         self._freshness_state_by_module = freshness_state_by_module or {}
 
+    @classmethod
+    def from_source_snapshots(cls, snapshots: tuple['HealthcheckSourceSnapshot', ...]) -> 'HealthcheckService':
+        return cls(
+            records=tuple(snapshot.record for snapshot in snapshots),
+            freshness_state_by_module={snapshot.record.module_id: snapshot.freshness_state for snapshot in snapshots},
+        )
+
     def workspace_status(self) -> str:
         return 'ready' if self._records else 'not_configured'
 
     def get_workspace(self) -> dict:
         modules = [self._to_module(record) for record in self._records]
-        signals = [self._to_signal(record) for record in self._records if record.status in {'warn', 'stale', 'fail'}]
+        signals = [self._to_signal(record) for record in self._records if record.status in {'warn', 'stale', 'fail', 'unknown', 'not_configured'}]
         summary_bar = self._summary_bar(modules)
         events = self._events if self._records else ()
         return {

--- a/apps/api/tests/test_healthcheck_dashboard_api.py
+++ b/apps/api/tests/test_healthcheck_dashboard_api.py
@@ -11,6 +11,7 @@ from apps.api.src.modules.healthcheck.domain import (
     HEALTHCHECK_STATUS_VALUES,
     HealthcheckRecord,
 )
+from apps.api.src.modules.healthcheck.registry import HealthcheckSourceRegistry
 from apps.api.src.modules.healthcheck.service import HealthcheckService
 from apps.api.src.modules.dashboard.service import DashboardService
 
@@ -105,8 +106,91 @@ def test_healthcheck_signal_check_ids_do_not_derive_from_client_or_dynamic_input
 
     assert {signal['check_id'] for signal in payload['signals']} == {'cronjobs.registry', 'gateway.zoro.process'}
 
-    with pytest.raises(ValueError, match='Unsupported healthcheck source id'):
+    with pytest.raises(ValueError, match='Unsupported healthcheck source id') as exc_info:
         HealthcheckService(records=(_record('gateway../../etc/passwd', 'Injected gateway', 'warn', 'high', '2026-04-24T07:44:00Z'),)).get_workspace()
+    assert 'gateway../../etc/passwd' not in str(exc_info.value)
+
+
+def test_healthcheck_source_registry_normalizes_allowed_fields_only():
+    snapshot = HealthcheckSourceRegistry().normalize(
+        'cronjobs',
+        {
+            'label': 'Cronjobs',
+            'status': 'warn',
+            'severity': 'medium',
+            'updated_at': '2026-04-24T07:41:00Z',
+            'summary': 'Safe cron summary.',
+            'warning_text': 'Synthetic safe warning.',
+            'source_label': 'Cron safe summary',
+            'freshness_label': 'Actualizado hace 5 min',
+            'freshness_state': 'stale',
+            'path': '/srv/crew-core/private/.env',
+            'url': 'https://internal.example/redacted',
+            'method': 'POST',
+            'stdout': 'synthetic sensitive stdout',
+            'stderr': 'Traceback with /home/agentops/.env',
+            'raw_output': 'synthetic raw output',
+            'command': 'cat /srv/crew-core/.env',
+            'traceback': 'internal traceback',
+            'pid': 1234,
+            'unit_content': '[Service] Environment=SYNTHETIC_REDACTED',
+            'journal': 'journal raw logs',
+            'backup_path': '/srv/backups/private',
+            'included_path': '/home/agentops/private',
+            'prompt_body': 'synthetic prompt body',
+            'chat_id': 'synthetic-chat-id',
+            'delivery_target': 'telegram:synthetic-chat-id',
+            'cookie': 'synthetic-cookie',
+            'credentials': 'synthetic-credentials',
+            'git_diff': 'diff --git a/.env b/.env',
+            'untracked_files': ['.env'],
+            'remote_url': 'git@github.com:private/repo.git',
+        },
+    )
+
+    payload = HealthcheckService.from_source_snapshots((snapshot,)).get_workspace()
+
+    assert payload['modules'] == [
+        {
+            'module_id': 'cronjobs',
+            'label': 'Cronjobs',
+            'status': 'warn',
+            'severity': 'medium',
+            'updated_at': '2026-04-24T07:41:00Z',
+            'summary': 'Safe cron summary.',
+        }
+    ]
+    assert payload['signals'][0]['check_id'] == 'cronjobs.registry'
+    assert payload['signals'][0]['freshness']['state'] == 'stale'
+    _assert_no_sensitive_host_output(payload)
+
+
+def test_healthcheck_source_registry_models_absent_unreadable_and_unregistered_as_degraded():
+    registry = HealthcheckSourceRegistry()
+    service = HealthcheckService.from_source_snapshots(
+        (
+            registry.normalize_absent('vault-sync'),
+            registry.normalize_unreadable('backup-health'),
+            registry.normalize_unregistered('gateway.zoro'),
+        )
+    )
+
+    payload = service.get_workspace()
+
+    status_by_module = {module['module_id']: module['status'] for module in payload['modules']}
+    assert status_by_module == {
+        'vault-sync': 'not_configured',
+        'backup-health': 'unknown',
+        'gateway.zoro': 'not_configured',
+    }
+    assert payload['summary_bar']['overall_status'] != 'pass'
+    assert payload['summary_bar']['warnings'] == 3
+    assert {signal['check_id'] for signal in payload['signals']} == {
+        'vault-sync.last-sync',
+        'backup-health.last-backup',
+        'gateway.zoro.process',
+    }
+    _assert_no_sensitive_host_output(payload)
 
 
 def test_healthcheck_returns_sanitized_workspace():

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -43,6 +43,7 @@
 - exponer `GET /api/v1/healthcheck` como workspace read-only saneado
 - resumir `vault-sync`, `project-health`, `backup-health`, `hermes-gateways`, `gateway.<mugiwara-slug>` y `cronjobs` desde catálogo seguro backend-owned
 - mantener vocabulario allowlisted de `status`, `severity`, `freshness.state`, source IDs y check IDs en el dominio backend
+- normalizar payloads de adapters futuros con registro backend-owned allowlist-only antes de serializar; campos crudos o desconocidos se descartan y los source IDs rechazados no se ecoan
 - consumir solo fuentes saneadas y timestamps de frescura
 - no ejecutar shell, Docker, systemd ni leer logs/salidas crudas del host en esta fase
 - representar `stale`/`not_configured`/`unknown` de forma explícita

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -64,6 +64,8 @@ Familias/fuentes estables para el bloque Phase 15:
 
 Phase 15.2a no añade lecturas vivas: no lee manifiestos, filesystem, Git/GitHub, systemd ni cronjobs reales. La compatibilidad actual se mantiene como catálogo saneado fixture-backed con IDs ya alineados a este vocabulario.
 
+Phase 15.2b añade una normalización backend-owned previa a futuras fuentes vivas. Los adapters futuros entregarán payloads ya resumidos al registro de fuentes; el registro solo copia una allowlist mínima (`label`, `status`, `severity`, `updated_at`, `summary`, `warning_text`, `source_label`, `freshness_label`, `freshness_state`) y descarta campos desconocidos antes de que lleguen al modelo serializable. Ausencias, fuentes no legibles y adapters no registrados se representan como `not_configured` o `unknown`, nunca como `pass` silencioso. Los errores de source ID no deben ecoar el valor rechazado para evitar filtrar paths, comandos o nombres internos.
+
 ### `memory.agent_summary`
 Campos esperados:
 - `mugiwara_slug`

--- a/openspec/phase-15-2b-health-source-normalizer.md
+++ b/openspec/phase-15-2b-health-source-normalizer.md
@@ -1,0 +1,49 @@
+# Phase 15.2b — Health source registry normalization and unsafe-field rejection
+
+## Goal
+Close the second implementation slice of the Phase 15.2 Healthcheck foundation by adding a backend-owned source registry/normalizer before future live adapters exist.
+
+## Scope delivered
+- Added `HealthcheckSourceRegistry` in `apps/api/src/modules/healthcheck/registry.py`.
+- Added `HealthcheckSourceSnapshot` as the internal bridge between normalized adapter-like payloads and the existing `HealthcheckService` read model.
+- Added `HealthcheckService.from_source_snapshots(...)` so future adapters can feed normalized records without bypassing Healthcheck validation.
+- Ensured registry input copies only allowlisted fields:
+  - `label`
+  - `status`
+  - `severity`
+  - `updated_at`
+  - `summary`
+  - `warning_text`
+  - `source_label`
+  - `freshness_label`
+  - `freshness_state`
+- Dropped unknown/raw adapter-like fields before API/service serialization.
+- Modeled absent, unreadable and unregistered source conditions explicitly as degraded states:
+  - absent -> `not_configured`
+  - unreadable -> `unknown`
+  - unregistered -> `not_configured`
+- Changed unsupported Healthcheck source ID errors so they do not echo the rejected raw value.
+
+## Explicitly out of scope
+- No live source adapters.
+- No manifest reads.
+- No filesystem reads or globbing.
+- No Git/GitHub queries.
+- No systemd, shell, Docker or subprocess access.
+- No cronjob runtime visibility.
+- No final freshness threshold policy; that remains Phase 15.2c.
+
+## TDD notes
+Added tests first for:
+- missing `registry.py` import and registry normalizer API;
+- unsafe adapter-like fields not leaking into service/API-shaped output;
+- absent/unreadable/unregistered sources degrading visibly and never becoming `pass`;
+- unsupported source ID errors not echoing the rejected source value.
+
+The first targeted run failed on `ModuleNotFoundError: apps.api.src.modules.healthcheck.registry`, then implementation made the suite pass.
+
+## Security boundary
+This phase does not broaden host visibility. It only adds a deny-by-default normalization boundary for future adapters. Raw fields such as paths, URLs, commands, stdout/stderr, journals, prompts, chat IDs, credentials, cookies, `.env`, git diffs, untracked file lists and internal remote details are not part of the allowed output contract.
+
+## Verify checklist
+See `openspec/phase-15-2b-verify-checklist.md`.

--- a/openspec/phase-15-2b-verify-checklist.md
+++ b/openspec/phase-15-2b-verify-checklist.md
@@ -1,0 +1,17 @@
+# Phase 15.2b verify checklist
+
+- [x] Branch created from current `main`: `zoro/phase-15-2b-health-source-normalizer`.
+- [x] TDD red run observed: `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` failed on missing `apps.api.src.modules.healthcheck.registry` before implementation.
+- [x] Backend-owned Healthcheck source registry/normalizer exists in `apps/api/src/modules/healthcheck/registry.py`.
+- [x] Registry output serializes only allowlisted Healthcheck fields.
+- [x] Unsafe adapter-like fields are dropped before service/API-shaped output.
+- [x] Absent/unreadable/unregistered sources are represented as degraded `not_configured` or `unknown`, never `pass`.
+- [x] Unsupported source ID errors do not echo rejected raw values.
+- [x] No live source reads added: no manifest, filesystem, Git/GitHub, systemd, cronjob runtime, shell, Docker or subprocess integration.
+- [x] `docs/read-models.md` documents registry normalization semantics.
+- [x] `docs/api-modules.md` reflects the allowlist-only Healthcheck normalizer.
+- [x] `python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/registry.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py`
+- [x] `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q`
+- [x] `npm run verify:health-dashboard-server-only`
+- [x] `npm run verify:perimeter-policy`
+- [x] `git diff --check`


### PR DESCRIPTION
## Objetivo

Implementa Phase 15.2b de `mugiwara-control-panel`: registry normalization and unsafe-field rejection para Healthcheck antes de conectar fuentes vivas.

## Cambios

- Añade `HealthcheckSourceRegistry` y `HealthcheckSourceSnapshot` en `apps/api/src/modules/healthcheck/registry.py`.
- Añade `HealthcheckService.from_source_snapshots(...)` para consumir snapshots normalizados sin saltarse validación.
- Copia solo campos allowlisted desde payloads adapter-like futuros y descarta campos crudos/desconocidos antes de serializar.
- Modela fuentes ausentes/no legibles/no registradas como estados degradados (`not_configured` o `unknown`), nunca `pass`.
- Evita ecoar source IDs rechazados en errores `Unsupported healthcheck source id`.
- Actualiza tests, docs, OpenSpec y `.engram` de cierre.

## Fuera de alcance

- Sin adapters vivos.
- Sin lecturas de manifests, filesystem, Git/GitHub, systemd, cronjob runtime, shell, Docker ni subprocess.
- Sin política final de freshness thresholds; queda para 15.2c.

## Verificación de Zoro

- [x] TDD red: `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` falló por `ModuleNotFoundError: apps.api.src.modules.healthcheck.registry` antes de implementar.
- [x] `python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/registry.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py`
- [x] `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` → 14 passed
- [x] `npm run verify:health-dashboard-server-only`
- [x] `npm run verify:perimeter-policy`
- [x] `git diff --check`

## Riesgo y review solicitada

- **Chopper obligatorio**: revisar allowlist, rechazo/dropping de campos crudos, no eco de valores rechazados y superficie de fuga.
- **Franky recomendado**: revisar operabilidad futura del contrato para adapters y estados ausente/no legible/no registrado.
