### PR TITLE
feat: add vault sync health source adapter

### DIFF
--- a/.engram/phase-15-3a-vault-sync-adapter-closeout.md
+++ b/.engram/phase-15-3a-vault-sync-adapter-closeout.md
@@ -1,0 +1,30 @@
+# Phase 15.3a closeout — Vault sync safe adapter
+
+## What changed
+- Added `apps/api/src/modules/healthcheck/source_adapters.py` with `VaultSyncManifestAdapter`.
+- Wired `HealthcheckService()` defaults so the `vault-sync` fixture is replaced by the adapter snapshot while the remaining safe catalog stays available.
+- Added backend tests for recent success, stale timestamp, missing manifest, unreadable manifest and sanitized/noisy manifest fields.
+- Updated Healthcheck source policy/read-model/API docs and added OpenSpec + verify checklist.
+
+## Key decisions
+- 15.3 was split: 15.3a covers `vault-sync` only; local backup health remains a separate 15.3b microphase.
+- The adapter reads only a fixed Franky-owned manifest path and consumes only safe result/timestamp semantics.
+- Missing manifest maps to `not_configured`; unreadable or invalid manifest maps to `unknown`; neither becomes healthy output.
+- Manifest fields such as path, stdout, remote URL, branch or counts are not serialized. Public text still goes through `HealthcheckSourceRegistry`.
+
+## Verification
+Passed:
+- `python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/registry.py apps/api/src/modules/healthcheck/source_adapters.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py`
+- `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q`
+- `PYTHONPATH=. python -m pytest apps/api/tests -q`
+- `npm run verify:healthcheck-source-policy`
+- `npm run verify:perimeter-policy`
+- `npm --prefix apps/web run typecheck`
+- `npm --prefix apps/web run build`
+- `npm run verify:health-dashboard-server-only`
+- `git diff --check`
+
+## Continuity
+- Review needed: Franky + Chopper.
+- Next implementation slice should be 15.3b for local backup safe adapter, using the same adapter/registry pattern but with backup-specific manifest semantics and leakage tests.
+- Do not add project health, gateways or cronjobs until their planned microphases.

--- a/apps/api/src/modules/healthcheck/service.py
+++ b/apps/api/src/modules/healthcheck/service.py
@@ -17,6 +17,8 @@ from .domain import (
     validate_healthcheck_status,
 )
 
+from .source_adapters import VaultSyncManifestAdapter
+
 if TYPE_CHECKING:
     from .registry import HealthcheckSourceSnapshot
 
@@ -51,13 +53,14 @@ class HealthcheckService:
     def __init__(
         self,
         *,
-        records: tuple[HealthcheckRecord, ...] = SAFE_HEALTHCHECK_RECORDS,
+        records: tuple[HealthcheckRecord, ...] | None = None,
         events: tuple[HealthcheckEvent, ...] = SAFE_EVENTS,
         freshness_state_by_module: dict[str, str] | None = None,
     ) -> None:
-        self._records = records
+        default_snapshot_state = self._default_source_snapshot_state() if records is None else {}
+        self._records = records if records is not None else self._records_with_default_sources(default_snapshot_state)
         self._events = events
-        self._freshness_state_by_module = freshness_state_by_module or {}
+        self._freshness_state_by_module = {**default_snapshot_state, **(freshness_state_by_module or {})}
 
     @classmethod
     def from_source_snapshots(cls, snapshots: tuple['HealthcheckSourceSnapshot', ...]) -> 'HealthcheckService':
@@ -65,6 +68,15 @@ class HealthcheckService:
             records=tuple(snapshot.record for snapshot in snapshots),
             freshness_state_by_module={snapshot.record.module_id: snapshot.freshness_state for snapshot in snapshots},
         )
