### PR TITLE
feat: add healthcheck source policy guardrails

### DIFF
--- a/.engram/phase-15-2c-implementation-closeout.md
+++ b/.engram/phase-15-2c-implementation-closeout.md
@@ -1,0 +1,28 @@
+# Phase 15.2c implementation closeout
+
+## Result
+Phase 15.2c closes the Healthcheck source foundation before live adapters by adding static guardrails, manifest ownership policy and freshness thresholds.
+
+## Key technical points
+- `apps/api/src/modules/healthcheck/domain.py` now owns manifest policy and threshold constants for Phase 15 source families.
+- `scripts/check-healthcheck-source-policy.mjs` blocks generic host-console patterns in Healthcheck module source and verifies policy docs/scripts remain wired.
+- `docs/healthcheck-source-policy.md` defines owners, safe location classes, sensitivity exclusions and thresholds.
+- `package.json` exposes `npm run verify:healthcheck-source-policy`.
+- Existing Healthcheck registry normalizer from Phase 15.2b remains the only bridge for future adapter-like payloads.
+
+## TDD/verify
+- Red run: `npm run verify:healthcheck-source-policy` failed on missing `scripts/check-healthcheck-source-policy.mjs`.
+- Red run: `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` failed on missing policy constants.
+- Green verify:
+  - `python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/registry.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py`
+  - `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q`
+  - `npm run verify:health-dashboard-server-only`
+  - `npm run verify:perimeter-policy`
+  - `npm run verify:healthcheck-source-policy`
+  - `git diff --check`
+
+## Out of scope kept
+No manifests were read. No live adapters, filesystem discovery, Git/GitHub queries, systemd, cron runtime, shell, Docker, subprocess or threshold application against live data were added.
+
+## Next
+Open PR and request Franky + Chopper review. After merge, Phase 15.3 can start vault sync + local backup adapters using this policy boundary.