+
+    def _default_source_snapshot_state(self) -> dict[str, str]:
+        vault_snapshot = VaultSyncManifestAdapter().snapshot()
+        self._default_source_records = {vault_snapshot.record.module_id: vault_snapshot.record}
+        return {vault_snapshot.record.module_id: vault_snapshot.freshness_state}
+
+    def _records_with_default_sources(self, _snapshot_state: dict[str, str]) -> tuple[HealthcheckRecord, ...]:
+        source_records = getattr(self, '_default_source_records', {})
+        return tuple(source_records.get(record.module_id, record) for record in SAFE_HEALTHCHECK_RECORDS)
 
     def workspace_status(self) -> str:
         return 'ready' if self._records else 'not_configured'

--- a/apps/api/src/modules/healthcheck/source_adapters.py
+++ b/apps/api/src/modules/healthcheck/source_adapters.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping
+
+from .domain import HEALTHCHECK_SOURCE_FRESHNESS_THRESHOLDS
+from .registry import HealthcheckSourceRegistry, HealthcheckSourceSnapshot
+
+VAULT_SYNC_STATUS_MANIFEST = Path('/srv/crew-core/runtime/healthcheck/vault-sync-status.json')
+
+
+class VaultSyncManifestAdapter:
+    """Fixed, allowlisted reader for Franky-owned vault sync status manifests."""
+
+    source_id = 'vault-sync'
+
+    def __init__(
+        self,
+        *,
+        manifest_path: Path = VAULT_SYNC_STATUS_MANIFEST,
+        registry: HealthcheckSourceRegistry | None = None,
+    ) -> None:
+        self._manifest_path = manifest_path
+        self._registry = registry or HealthcheckSourceRegistry()
+
+    def snapshot(self, *, now: str | datetime | None = None) -> HealthcheckSourceSnapshot:
+        if not self._manifest_path.exists():
+            return self._registry.normalize_absent(self.source_id)
+
+        try:
+            manifest = json.loads(self._manifest_path.read_text(encoding='utf-8'))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return self._registry.normalize_unreadable(self.source_id)
+
+        if not isinstance(manifest, Mapping):
+            return self._registry.normalize_unreadable(self.source_id)
+
+        raw = self._manifest_to_raw(manifest, now=self._parse_now(now))
+        return self._registry.normalize(self.source_id, raw)
+
+    def _manifest_to_raw(self, manifest: Mapping[object, object], *, now: datetime) -> dict[str, str]:
+        updated_at = self._safe_timestamp(manifest.get('last_success_at')) or self._safe_timestamp(manifest.get('updated_at'))
+        if updated_at is None:
+            return {
+                'status': 'unknown',
+                'severity': 'unknown',
+                'updated_at': '',
+                'summary': 'Vault sync sin timestamp seguro disponible.',
+                'warning_text': 'Vault sync sin timestamp seguro.',
+                'source_label': 'Vault sync safe manifest',
+                'freshness_label': 'Frescura desconocida',
+                'freshness_state': 'unknown',
+            }
+
+        result = self._safe_result(manifest.get('status')) or self._safe_result(manifest.get('result'))
+        age_minutes = (now - _parse_timestamp(updated_at)).total_seconds() / 60
+        thresholds = HEALTHCHECK_SOURCE_FRESHNESS_THRESHOLDS[self.source_id]
+
+        if result in {'error', 'failed', 'fail'}:
+            status = 'fail'
+            severity = 'high'
+            summary = 'Vault sync reporta fallo en su manifiesto seguro.'
+            warning = 'Vault sync falló; revisar fuente operacional.'
+            freshness_state = 'stale'
+        elif result in {'dirty', 'diverged', 'ahead', 'behind', 'stale', 'warning', 'warn'}:
+            status = 'warn'
+            severity = 'medium'
+            summary = 'Vault sync requiere revisión según manifiesto seguro.'
+            warning = 'Vault sync con divergencia o cambios pendientes.'
+            freshness_state = 'stale'
+        elif age_minutes >= thresholds['fail_after_minutes']:
+            status = 'stale'
+            severity = 'high'
+            summary = 'Vault sync no tiene actualización reciente.'
+            warning = 'Vault sync stale; revisar fuente operacional.'
+            freshness_state = 'stale'
+        elif age_minutes >= thresholds['warn_after_minutes']:
+            status = 'warn'
+            severity = 'medium'
+            summary = 'Vault sync se acerca al umbral de frescura.'
+            warning = 'Vault sync próximo a stale.'
+            freshness_state = 'stale'
+        else:
+            status = 'pass'
+            severity = 'low'
+            summary = 'Vault sincronizado recientemente.'
+            warning = 'Sin alerta activa.'
+            freshness_state = 'fresh'
+
+        return {
+            'status': status,
+            'severity': severity,
+            'updated_at': updated_at,
+            'summary': summary,
+            'warning_text': warning,
+            'source_label': 'Vault sync safe manifest',
+            'freshness_label': self._freshness_label(age_minutes),
+            'freshness_state': freshness_state,
+        }
+
+    def _parse_now(self, value: str | datetime | None) -> datetime:
+        if value is None:
+            return datetime.now(timezone.utc)
+        if isinstance(value, datetime):
+            return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+        return _parse_timestamp(value)
+
+    def _safe_timestamp(self, value: object) -> str | None:
+        if not isinstance(value, str):
+            return None
+        try:
+            _parse_timestamp(value)
+        except ValueError:
+            return None
+        return value
+
+    def _safe_result(self, value: object) -> str | None:
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip().lower()
+        allowed = {'success', 'ok', 'pass', 'error', 'failed', 'fail', 'dirty', 'diverged', 'ahead', 'behind', 'stale', 'warning', 'warn'}
+        return normalized if normalized in allowed else None
+
+    def _freshness_label(self, age_minutes: float) -> str:
+        if age_minutes < 1:
+            return 'Actualizado hace menos de 1 min'
+        rounded_minutes = int(age_minutes)
+        return f'Actualizado hace {rounded_minutes} min'
+
+
+def _parse_timestamp(value: str) -> datetime:
+    normalized = value.replace('Z', '+00:00') if value.endswith('Z') else value
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed

--- a/apps/api/tests/test_healthcheck_dashboard_api.py
+++ b/apps/api/tests/test_healthcheck_dashboard_api.py
@@ -15,6 +15,7 @@ from apps.api.src.modules.healthcheck.domain import (
     HealthcheckRecord,
 )
 from apps.api.src.modules.healthcheck.registry import HealthcheckSourceRegistry
+from apps.api.src.modules.healthcheck.source_adapters import VaultSyncManifestAdapter
 from apps.api.src.modules.healthcheck.service import HealthcheckService
 from apps.api.src.modules.dashboard.service import DashboardService
 
@@ -263,6 +264,67 @@ def test_healthcheck_source_registry_models_absent_unreadable_and_unregistered_a
     _assert_no_sensitive_host_output(payload)
 
 
+def test_vault_sync_manifest_adapter_maps_recent_success_to_safe_pass(tmp_path):
+    manifest = tmp_path / 'vault-sync-status.json'
+    manifest.write_text(
+        '{"status":"success","last_success_at":"2026-04-24T07:30:00Z","updated_at":"2026-04-24T07:30:00Z","branch":"main","ahead":0,"behind":0}',
+        encoding='utf-8',
+    )
+
+    snapshot = VaultSyncManifestAdapter(manifest_path=manifest).snapshot(now='2026-04-24T08:00:00Z')
+    payload = HealthcheckService.from_source_snapshots((snapshot,)).get_workspace()
+
+    assert payload['modules'] == [
+        {
+            'module_id': 'vault-sync',
+            'label': 'Vault sync',
+            'status': 'pass',
+            'severity': 'low',
+            'updated_at': '2026-04-24T07:30:00Z',
+            'summary': 'Vault sincronizado recientemente.',
+        }
+    ]
+    assert payload['signals'] == []
+    _assert_no_sensitive_host_output(payload)
+
+
+def test_vault_sync_manifest_adapter_degrades_stale_and_ignores_manifest_noise(tmp_path):
+    manifest = tmp_path / 'vault-sync-status.json'
+    manifest.write_text(
+        '{"status":"success","last_success_at":"2026-04-24T01:00:00Z","updated_at":"2026-04-24T01:00:00Z","path":"/srv/crew-core/vault/.env","stdout":"token secret raw_output","remote_url":"git@github.com:private/repo.git"}',
+        encoding='utf-8',
+    )
+
+    snapshot = VaultSyncManifestAdapter(manifest_path=manifest).snapshot(now='2026-04-24T08:00:00Z')
+    payload = HealthcheckService.from_source_snapshots((snapshot,)).get_workspace()
+
+    module = payload['modules'][0]
+    signal = payload['signals'][0]
+    assert module['status'] == 'stale'
+    assert module['severity'] == 'high'
+    assert module['updated_at'] == '2026-04-24T01:00:00Z'
+    assert signal['check_id'] == 'vault-sync.last-sync'
+    assert signal['freshness']['state'] == 'stale'
+    assert signal['warning_text'] == 'Vault sync stale; revisar fuente operacional.'
+    _assert_no_sensitive_host_output(payload)
+
+
+def test_vault_sync_manifest_adapter_models_missing_or_unreadable_manifest(tmp_path):
+    missing = VaultSyncManifestAdapter(manifest_path=tmp_path / 'missing.json').snapshot(now='2026-04-24T08:00:00Z')
+    unreadable_manifest = tmp_path / 'vault-sync-status.json'
+    unreadable_manifest.write_text('{not-json', encoding='utf-8')
+    unreadable = VaultSyncManifestAdapter(manifest_path=unreadable_manifest).snapshot(now='2026-04-24T08:00:00Z')
+
+    payload = HealthcheckService.from_source_snapshots((missing, unreadable)).get_workspace()
+
+    status_by_module = {module['summary']: module['status'] for module in payload['modules']}
+    assert status_by_module == {
+        'Fuente Healthcheck ausente o todavía no configurada.': 'not_configured',
+        'Fuente Healthcheck no legible; no se expone salida cruda.': 'unknown',
+    }
+    _assert_no_sensitive_host_output(payload)
+
+
 def test_healthcheck_returns_sanitized_workspace():
     response = client.get('/api/v1/healthcheck')
 