--- a/apps/api/src/modules/healthcheck/domain.py
+++ b/apps/api/src/modules/healthcheck/domain.py
@@ -41,6 +41,71 @@ HEALTHCHECK_CHECK_ID_BY_SOURCE_ID: dict[str, str] = {
 
 HEALTHCHECK_CHECK_IDS: tuple[str, ...] = tuple(HEALTHCHECK_CHECK_ID_BY_SOURCE_ID.values())
 
+_HEALTHCHECK_GATEWAY_FRESHNESS_THRESHOLD: Mapping[str, int] = MappingProxyType(
+    {'warn_after_minutes': 15, 'fail_after_minutes': 60}
+)
+
+HEALTHCHECK_SOURCE_FRESHNESS_THRESHOLDS: Mapping[str, Mapping[str, int]] = MappingProxyType(
+    {
+        'vault-sync': MappingProxyType({'warn_after_minutes': 90, 'fail_after_minutes': 360}),
+        'project-health': MappingProxyType({'warn_after_minutes': 120, 'fail_after_minutes': 480}),
+        'backup-health': MappingProxyType({'warn_after_minutes': 1800, 'fail_after_minutes': 4320}),
+        'hermes-gateways': _HEALTHCHECK_GATEWAY_FRESHNESS_THRESHOLD,
+        **{source_id: _HEALTHCHECK_GATEWAY_FRESHNESS_THRESHOLD for source_id in MUGIWARA_GATEWAY_SOURCE_IDS},
+        'cronjobs': MappingProxyType({'warn_after_minutes': 180, 'fail_after_minutes': 720}),
+    }
+)
+
+HEALTHCHECK_SOURCE_MANIFEST_POLICIES: Mapping[str, Mapping[str, str]] = MappingProxyType(
+    {
+        'vault-sync': MappingProxyType(
+            {
+                'owner': 'franky',
+                'safe_location_class': 'franky-owned-vault-sync-status-manifest',
+                'exclusions': 'raw logs, stdout, stderr, git diffs, credentials, absolute host paths',
+            }
+        ),
+        'project-health': MappingProxyType(
+            {
+                'owner': 'zoro',
+                'safe_location_class': 'repo-local-project-health-summary',
+                'exclusions': 'untracked file lists, internal remotes, git diffs, absolute host paths, credentials',
+            }
+        ),
+        'backup-health': MappingProxyType(
+            {
+                'owner': 'franky',
+                'safe_location_class': 'franky-owned-backup-status-manifest',
+                'exclusions': 'backup_path, included_path, raw logs, stdout, stderr, credentials, absolute host paths',
+            }
+        ),
+        'hermes-gateways': MappingProxyType(
+            {
+                'owner': 'franky',
+                'safe_location_class': 'systemd-user-gateway-status-summary',
+                'exclusions': 'unit_content, journal, pid, command lines, stdout, stderr, environment values',
+            }
+        ),
+        **{
+            source_id: MappingProxyType(
+                {
+                    'owner': 'franky',
+                    'safe_location_class': 'allowlisted-gateway-status-summary',
+                    'exclusions': 'unit_content, journal, pid, command lines, stdout, stderr, environment values',
+                }
+            )
+            for source_id in MUGIWARA_GATEWAY_SOURCE_IDS
+        },
+        'cronjobs': MappingProxyType(
+            {
+                'owner': 'franky',
+                'safe_location_class': 'shared-manifest-registry',
+                'exclusions': 'zoro profile-local cronjob list, prompt_body, chat_id, delivery targets, tokens, credentials',
+            }
+        ),
+    }
+)
+
 HEALTHCHECK_SOURCE_LABELS: Mapping[str, str] = MappingProxyType(
     {
         'vault-sync': 'Vault sync',

--- a/apps/api/tests/test_healthcheck_dashboard_api.py
+++ b/apps/api/tests/test_healthcheck_dashboard_api.py
@@ -8,6 +8,8 @@ from apps.api.src.modules.healthcheck.domain import (
     HEALTHCHECK_FRESHNESS_STATES,
     HEALTHCHECK_SEVERITY_VALUES,
     HEALTHCHECK_SOURCE_FAMILY_IDS,
+    HEALTHCHECK_SOURCE_FRESHNESS_THRESHOLDS,
+    HEALTHCHECK_SOURCE_MANIFEST_POLICIES,
     HEALTHCHECK_STATUS_VALUES,
     HealthcheckRecord,
 )
@@ -84,6 +86,21 @@ def test_healthcheck_contract_vocabulary_is_backend_owned():
         'gateway.jinbe.process',
         'cronjobs.registry',
     }
+
+
+def test_healthcheck_manifest_and_freshness_policy_is_backend_owned():
+    assert HEALTHCHECK_SOURCE_MANIFEST_POLICIES['vault-sync']['owner'] == 'franky'
+    assert HEALTHCHECK_SOURCE_MANIFEST_POLICIES['backup-health']['owner'] == 'franky'
+    assert HEALTHCHECK_SOURCE_MANIFEST_POLICIES['cronjobs']['owner'] == 'franky'
+    assert HEALTHCHECK_SOURCE_MANIFEST_POLICIES['cronjobs']['safe_location_class'] == 'shared-manifest-registry'
+    assert 'zoro profile-local cronjob list' in HEALTHCHECK_SOURCE_MANIFEST_POLICIES['cronjobs']['exclusions']
+    assert all('/srv/' not in policy['safe_location_class'] for policy in HEALTHCHECK_SOURCE_MANIFEST_POLICIES.values())
+
+    assert HEALTHCHECK_SOURCE_FRESHNESS_THRESHOLDS['vault-sync'] == {'warn_after_minutes': 90, 'fail_after_minutes': 360}
+    assert HEALTHCHECK_SOURCE_FRESHNESS_THRESHOLDS['backup-health'] == {'warn_after_minutes': 1800, 'fail_after_minutes': 4320}
+    assert HEALTHCHECK_SOURCE_FRESHNESS_THRESHOLDS['cronjobs'] == {'warn_after_minutes': 180, 'fail_after_minutes': 720}
+    assert HEALTHCHECK_SOURCE_FRESHNESS_THRESHOLDS['hermes-gateways'] == {'warn_after_minutes': 15, 'fail_after_minutes': 60}
+    assert HEALTHCHECK_SOURCE_FRESHNESS_THRESHOLDS['gateway.zoro'] == {'warn_after_minutes': 15, 'fail_after_minutes': 60}
 
 
 def test_healthcheck_rejects_invalid_status_severity_and_freshness():

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -45,6 +45,8 @@
 - mantener vocabulario allowlisted de `status`, `severity`, `freshness.state`, source IDs y check IDs en el dominio backend
 - normalizar payloads de adapters futuros con registro backend-owned allowlist-only antes de serializar; campos crudos o desconocidos se descartan y los source IDs rechazados no se ecoan
 - consumir solo fuentes saneadas y timestamps de frescura
+- documentar y verificar manifest ownership and freshness thresholds antes de cualquier lectura viva (`docs/healthcheck-source-policy.md`)
+- bloquear crecimiento accidental hacia consola host genérica con `npm run verify:healthcheck-source-policy`
 - no ejecutar shell, Docker, systemd ni leer logs/salidas crudas del host en esta fase
 - representar `stale`/`not_configured`/`unknown` de forma explícita
 

--- a/docs/healthcheck-source-policy.md
+++ b/docs/healthcheck-source-policy.md
@@ -1,0 +1,49 @@
+# Healthcheck source policy
+
+## Purpose
+Phase 15.2c closes the final foundation slice before live Healthcheck source adapters. It defines the source-policy contract that later adapters must satisfy without adding live reads yet.
+
+## No generic host console
+Healthcheck must not become a generic host console. New source code in `apps/api/src/modules/healthcheck` must not introduce generic shell, process, command execution or arbitrary URL-fetch adapters without a reviewed, allowlisted phase.
+
+Blocked by `npm run verify:healthcheck-source-policy`:
+- generic subprocess or shell usage;
+- `exec()` / `eval()` style execution;
+- generic `requests`, `httpx` or `urllib.request` URL fetches inside the Healthcheck module;
+- command-parameter based host adapters.
+
+Adapters remain explicit, source-family-specific and reviewed. No live manifest reads are implemented in Phase 15.2c.
+
+## Manifest ownership and safe location class
+Future live adapters may consume only sanitized summaries from reviewed sources. They must never expose raw host details.
+
+| Source family | Owner | Safe location class | Notes |
+| --- | --- | --- | --- |
+| `vault-sync` | Franky | Franky-owned operational source | Status manifest or wrapper maintained by operations. |
+| `backup-health` | Franky | Franky-owned operational source | Status manifest or wrapper maintained by operations. |
+| `cronjobs` | Franky | shared manifest registry, not Zoro profile-local `cronjob list` | Must represent global scheduled jobs safely, not one profile's local runtime view. |
+| `hermes-gateways` | Franky | systemd user gateway summary | Aggregated gateway status only. |
+| `gateway.<mugiwara-slug>` | Franky | allowlisted gateway status summary | One allowlisted process summary per Mugiwara slug. |
+| `project-health` | Zoro | repo-local project health summary | Project health remains repo-scope and must not expose raw Git internals. |
+
+Source manifests or wrappers do not include `stdout`, `stderr`, `raw_output`, `command`, `traceback`, `pid`, `unit_content`, `journal`, absolute host paths, `backup_path`, `included_path`, `prompt_body`, `chat_id`, delivery targets, tokens, cookies, credentials, `.env`, Git diffs, untracked file lists or internal remotes.
+
+## Initial freshness thresholds
+Thresholds are intentionally backend-owned policy before Phase 15.3+ live adapters start mapping timestamps to `pass`/`warn`/`fail`.
+
+- `vault-sync`: warn after 90 minutes, fail after 360 minutes.
+- `project-health`: warn after 120 minutes, fail after 480 minutes.
+- `backup-health`: warn after 1800 minutes, fail after 4320 minutes.
+- `hermes-gateways` and `gateway.<mugiwara-slug>`: warn after 15 minutes, fail after 60 minutes.
+- `cronjobs`: warn after 180 minutes, fail after 720 minutes.
+
+These thresholds are not applied to live data in Phase 15.2c. Future adapters must parse timestamps explicitly, normalize to the existing Healthcheck freshness vocabulary and degrade absent/unreadable data to `not_configured`, `unknown` or `stale`, never to healthy output.
+
+## Verify
+Run after changes that touch Healthcheck source adapters, docs or source-policy boundaries:
+
+```bash
+npm run verify:healthcheck-source-policy
+```
+
+For implementation phases that also touch the API read model, run the backend test suite and existing perimeter guardrails as well.

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -66,6 +66,8 @@ Phase 15.2a no añade lecturas vivas: no lee manifiestos, filesystem, Git/GitHub
 
 Phase 15.2b añade una normalización backend-owned previa a futuras fuentes vivas. Los adapters futuros entregarán payloads ya resumidos al registro de fuentes; el registro solo copia una allowlist mínima (`label`, `status`, `severity`, `updated_at`, `summary`, `warning_text`, `source_label`, `freshness_label`, `freshness_state`) y descarta campos desconocidos antes de que lleguen al modelo serializable. Ausencias, fuentes no legibles y adapters no registrados se representan como `not_configured` o `unknown`, nunca como `pass` silencioso. Los errores de source ID no deben ecoar el valor rechazado para evitar filtrar paths, comandos o nombres internos.
 
+Phase 15.2c adds static guardrails, manifest ownership and freshness thresholds before live adapters. The detailed policy lives in `docs/healthcheck-source-policy.md`; it defines Franky/Zoro ownership per source family, safe location classes, explicit exclusions for raw host data and initial warn/fail thresholds. This phase still does not read manifests or apply thresholds to live data.
+
 ### `memory.agent_summary`
 Campos esperados:
 - `mugiwara_slug`

--- a/docs/security-perimeter.md
+++ b/docs/security-perimeter.md
@@ -110,6 +110,8 @@ Remaining constraints for future #16 work:
 - only introduce `critical` severity aggregation when real sources can emit it deterministically;
 - revisit backend host allowlist if the real deployment topology needs enforcement beyond the current server-only URL policy.
 
+Phase 15.2c adds the static source-policy guardrail before live adapters: `npm run verify:healthcheck-source-policy`. Manifest ownership and freshness thresholds are documented in `docs/healthcheck-source-policy.md`; no live manifest reads are introduced by that foundation slice.
+
 ## Verify
 Run this static policy guardrail after changes that touch perimeter docs, runtime config or Skills BFF boundaries:
 

--- a/openspec/phase-15-2c-health-source-policy.md
+++ b/openspec/phase-15-2c-health-source-policy.md
@@ -1,0 +1,47 @@
+# Phase 15.2c — Guardrails, manifest ownership and freshness policy
+
+## Goal
+Close the final Phase 15.2 Healthcheck foundation slice before live real-source adapters by adding static host-console guardrails, manifest ownership policy and backend-owned freshness thresholds.
+
+## Scope delivered
+- Added `HEALTHCHECK_SOURCE_MANIFEST_POLICIES` in `apps/api/src/modules/healthcheck/domain.py`.
+- Added `HEALTHCHECK_SOURCE_FRESHNESS_THRESHOLDS` in `apps/api/src/modules/healthcheck/domain.py`.
+- Added a cheap static guardrail command: `npm run verify:healthcheck-source-policy`.
+- Added `scripts/check-healthcheck-source-policy.mjs` to block accidental generic host-console patterns in Healthcheck module source.
+- Added dedicated policy docs in `docs/healthcheck-source-policy.md`.
+- Linked the policy from `docs/api-modules.md`, `docs/read-models.md` and `docs/security-perimeter.md`.
+- Added backend tests proving the policy is backend-owned and does not encode absolute safe paths.
+
+## Explicitly out of scope
+- No live manifest reads.
+- No filesystem discovery.
+- No Git/GitHub queries.
+- No systemd, shell, Docker, subprocess or cron runtime integration.
+- No application of thresholds to live data.
+- No Dashboard aggregation change.
+
+## TDD notes
+Red checks observed before implementation:
+- `npm run verify:healthcheck-source-policy` failed because the package script pointed to a missing guardrail file.
+- `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` failed during collection because `HEALTHCHECK_SOURCE_FRESHNESS_THRESHOLDS` and `HEALTHCHECK_SOURCE_MANIFEST_POLICIES` did not exist yet.
+
+## Policy summary
+Manifest ownership:
+- `vault-sync`: Franky-owned operational source.
+- `backup-health`: Franky-owned operational source.
+- `cronjobs`: Franky-owned shared manifest registry, not inferred from Zoro profile-local `cronjob list`.
+- `hermes-gateways` and `gateway.<mugiwara-slug>`: Franky-owned gateway status summaries.
+- `project-health`: Zoro-owned repo-local project health summary.
+
+Initial freshness thresholds:
+- `vault-sync`: warn 90 min, fail 360 min.
+- `project-health`: warn 120 min, fail 480 min.
+- `backup-health`: warn 1800 min, fail 4320 min.
+- gateways: warn 15 min, fail 60 min.
+- `cronjobs`: warn 180 min, fail 720 min.
+
+## Security boundary
+The new guardrail scans Healthcheck module Python source for generic host-console growth: subprocess imports/usage, `os.system`, `shell=True`, `exec`, `eval`, command-parameter adapters and generic URL fetch libraries. It deliberately does not approve any live adapter; it only freezes the deny-by-default boundary before Phase 15.3+.
+
+## Verify checklist
+See `openspec/phase-15-2c-verify-checklist.md`.

--- a/openspec/phase-15-2c-verify-checklist.md
+++ b/openspec/phase-15-2c-verify-checklist.md
@@ -1,0 +1,25 @@
+# Phase 15.2c verify checklist
+
+- [x] Branch created from current `main`: `zoro/phase-15-2c-health-source-policy`.
+- [x] TDD red run observed: `npm run verify:healthcheck-source-policy` failed on missing guardrail file after package script was added.
+- [x] TDD red run observed: `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` failed on missing policy constants before implementation.
+- [x] Backend-owned manifest ownership policy exists in `apps/api/src/modules/healthcheck/domain.py`.
+- [x] Backend-owned freshness thresholds exist in `apps/api/src/modules/healthcheck/domain.py`.
+- [x] `docs/healthcheck-source-policy.md` documents owner, safe location class and sensitivity exclusions per source family.
+- [x] `docs/healthcheck-source-policy.md` documents initial freshness thresholds for vault sync, project health, backup, gateways and cronjobs.
+- [x] `npm run verify:healthcheck-source-policy` is wired in `package.json` and passes.
+- [x] No live source adapters, manifest reads, filesystem discovery, Git/GitHub queries, systemd, shell, Docker, subprocess or cron runtime visibility were added.
+- [x] Existing Healthcheck/Dashboard API compatibility tests pass.
+- [x] Existing perimeter guardrails pass.
+- [ ] PR review handoff requested from Franky + Chopper.
+
+## Verify commands
+
+```bash
+python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/registry.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py
+PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q
+npm run verify:health-dashboard-server-only
+npm run verify:perimeter-policy
+npm run verify:healthcheck-source-policy
+git diff --check
+```

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "verify:skills-server-only": "node scripts/check-skills-server-only.mjs",
     "verify:vault-server-only": "node scripts/check-vault-server-only.mjs",
     "verify:health-dashboard-server-only": "node scripts/check-health-dashboard-server-only.mjs",
+    "verify:healthcheck-source-policy": "node scripts/check-healthcheck-source-policy.mjs",
     "dev:api": "uvicorn apps.api.src.main:app --reload",
     "lint": "echo 'Pending lint setup'",
     "test": "echo 'Pending test setup'",

--- a/scripts/check-healthcheck-source-policy.mjs
+++ b/scripts/check-healthcheck-source-policy.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Static guardrail for Phase 15.2c Healthcheck source policy.
+ *
+ * Inputs: Healthcheck backend module source, package.json and source-policy docs.
+ * Output: exits non-zero if Healthcheck grows generic host-console patterns or
+ * if manifest ownership/freshness policy docs disappear. Read-only.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = process.cwd()
+const paths = {
+  packageJson: join(repoRoot, 'package.json'),
+  healthcheckModule: join(repoRoot, 'apps/api/src/modules/healthcheck'),
+  sourcePolicyDoc: join(repoRoot, 'docs/healthcheck-source-policy.md'),
+  apiModulesDoc: join(repoRoot, 'docs/api-modules.md'),
+  readModelsDoc: join(repoRoot, 'docs/read-models.md'),
+}
+
+const failures = []
+
+function read(pathName, label) {
+  if (!existsSync(pathName)) {
+    failures.push(`missing ${label} at ${pathName}`)
+    return ''
+  }
+  return readFileSync(pathName, 'utf8')
+}
+
+function listPythonFiles(dir) {
+  if (!existsSync(dir)) {
+    failures.push(`missing Healthcheck module directory at ${dir}`)
+    return []
+  }
+
+  const files = []
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry)
+    const stat = statSync(fullPath)
+    if (stat.isDirectory()) {
+      if (entry !== '__pycache__') files.push(...listPythonFiles(fullPath))
+    } else if (entry.endsWith('.py')) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+function mustInclude(text, snippet, label) {
+  if (!text.includes(snippet)) {
+    failures.push(`${label} must include: ${snippet}`)
+  }
+}
+
+const packageJsonText = read(paths.packageJson, 'package.json')
+const sourcePolicyDoc = read(paths.sourcePolicyDoc, 'Healthcheck source policy document')
+const apiModulesDoc = read(paths.apiModulesDoc, 'API modules document')
+const readModelsDoc = read(paths.readModelsDoc, 'read models document')
+
+let packageJson
+try {
+  packageJson = JSON.parse(packageJsonText)
+} catch {
+  failures.push('package.json must be valid JSON')
+}
+
+if (packageJson && packageJson.scripts?.['verify:healthcheck-source-policy'] !== 'node scripts/check-healthcheck-source-policy.mjs') {
+  failures.push('package.json must expose verify:healthcheck-source-policy')
+}
+
+const forbiddenHostConsolePatterns = [
+  { pattern: /\bimport\s+subprocess\b/, label: 'import subprocess' },
+  { pattern: /\bfrom\s+subprocess\s+import\b/, label: 'from subprocess import' },
+  { pattern: /\bsubprocess\s*\./, label: 'subprocess usage' },
+  { pattern: /\bos\.system\s*\(/, label: 'os.system' },
+  { pattern: /\bshell\s*=\s*True\b/, label: 'shell=True' },
+  { pattern: /\bexec\s*\(/, label: 'exec()' },
+  { pattern: /\beval\s*\(/, label: 'eval()' },
+  { pattern: /\bcommand\s*=/, label: 'command parameter' },
+  { pattern: /\bimport\s+requests\b/, label: 'import requests' },
+  { pattern: /\brequests\.(get|post|put|patch|delete|request)\s*\(/, label: 'requests generic URL fetch' },
+  { pattern: /\bimport\s+httpx\b/, label: 'import httpx' },
+  { pattern: /\bhttpx\.(get|post|put|patch|delete|request)\s*\(/, label: 'httpx generic URL fetch' },
+  { pattern: /\burllib\.request\b/, label: 'urllib.request generic URL fetch' },
+]
+
+for (const filePath of listPythonFiles(paths.healthcheckModule)) {
+  const text = readFileSync(filePath, 'utf8')
+  for (const { pattern, label } of forbiddenHostConsolePatterns) {
+    if (pattern.test(text)) {
+      failures.push(`Healthcheck source must not contain ${label}: ${filePath}`)
+    }
+  }
+}
+
+const requiredDocSnippets = [
+  'No generic host console',
+  'Franky-owned operational source',
+  'shared manifest registry, not Zoro profile-local `cronjob list`',
+  '`vault-sync`: warn after 90 minutes, fail after 360 minutes',
+  '`backup-health`: warn after 1800 minutes, fail after 4320 minutes',
+  '`cronjobs`: warn after 180 minutes, fail after 720 minutes',
+  '`hermes-gateways` and `gateway.<mugiwara-slug>`: warn after 15 minutes, fail after 60 minutes',
+  '`project-health`: warn after 120 minutes, fail after 480 minutes',
+  'No live manifest reads are implemented in Phase 15.2c',
+  'do not include `stdout`, `stderr`, `raw_output`, `command`, `traceback`, `pid`, `unit_content`, `journal`, absolute host paths, `backup_path`, `included_path`, `prompt_body`, `chat_id`, delivery targets, tokens, cookies, credentials, `.env`, Git diffs, untracked file lists or internal remotes',
+]
+
+for (const snippet of requiredDocSnippets) {
+  mustInclude(sourcePolicyDoc, snippet, 'Healthcheck source policy document')
+}
+
+mustInclude(apiModulesDoc, 'npm run verify:healthcheck-source-policy', 'API modules document')
+mustInclude(apiModulesDoc, 'manifest ownership and freshness thresholds', 'API modules document')
+mustInclude(readModelsDoc, 'Phase 15.2c adds static guardrails, manifest ownership and freshness thresholds', 'read models document')
+mustInclude(readModelsDoc, 'docs/healthcheck-source-policy.md', 'read models document')
+
+if (failures.length > 0) {
+  console.error('Healthcheck source policy check failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log('Healthcheck source policy check passed')


### PR DESCRIPTION
## Summary
- Add backend-owned Healthcheck source manifest policy and freshness thresholds before live adapters.
- Add `npm run verify:healthcheck-source-policy` and `scripts/check-healthcheck-source-policy.mjs` to block accidental generic host-console growth in the Healthcheck module.
- Document source ownership, safe location classes, sensitivity exclusions and thresholds in `docs/healthcheck-source-policy.md`, with links from existing docs/OpenSpec/Engram closeout.

## Scope boundary
- No live manifest reads.
- No filesystem discovery.
- No Git/GitHub queries.
- No systemd, shell, Docker, subprocess or cron runtime integration.
- No Dashboard aggregation change.

## TDD / red checks observed
- `npm run verify:healthcheck-source-policy` failed on missing guardrail file after wiring the package script.
- `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` failed on missing policy constants before implementation.

## Verification
```bash
python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/registry.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py
PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q
npm run verify:health-dashboard-server-only
npm run verify:perimeter-policy
npm run verify:healthcheck-source-policy
git diff --check
```

## Review requested
- Franky: operational feasibility of source ownership, safe location classes, freshness thresholds and guardrail script maintainability.
- Chopper: security boundary, leakage exclusions and whether the guardrail is strict enough before Phase 15.3+ live adapters.