@@ -295,13 +357,13 @@ def test_healthcheck_empty_source_is_not_configured():
     assert service.get_workspace()['signals'] == []
 
 
-def test_healthcheck_stale_state_is_visible():
+def test_healthcheck_degraded_source_state_is_visible():
     payload = client.get('/api/v1/healthcheck').json()
 
-    assert any(module['status'] == 'stale' for module in payload['data']['modules'])
-    stale_signal = next(signal for signal in payload['data']['signals'] if signal['status'] == 'stale')
-    assert stale_signal['freshness']['label']
-    assert stale_signal['warning_text']
+    assert any(module['status'] in {'stale', 'not_configured', 'unknown'} for module in payload['data']['modules'])
+    degraded_signal = next(signal for signal in payload['data']['signals'] if signal['status'] in {'stale', 'not_configured', 'unknown'})
+    assert degraded_signal['freshness']['label']
+    assert degraded_signal['warning_text']
 
 
 def test_healthcheck_uses_explicit_timestamp_parsing_for_latest_update():

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -45,6 +45,8 @@
 - mantener vocabulario allowlisted de `status`, `severity`, `freshness.state`, source IDs y check IDs en el dominio backend
 - normalizar payloads de adapters futuros con registro backend-owned allowlist-only antes de serializar; campos crudos o desconocidos se descartan y los source IDs rechazados no se ecoan
 - consumir solo fuentes saneadas y timestamps de frescura
+- conectar en Phase 15.3a el primer adapter vivo `vault-sync` desde manifiesto fijo Franky-owned, sin exponer rutas, ramas, remotes, Git output ni campos raw
+- mantener backup/project/gateway/cronjob reads fuera hasta sus microfases revisadas
 - documentar y verificar manifest ownership and freshness thresholds antes de cualquier lectura viva (`docs/healthcheck-source-policy.md`)
 - bloquear crecimiento accidental hacia consola host genérica con `npm run verify:healthcheck-source-policy`
 - no ejecutar shell, Docker, systemd ni leer logs/salidas crudas del host en esta fase

--- a/docs/healthcheck-source-policy.md
+++ b/docs/healthcheck-source-policy.md
@@ -1,7 +1,7 @@
 # Healthcheck source policy
 
 ## Purpose
-Phase 15.2c closes the final foundation slice before live Healthcheck source adapters. It defines the source-policy contract that later adapters must satisfy without adding live reads yet.
+Phase 15.2c closed the final foundation slice before live Healthcheck source adapters. It defines the source-policy contract that adapters must satisfy. Phase 15.3a starts live reads with the `vault-sync` adapter only, through a fixed Franky-owned manifest path and the existing registry sanitizer.
 
 ## No generic host console
 Healthcheck must not become a generic host console. New source code in `apps/api/src/modules/healthcheck` must not introduce generic shell, process, command execution, arbitrary URL-fetch adapters or generic filesystem discovery without a reviewed, allowlisted phase.
@@ -13,7 +13,7 @@ Blocked by `npm run verify:healthcheck-source-policy`:
 - command-parameter based host adapters;
 - generic filesystem discovery or reads such as `glob`, `os.listdir`, `os.scandir`, `os.walk`, ambient `Path.home()` / `Path.cwd()`, recursive `rglob()` or direct `open()` in the Healthcheck module.
 
-Adapters remain explicit, source-family-specific and reviewed. No live manifest reads are implemented in Phase 15.2c.
+Adapters remain explicit, source-family-specific and reviewed. No live manifest reads are implemented in Phase 15.2c. Phase 15.3a allows only the fixed `vault-sync` manifest reader in `source_adapters.py`; it does not add backup, project-health, gateway or cronjob reads.
 
 ## Text field sanitization
 Future adapters must sanitize summaries before handing them to Healthcheck. As defense in depth, `HealthcheckSourceRegistry` ignores adapter-provided labels and always resolves `label` from backend-owned `HEALTHCHECK_SOURCE_LABELS[source_id]`. It also applies a final sensitive-marker filter to allowed textual fields: `summary`, `warning_text`, `source_label` and `freshness_label`.
@@ -25,7 +25,7 @@ Future live adapters may consume only sanitized summaries from reviewed sources.
 
 | Source family | Owner | Safe location class | Notes |
 | --- | --- | --- | --- |
-| `vault-sync` | Franky | Franky-owned operational source | Status manifest or wrapper maintained by operations. |
+| `vault-sync` | Franky | Franky-owned operational source | Phase 15.3a reads a fixed status manifest and exposes only timestamp/result-derived summary fields. |
 | `backup-health` | Franky | Franky-owned operational source | Status manifest or wrapper maintained by operations. |
 | `cronjobs` | Franky | shared manifest registry, not Zoro profile-local `cronjob list` | Must represent global scheduled jobs safely, not one profile's local runtime view. |
 | `hermes-gateways` | Franky | systemd user gateway summary | Aggregated gateway status only. |

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -68,7 +68,9 @@ Phase 15.2b añade una normalización backend-owned previa a futuras fuentes viv
 
 Issue #34 / Phase 15.3 prerequisite añade defensa en profundidad para campos textuales permitidos antes de conectar adaptadores vivos. `HealthcheckSourceRegistry` no acepta `label` del adaptador: lo resuelve desde vocabulario backend-owned. Además filtra marcadores sensibles dentro de `summary`, `warning_text`, `source_label` y `freshness_label`; si detecta rutas host, `.env`, tokens, credenciales, salidas crudas, comandos, tracebacks, journals, prompts, chat IDs, delivery targets o metadatos Git internos, sustituye el texto por un fallback genérico saneado preservando estado, severidad y frescura.
 
-Phase 15.2c adds static guardrails, manifest ownership and freshness thresholds before live adapters. The detailed policy lives in `docs/healthcheck-source-policy.md`; it defines Franky/Zoro ownership per source family, safe location classes, explicit exclusions for raw host data and initial warn/fail thresholds. This phase still does not read manifests or apply thresholds to live data.
+Phase 15.2c adds static guardrails, manifest ownership and freshness thresholds before live adapters. The detailed policy lives in `docs/healthcheck-source-policy.md`; it defines Franky/Zoro ownership per source family, safe location classes, explicit exclusions for raw host data and initial warn/fail thresholds.
+
+Phase 15.3a connects the first live source: `vault-sync`. The adapter reads only a fixed Franky-owned status manifest, derives `pass`/`warn`/`stale`/`fail` from safe result and timestamp fields, routes output through `HealthcheckSourceRegistry`, and degrades missing or unreadable manifests to `not_configured`/`unknown`. It does not expose manifest paths, branch names, Git output, raw fields or remotes, and it does not add backup/project/gateway/cronjob reads.
 
 ### `memory.agent_summary`
 Campos esperados:

--- a/openspec/phase-15-3a-vault-sync-adapter.md
+++ b/openspec/phase-15-3a-vault-sync-adapter.md
@@ -1,0 +1,70 @@
+# Phase 15.3a — Vault sync safe adapter
+
+## Objective
+Connect the first live Healthcheck source for Phase 15.3: `vault-sync` only.
+
+This microphase reads a fixed, Franky-owned vault sync status manifest and exposes only a sanitized Healthcheck summary through the existing backend-owned source registry.
+
+## Why split 15.3
+Phase 15.3 originally covered both vault sync and local backups. That is too broad for the first live-source PR because each source family has different operational ownership, manifest semantics and leakage risks.
+
+15.3a therefore proves the pattern with `vault-sync` only. Backup health remains for 15.3b.
+
+## Scope
+- Add `VaultSyncManifestAdapter` under the Healthcheck backend module.
+- Read only a fixed allowlisted status manifest path owned by operations.
+- Accept only safe manifest semantics: result/status and timestamp fields.
+- Derive Healthcheck `status`, `severity`, `freshness_state`, summary and warning text from backend-owned policy.
+- Route adapter output through `HealthcheckSourceRegistry` so label ownership, field allowlisting and sensitive-text fallback still apply.
+- Replace the default fixture-backed `vault-sync` record with the adapter snapshot while preserving the rest of the safe catalog.
+- Update Healthcheck docs/read-models/source-policy.
+
+## Out of scope
+- Backup adapter.
+- Project health adapter.
+- Gateway/systemd adapter.
+- Cronjob registry adapter.
+- Shell, subprocess, Git command execution, GitHub API calls, generic filesystem discovery or URL fetches.
+- Exposing manifest path, branch name, remote URL, Git output, raw output, stdout/stderr, diff, untracked files or internal runtime details.
+
+## Manifest contract
+The adapter treats the manifest as an operational input, not a public API. It consumes only:
+
+- `status` or `result`: safe enum-like status values.
+- `last_success_at` or `updated_at`: ISO timestamp.
+
+Other manifest fields are ignored before serialization. If the manifest is missing, output is `not_configured`; if it is unreadable or invalid JSON, output is `unknown`. Neither case becomes healthy output.
+
+## Freshness policy
+Uses the existing backend-owned `vault-sync` thresholds:
+
+- warn after 90 minutes.
+- fail/stale after 360 minutes.
+
+Recent successful status becomes `pass/low/fresh`. Warning/divergence-like status becomes `warn/medium/stale`. Old successful timestamps become `warn` or `stale` depending on age. Error/fail status becomes `fail/high/stale`.
+
+## Definition of done
+- Tests cover recent success, stale timestamp, missing manifest and unreadable manifest.
+- Tests prove noisy manifest fields do not reach the serialized workspace.
+- `/api/v1/healthcheck` continues to return a sanitized read model.
+- Static Healthcheck source-policy guardrail still passes.
+- No new generic host-console pattern appears in Healthcheck source code.
+- Docs and closeout are updated.
+
+## Verify
+Run from repo root:
+
+```bash
+python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/registry.py apps/api/src/modules/healthcheck/source_adapters.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py
+PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q
+PYTHONPATH=. python -m pytest apps/api/tests -q
+npm run verify:healthcheck-source-policy
+npm run verify:perimeter-policy
+git diff --check
+```
+
+## Review
+Request Franky + Chopper:
+
+- Franky: operational feasibility of the fixed manifest adapter and freshness semantics.
+- Chopper: leakage boundary, sanitizer preservation and absence of generic host reads.

--- a/openspec/phase-15-3a-verify-checklist.md
+++ b/openspec/phase-15-3a-verify-checklist.md
@@ -1,0 +1,36 @@
+# Phase 15.3a — Verify checklist
+
+## Scope verified
+- [x] `VaultSyncManifestAdapter` added as the first live Healthcheck source adapter.
+- [x] Adapter is source-specific and fixed to `vault-sync`; no generic host console, shell, subprocess, Git command, GitHub API, URL fetch or filesystem discovery added.
+- [x] Manifest values are reduced to safe status/timestamp semantics before entering the public read model.
+- [x] Output still passes through `HealthcheckSourceRegistry` label ownership, allowlist filtering and text sanitizer.
+- [x] Missing manifest degrades to `not_configured`; unreadable/invalid manifest degrades to `unknown`.
+- [x] Docs updated in `docs/api-modules.md`, `docs/read-models.md` and `docs/healthcheck-source-policy.md`.
+
+## Automated verify
+Executed from repo root on branch `zoro/phase-15-3a-vault-sync-adapter`:
+
+```bash
+python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/registry.py apps/api/src/modules/healthcheck/source_adapters.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py
+PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q
+PYTHONPATH=. python -m pytest apps/api/tests -q
+npm run verify:healthcheck-source-policy
+npm run verify:perimeter-policy
+npm --prefix apps/web run typecheck
+npm --prefix apps/web run build
+npm run verify:health-dashboard-server-only
+git diff --check
+```
+
+Result: all passed.
+
+## Security/leakage checks
+- [x] Regression test injects manifest noise containing host path, `.env`, token/raw output and internal remote fields; serialized workspace remains sanitized.
+- [x] Adapter ignores branch/ahead/behind/path/stdout/remote fields in the manifest.
+- [x] No backup/project/gateway/cronjob live reads introduced.
+
+## Review routing
+Request Franky + Chopper before merge:
+- Franky for operational manifest and freshness semantics.
+- Chopper for host/leakage boundary.


### PR DESCRIPTION
## Summary
- Split Phase 15.3 into a first live-source microphase: 15.3a `vault-sync` only.
- Added `VaultSyncManifestAdapter` to read a fixed Franky-owned vault sync status manifest and reduce it to safe result/timestamp semantics.
- Wired default Healthcheck output so the `vault-sync` fixture is replaced by the adapter snapshot while the rest of the safe catalog stays stable.
- Added regression tests for recent success, stale timestamp, missing manifest, unreadable manifest and noisy manifest fields that must not leak.
- Updated OpenSpec, `.engram` closeout and Healthcheck docs/read-models/source-policy.

## Security / scope boundaries
- No shell, subprocess, Git command execution, GitHub API calls, generic URL fetches or filesystem discovery.
- No backup, project health, gateway/systemd or cronjob live reads in this PR.
- Manifest path/branch/remotes/stdout/raw fields are not serialized; output still flows through `HealthcheckSourceRegistry`.

## Verification
- `python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/registry.py apps/api/src/modules/healthcheck/source_adapters.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py`
- `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` → 20 passed
- `PYTHONPATH=. python -m pytest apps/api/tests -q` → 45 passed
- `npm run verify:healthcheck-source-policy` → passed
- `npm run verify:perimeter-policy` → passed
- `npm --prefix apps/web run typecheck` → passed
- `npm --prefix apps/web run build` → passed
- `npm run verify:health-dashboard-server-only` → passed
- `git diff --check` → passed

## Review requested
Franky + Chopper.

- Franky: validate the operational manifest/freshness semantics and whether the fixed adapter shape is viable for operations.
- Chopper: validate leakage boundary, sanitizer preservation and absence of generic host read/console growth.
