### PR TITLE
feat: add backup health source adapter

### DIFF
--- a/.engram/phase-15-3b-closeout.md
+++ b/.engram/phase-15-3b-closeout.md
@@ -1,0 +1,24 @@
+# Phase 15.3b closeout — Backup health adapter
+
+## Summary
+Implemented a source-specific `backup-health` live adapter for Healthcheck. The adapter reads only the fixed Franky-owned local backup status manifest at `/srv/crew-core/runtime/healthcheck/backup-health-status.json`, consumes safe status/timestamp/checksum/retention fields and routes the result through `HealthcheckSourceRegistry` before serialization.
+
+## Security boundary
+- No shell, subprocess, backup command execution, generic URL fetch, filesystem discovery or archive enumeration.
+- Missing manifest -> `not_configured`; unreadable/invalid manifest -> `unknown`.
+- Manifest noise such as archive paths, included paths, stdout/raw output and token markers is ignored before serialization.
+- The source registry remains the final label owner and text sanitizer.
+
+## Verify
+- `python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/registry.py apps/api/src/modules/healthcheck/source_adapters.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py`
+- `PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q`
+- `PYTHONPATH=. python -m pytest apps/api/tests -q`
+- `npm run verify:healthcheck-source-policy`
+- `npm run verify:perimeter-policy`
+- `npm --prefix apps/web run typecheck`
+- `npm --prefix apps/web run build`
+- `npm run verify:health-dashboard-server-only`
+- `git diff --check`
+
+## Next
+15.4 can move to `project-health` adapter. The real backup manifest producer remains an operational follow-up for Franky, not part of this backend adapter PR.

--- a/apps/api/src/modules/healthcheck/service.py
+++ b/apps/api/src/modules/healthcheck/service.py
@@ -17,7 +17,7 @@ from .domain import (
     validate_healthcheck_status,
 )
 
-from .source_adapters import VaultSyncManifestAdapter
+from .source_adapters import BackupHealthManifestAdapter, VaultSyncManifestAdapter
 
 if TYPE_CHECKING:
     from .registry import HealthcheckSourceSnapshot
@@ -71,8 +71,10 @@ class HealthcheckService:
 
     def _default_source_snapshot_state(self) -> dict[str, str]:
         vault_snapshot = VaultSyncManifestAdapter().snapshot()
-        self._default_source_records = {vault_snapshot.record.module_id: vault_snapshot.record}
-        return {vault_snapshot.record.module_id: vault_snapshot.freshness_state}
+        backup_snapshot = BackupHealthManifestAdapter().snapshot()
+        snapshots = (vault_snapshot, backup_snapshot)
+        self._default_source_records = {snapshot.record.module_id: snapshot.record for snapshot in snapshots}
+        return {snapshot.record.module_id: snapshot.freshness_state for snapshot in snapshots}
 
     def _records_with_default_sources(self, _snapshot_state: dict[str, str]) -> tuple[HealthcheckRecord, ...]:
         source_records = getattr(self, '_default_source_records', {})

--- a/apps/api/src/modules/healthcheck/source_adapters.py
+++ b/apps/api/src/modules/healthcheck/source_adapters.py
@@ -9,6 +9,7 @@ from .domain import HEALTHCHECK_SOURCE_FRESHNESS_THRESHOLDS
 from .registry import HealthcheckSourceRegistry, HealthcheckSourceSnapshot
 
 VAULT_SYNC_STATUS_MANIFEST = Path('/srv/crew-core/runtime/healthcheck/vault-sync-status.json')
+BACKUP_HEALTH_STATUS_MANIFEST = Path('/srv/crew-core/runtime/healthcheck/backup-health-status.json')
 
 
 class VaultSyncManifestAdapter:
@@ -122,6 +123,141 @@ class VaultSyncManifestAdapter:
         normalized = value.strip().lower()
         allowed = {'success', 'ok', 'pass', 'error', 'failed', 'fail', 'dirty', 'diverged', 'ahead', 'behind', 'stale', 'warning', 'warn'}
         return normalized if normalized in allowed else None
+
+    def _freshness_label(self, age_minutes: float) -> str:
+        if age_minutes < 1:
+            return 'Actualizado hace menos de 1 min'
+        rounded_minutes = int(age_minutes)
+        return f'Actualizado hace {rounded_minutes} min'
+
+
+class BackupHealthManifestAdapter:
+    """Fixed, allowlisted reader for Franky-owned local backup status manifests."""
+
+    source_id = 'backup-health'
+
+    def __init__(
+        self,
+        *,
+        manifest_path: Path = BACKUP_HEALTH_STATUS_MANIFEST,
+        registry: HealthcheckSourceRegistry | None = None,
+    ) -> None:
+        self._manifest_path = manifest_path
+        self._registry = registry or HealthcheckSourceRegistry()
+
+    def snapshot(self, *, now: str | datetime | None = None) -> HealthcheckSourceSnapshot:
+        if not self._manifest_path.exists():
+            return self._registry.normalize_absent(self.source_id)
+
+        try:
+            manifest = json.loads(self._manifest_path.read_text(encoding='utf-8'))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return self._registry.normalize_unreadable(self.source_id)
+
+        if not isinstance(manifest, Mapping):
+            return self._registry.normalize_unreadable(self.source_id)
+
+        raw = self._manifest_to_raw(manifest, now=self._parse_now(now))
+        return self._registry.normalize(self.source_id, raw)
+
+    def _manifest_to_raw(self, manifest: Mapping[object, object], *, now: datetime) -> dict[str, str]:
+        updated_at = self._safe_timestamp(manifest.get('last_success_at')) or self._safe_timestamp(manifest.get('updated_at'))
+        if updated_at is None:
+            return {
+                'status': 'unknown',
+                'severity': 'unknown',
+                'updated_at': '',
+                'summary': 'Backup local sin timestamp seguro disponible.',
+                'warning_text': 'Backup local sin timestamp seguro.',
+                'source_label': 'Backup safe manifest',
+                'freshness_label': 'Frescura desconocida',
+                'freshness_state': 'unknown',
+            }
+
+        result = self._safe_result(manifest.get('status')) or self._safe_result(manifest.get('result'))
+        checksum_present = self._safe_bool(manifest.get('checksum_present'))
+        retention_count = self._safe_int(manifest.get('retention_count'))
+        age_minutes = (now - _parse_timestamp(updated_at)).total_seconds() / 60
+        thresholds = HEALTHCHECK_SOURCE_FRESHNESS_THRESHOLDS[self.source_id]
+
+        if result in {'error', 'failed', 'fail'}:
+            status = 'fail'
+            severity = 'high'
+            summary = 'Backup local reporta fallo en su manifiesto seguro.'
+            warning = 'Backup local falló; revisar fuente operacional.'
+            freshness_state = 'stale'
+        elif checksum_present is False:
+            status = 'warn'
+            severity = 'medium'
+            summary = 'Backup local sin checksum seguro disponible.'
+            warning = 'Backup local sin checksum visible.'
+            freshness_state = 'stale'
+        elif retention_count is not None and retention_count < 4:
+            status = 'warn'
+            severity = 'medium'
+            summary = 'Backup local por debajo de la retención esperada.'
+            warning = 'Backup local con retención incompleta.'
+            freshness_state = 'stale'
+        elif age_minutes >= thresholds['fail_after_minutes']:
+            status = 'stale'
+            severity = 'high'
+            summary = 'Backup local stale según manifiesto seguro.'
+            warning = 'Backup local stale; revisar fuente operacional.'
+            freshness_state = 'stale'
+        elif age_minutes >= thresholds['warn_after_minutes']:
+            status = 'warn'
+            severity = 'medium'
+            summary = 'Backup local se acerca al umbral de frescura.'
+            warning = 'Backup local próximo a stale.'
+            freshness_state = 'stale'
+        else:
+            status = 'pass'
+            severity = 'low'
+            summary = 'Backup local reciente con checksum disponible.'
+            warning = 'Sin alerta activa.'
+            freshness_state = 'fresh'
+
+        return {
+            'status': status,
+            'severity': severity,
+            'updated_at': updated_at,
+            'summary': summary,
+            'warning_text': warning,
+            'source_label': 'Backup safe manifest',
+            'freshness_label': self._freshness_label(age_minutes),
+            'freshness_state': freshness_state,
+        }
+
+    def _parse_now(self, value: str | datetime | None) -> datetime:
+        if value is None:
+            return datetime.now(timezone.utc)
+        if isinstance(value, datetime):
+            return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+        return _parse_timestamp(value)
+
+    def _safe_timestamp(self, value: object) -> str | None:
+        if not isinstance(value, str):
+            return None
+        try:
+            _parse_timestamp(value)
+        except ValueError:
+            return None
+        return value
+
+    def _safe_result(self, value: object) -> str | None:
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip().lower()
+        allowed = {'success', 'ok', 'pass', 'error', 'failed', 'fail', 'stale', 'warning', 'warn'}
+        return normalized if normalized in allowed else None
+
+    def _safe_bool(self, value: object) -> bool | None:
+        return value if isinstance(value, bool) else None
+
+    def _safe_int(self, value: object) -> int | None:
+        if isinstance(value, bool):
+            return None
+        return value if isinstance(value, int) else None
 
     def _freshness_label(self, age_minutes: float) -> str:
         if age_minutes < 1:

--- a/apps/api/src/modules/healthcheck/source_adapters.py
+++ b/apps/api/src/modules/healthcheck/source_adapters.py
@@ -192,6 +192,12 @@ class BackupHealthManifestAdapter:
             summary = 'Backup local requiere revisión según manifiesto seguro.'
             warning = 'Backup local con degradación explícita.'
             freshness_state = 'stale'
+        elif result not in {'success', 'ok', 'pass'}:
+            status = 'warn'
+            severity = 'medium'
+            summary = 'Backup local sin resultado seguro disponible.'
+            warning = 'Backup local sin resultado positivo explícito.'
+            freshness_state = 'stale'
         elif checksum_present is not True:
             status = 'warn'
             severity = 'medium'

--- a/apps/api/src/modules/healthcheck/source_adapters.py
+++ b/apps/api/src/modules/healthcheck/source_adapters.py
@@ -186,13 +186,25 @@ class BackupHealthManifestAdapter:
             summary = 'Backup local reporta fallo en su manifiesto seguro.'
             warning = 'Backup local falló; revisar fuente operacional.'
             freshness_state = 'stale'
-        elif checksum_present is False:
+        elif result in {'stale', 'warning', 'warn'}:
+            status = 'warn'
+            severity = 'medium'
+            summary = 'Backup local requiere revisión según manifiesto seguro.'
+            warning = 'Backup local con degradación explícita.'
+            freshness_state = 'stale'
+        elif checksum_present is not True:
             status = 'warn'
             severity = 'medium'
             summary = 'Backup local sin checksum seguro disponible.'
             warning = 'Backup local sin checksum visible.'
             freshness_state = 'stale'
-        elif retention_count is not None and retention_count < 4:
+        elif retention_count is None:
+            status = 'warn'
+            severity = 'medium'
+            summary = 'Backup local sin retención segura disponible.'
+            warning = 'Backup local sin retención verificable.'
+            freshness_state = 'stale'
+        elif retention_count < 4:
             status = 'warn'
             severity = 'medium'
             summary = 'Backup local por debajo de la retención esperada.'

--- a/apps/api/tests/test_healthcheck_dashboard_api.py
+++ b/apps/api/tests/test_healthcheck_dashboard_api.py
@@ -397,6 +397,29 @@ def test_backup_health_manifest_adapter_preserves_explicit_degraded_status(tmp_p
 
 
 @pytest.mark.parametrize(
+    'manifest_body',
+    [
+        '{"last_success_at":"2026-04-24T07:30:00Z","checksum_present":true,"retention_count":4}',
+        '{"status":"green","last_success_at":"2026-04-24T07:30:00Z","checksum_present":true,"retention_count":4}',
+        '{"result":"done","last_success_at":"2026-04-24T07:30:00Z","checksum_present":true,"retention_count":4}',
+    ],
+)
+def test_backup_health_manifest_adapter_requires_explicit_positive_result(tmp_path, manifest_body):
+    manifest = tmp_path / 'backup-health-unsafe-result.json'
+    manifest.write_text(manifest_body, encoding='utf-8')
+
+    snapshot = BackupHealthManifestAdapter(manifest_path=manifest).snapshot(now='2026-04-24T08:00:00Z')
+    payload = HealthcheckService.from_source_snapshots((snapshot,)).get_workspace()
+
+    module = payload['modules'][0]
+    assert module['status'] == 'warn'
+    assert module['severity'] == 'medium'
+    assert module['summary'] == 'Backup local sin resultado seguro disponible.'
+    assert payload['signals'][0]['freshness']['state'] == 'stale'
+    _assert_no_sensitive_host_output(payload)
+
+
+@pytest.mark.parametrize(
     ('manifest_body', 'expected_summary'),
     [
         (

--- a/apps/api/tests/test_healthcheck_dashboard_api.py
+++ b/apps/api/tests/test_healthcheck_dashboard_api.py
@@ -15,7 +15,7 @@ from apps.api.src.modules.healthcheck.domain import (
     HealthcheckRecord,
 )
 from apps.api.src.modules.healthcheck.registry import HealthcheckSourceRegistry
-from apps.api.src.modules.healthcheck.source_adapters import VaultSyncManifestAdapter
+from apps.api.src.modules.healthcheck.source_adapters import BackupHealthManifestAdapter, VaultSyncManifestAdapter
 from apps.api.src.modules.healthcheck.service import HealthcheckService
 from apps.api.src.modules.dashboard.service import DashboardService
 
@@ -314,6 +314,72 @@ def test_vault_sync_manifest_adapter_models_missing_or_unreadable_manifest(tmp_p
     unreadable_manifest = tmp_path / 'vault-sync-status.json'
     unreadable_manifest.write_text('{not-json', encoding='utf-8')
     unreadable = VaultSyncManifestAdapter(manifest_path=unreadable_manifest).snapshot(now='2026-04-24T08:00:00Z')
+
+    payload = HealthcheckService.from_source_snapshots((missing, unreadable)).get_workspace()
+
+    status_by_module = {module['summary']: module['status'] for module in payload['modules']}
+    assert status_by_module == {
+        'Fuente Healthcheck ausente o todavía no configurada.': 'not_configured',
+        'Fuente Healthcheck no legible; no se expone salida cruda.': 'unknown',
+    }
+    _assert_no_sensitive_host_output(payload)
+
+
+def test_backup_health_manifest_adapter_maps_recent_success_to_safe_pass(tmp_path):
+    manifest = tmp_path / 'backup-health-status.json'
+    manifest.write_text(
+        '{"status":"success","last_success_at":"2026-04-24T07:30:00Z","checksum_present":true,"retention_count":4,"archive_path":"/srv/crew-core/backups/private.tar.gz","included_path":"/home/agentops/private","stdout":"token secret raw_output"}',
+        encoding='utf-8',
+    )
+
+    snapshot = BackupHealthManifestAdapter(manifest_path=manifest).snapshot(now='2026-04-24T08:00:00Z')
+    payload = HealthcheckService.from_source_snapshots((snapshot,)).get_workspace()
+
+    assert payload['modules'] == [
+        {
+            'module_id': 'backup-health',
+            'label': 'Backups',
+            'status': 'pass',
+            'severity': 'low',
+            'updated_at': '2026-04-24T07:30:00Z',
+            'summary': 'Backup local reciente con checksum disponible.',
+        }
+    ]
+    assert payload['signals'] == []
+    _assert_no_sensitive_host_output(payload)
+
+
+def test_backup_health_manifest_adapter_degrades_stale_and_missing_checksum(tmp_path):
+    stale_manifest = tmp_path / 'backup-health-stale.json'
+    stale_manifest.write_text(
+        '{"status":"success","last_success_at":"2026-04-21T08:00:00Z","checksum_present":true,"retention_count":4}',
+        encoding='utf-8',
+    )
+    missing_checksum_manifest = tmp_path / 'backup-health-missing-checksum.json'
+    missing_checksum_manifest.write_text(
+        '{"status":"success","last_success_at":"2026-04-24T07:30:00Z","checksum_present":false,"retention_count":4}',
+        encoding='utf-8',
+    )
+
+    stale = BackupHealthManifestAdapter(manifest_path=stale_manifest).snapshot(now='2026-04-24T08:00:00Z')
+    missing_checksum = BackupHealthManifestAdapter(manifest_path=missing_checksum_manifest).snapshot(now='2026-04-24T08:00:00Z')
+    payload = HealthcheckService.from_source_snapshots((stale, missing_checksum)).get_workspace()
+
+    status_by_summary = {module['summary']: module['status'] for module in payload['modules']}
+    assert status_by_summary == {
+        'Backup local stale según manifiesto seguro.': 'stale',
+        'Backup local sin checksum seguro disponible.': 'warn',
+    }
+    assert {signal['check_id'] for signal in payload['signals']} == {'backup-health.last-backup'}
+    assert all(signal['freshness']['state'] == 'stale' for signal in payload['signals'])
+    _assert_no_sensitive_host_output(payload)
+
+
+def test_backup_health_manifest_adapter_models_missing_or_unreadable_manifest(tmp_path):
+    missing = BackupHealthManifestAdapter(manifest_path=tmp_path / 'missing.json').snapshot(now='2026-04-24T08:00:00Z')
+    unreadable_manifest = tmp_path / 'backup-health-status.json'
+    unreadable_manifest.write_text('{not-json', encoding='utf-8')
+    unreadable = BackupHealthManifestAdapter(manifest_path=unreadable_manifest).snapshot(now='2026-04-24T08:00:00Z')
 
     payload = HealthcheckService.from_source_snapshots((missing, unreadable)).get_workspace()
 

--- a/apps/api/tests/test_healthcheck_dashboard_api.py
+++ b/apps/api/tests/test_healthcheck_dashboard_api.py
@@ -375,6 +375,55 @@ def test_backup_health_manifest_adapter_degrades_stale_and_missing_checksum(tmp_
     _assert_no_sensitive_host_output(payload)
 
 
+@pytest.mark.parametrize('degraded_status', ['warn', 'warning', 'stale'])
+def test_backup_health_manifest_adapter_preserves_explicit_degraded_status(tmp_path, degraded_status):
+    manifest = tmp_path / f'backup-health-{degraded_status}.json'
+    manifest.write_text(
+        f'{{"status":"{degraded_status}","last_success_at":"2026-04-24T07:30:00Z","checksum_present":true,"retention_count":4}}',
+        encoding='utf-8',
+    )
+
+    snapshot = BackupHealthManifestAdapter(manifest_path=manifest).snapshot(now='2026-04-24T08:00:00Z')
+    payload = HealthcheckService.from_source_snapshots((snapshot,)).get_workspace()
+
+    module = payload['modules'][0]
+    signal = payload['signals'][0]
+    assert module['status'] == 'warn'
+    assert module['severity'] == 'medium'
+    assert module['summary'] == 'Backup local requiere revisión según manifiesto seguro.'
+    assert signal['warning_text'] == 'Backup local con degradación explícita.'
+    assert signal['freshness']['state'] == 'stale'
+    _assert_no_sensitive_host_output(payload)
+
+
+@pytest.mark.parametrize(
+    ('manifest_body', 'expected_summary'),
+    [
+        (
+            '{"status":"success","last_success_at":"2026-04-24T07:30:00Z","retention_count":4}',
+            'Backup local sin checksum seguro disponible.',
+        ),
+        (
+            '{"status":"success","last_success_at":"2026-04-24T07:30:00Z","checksum_present":true}',
+            'Backup local sin retención segura disponible.',
+        ),
+    ],
+)
+def test_backup_health_manifest_adapter_requires_integrity_and_retention_fields(tmp_path, manifest_body, expected_summary):
+    manifest = tmp_path / 'backup-health-partial.json'
+    manifest.write_text(manifest_body, encoding='utf-8')
+
+    snapshot = BackupHealthManifestAdapter(manifest_path=manifest).snapshot(now='2026-04-24T08:00:00Z')
+    payload = HealthcheckService.from_source_snapshots((snapshot,)).get_workspace()
+
+    module = payload['modules'][0]
+    assert module['status'] == 'warn'
+    assert module['severity'] == 'medium'
+    assert module['summary'] == expected_summary
+    assert payload['signals'][0]['freshness']['state'] == 'stale'
+    _assert_no_sensitive_host_output(payload)
+
+
 def test_backup_health_manifest_adapter_models_missing_or_unreadable_manifest(tmp_path):
     missing = BackupHealthManifestAdapter(manifest_path=tmp_path / 'missing.json').snapshot(now='2026-04-24T08:00:00Z')
     unreadable_manifest = tmp_path / 'backup-health-status.json'

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -46,7 +46,8 @@
 - normalizar payloads de adapters futuros con registro backend-owned allowlist-only antes de serializar; campos crudos o desconocidos se descartan y los source IDs rechazados no se ecoan
 - consumir solo fuentes saneadas y timestamps de frescura
 - conectar en Phase 15.3a el primer adapter vivo `vault-sync` desde manifiesto fijo Franky-owned, sin exponer rutas, ramas, remotes, Git output ni campos raw
-- mantener backup/project/gateway/cronjob reads fuera hasta sus microfases revisadas
+- conectar en Phase 15.3b el adapter vivo `backup-health` desde manifiesto fijo Franky-owned, sin exponer rutas de archivo, nombres de archivos, paths incluidos, stdout/stderr, tamaños ni campos raw
+- mantener project/gateway/cronjob reads fuera hasta sus microfases revisadas
 - documentar y verificar manifest ownership and freshness thresholds antes de cualquier lectura viva (`docs/healthcheck-source-policy.md`)
 - bloquear crecimiento accidental hacia consola host genérica con `npm run verify:healthcheck-source-policy`
 - no ejecutar shell, Docker, systemd ni leer logs/salidas crudas del host en esta fase

--- a/docs/healthcheck-source-policy.md
+++ b/docs/healthcheck-source-policy.md
@@ -1,7 +1,7 @@
 # Healthcheck source policy
 
 ## Purpose
-Phase 15.2c closed the final foundation slice before live Healthcheck source adapters. It defines the source-policy contract that adapters must satisfy. Phase 15.3a starts live reads with the `vault-sync` adapter only, through a fixed Franky-owned manifest path and the existing registry sanitizer.
+Phase 15.2c closed the final foundation slice before live Healthcheck source adapters. It defines the source-policy contract that adapters must satisfy. Phase 15.3a started live reads with the `vault-sync` adapter only; Phase 15.3b adds the `backup-health` adapter. Both consume fixed Franky-owned manifests and route through the existing registry sanitizer.
 
 ## No generic host console
 Healthcheck must not become a generic host console. New source code in `apps/api/src/modules/healthcheck` must not introduce generic shell, process, command execution, arbitrary URL-fetch adapters or generic filesystem discovery without a reviewed, allowlisted phase.
@@ -13,7 +13,7 @@ Blocked by `npm run verify:healthcheck-source-policy`:
 - command-parameter based host adapters;
 - generic filesystem discovery or reads such as `glob`, `os.listdir`, `os.scandir`, `os.walk`, ambient `Path.home()` / `Path.cwd()`, recursive `rglob()` or direct `open()` in the Healthcheck module.
 
-Adapters remain explicit, source-family-specific and reviewed. No live manifest reads are implemented in Phase 15.2c. Phase 15.3a allows only the fixed `vault-sync` manifest reader in `source_adapters.py`; it does not add backup, project-health, gateway or cronjob reads.
+Adapters remain explicit, source-family-specific and reviewed. No live manifest reads are implemented in Phase 15.2c. Phase 15.3a allows the fixed `vault-sync` manifest reader in `source_adapters.py`; Phase 15.3b also allows the fixed `backup-health` manifest reader. These phases still do not add project-health, gateway or cronjob reads.
 
 ## Text field sanitization
 Future adapters must sanitize summaries before handing them to Healthcheck. As defense in depth, `HealthcheckSourceRegistry` ignores adapter-provided labels and always resolves `label` from backend-owned `HEALTHCHECK_SOURCE_LABELS[source_id]`. It also applies a final sensitive-marker filter to allowed textual fields: `summary`, `warning_text`, `source_label` and `freshness_label`.
@@ -26,7 +26,7 @@ Future live adapters may consume only sanitized summaries from reviewed sources.
 | Source family | Owner | Safe location class | Notes |
 | --- | --- | --- | --- |
 | `vault-sync` | Franky | Franky-owned operational source | Phase 15.3a reads a fixed status manifest and exposes only timestamp/result-derived summary fields. |
-| `backup-health` | Franky | Franky-owned operational source | Status manifest or wrapper maintained by operations. |
+| `backup-health` | Franky | Franky-owned operational source | Phase 15.3b reads a fixed local backup status manifest and exposes only timestamp/result/checksum/retention-derived summary fields. |
 | `cronjobs` | Franky | shared manifest registry, not Zoro profile-local `cronjob list` | Must represent global scheduled jobs safely, not one profile's local runtime view. |
 | `hermes-gateways` | Franky | systemd user gateway summary | Aggregated gateway status only. |
 | `gateway.<mugiwara-slug>` | Franky | allowlisted gateway status summary | One allowlisted process summary per Mugiwara slug. |
@@ -43,7 +43,7 @@ Thresholds are intentionally backend-owned policy before Phase 15.3+ live adapte
 - `hermes-gateways` and `gateway.<mugiwara-slug>`: warn after 15 minutes, fail after 60 minutes.
 - `cronjobs`: warn after 180 minutes, fail after 720 minutes.
 
-These thresholds are not applied to live data in Phase 15.2c. Future adapters must parse timestamps explicitly, normalize to the existing Healthcheck freshness vocabulary and degrade absent/unreadable data to `not_configured`, `unknown` or `stale`, never to healthy output.
+These thresholds are not applied to live data in Phase 15.2c. Phase 15.3a/15.3b apply them only to fixed `vault-sync` and `backup-health` manifests. Future adapters must parse timestamps explicitly, normalize to the existing Healthcheck freshness vocabulary and degrade absent/unreadable data to `not_configured`, `unknown` or `stale`, never to healthy output.
 
 ## Verify
 Run after changes that touch Healthcheck source adapters, docs or source-policy boundaries:

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -72,6 +72,8 @@ Phase 15.2c adds static guardrails, manifest ownership and freshness thresholds 
 
 Phase 15.3a connects the first live source: `vault-sync`. The adapter reads only a fixed Franky-owned status manifest, derives `pass`/`warn`/`stale`/`fail` from safe result and timestamp fields, routes output through `HealthcheckSourceRegistry`, and degrades missing or unreadable manifests to `not_configured`/`unknown`. It does not expose manifest paths, branch names, Git output, raw fields or remotes, and it does not add backup/project/gateway/cronjob reads.
 
+Phase 15.3b connects the second live source: `backup-health`. The adapter reads only a fixed Franky-owned local backup status manifest, consumes safe status/timestamp/checksum/retention fields, routes output through `HealthcheckSourceRegistry`, and degrades missing or unreadable manifests to `not_configured`/`unknown`. It does not expose archive names, backup paths, included paths, stdout/stderr, raw output, file sizes or runtime manifest internals, and it does not add project/gateway/cronjob reads.
+
 ### `memory.agent_summary`
 Campos esperados:
 - `mugiwara_slug`

--- a/openspec/phase-15-3b-backup-adapter.md
+++ b/openspec/phase-15-3b-backup-adapter.md
@@ -1,0 +1,74 @@
+# Phase 15.3b — Local backup safe adapter
+
+## Objective
+Connect the second live Healthcheck source for Phase 15.3: `backup-health` only.
+
+This microphase reads a fixed, Franky-owned local backup status manifest and exposes only a sanitized Healthcheck summary through the existing backend-owned source registry.
+
+## Why split 15.3b
+Phase 15.3 originally covered vault sync and local backups together. Phase 15.3a proved the live-source pattern with `vault-sync`. 15.3b keeps backup health isolated because backup manifests have different operational semantics and leakage risks: archive names, backup paths, included paths, checksums and retention metadata must not become public API output.
+
+## Scope
+- Add `BackupHealthManifestAdapter` under the Healthcheck backend module.
+- Read only a fixed allowlisted backup status manifest path owned by operations.
+- Consume only safe manifest semantics: `status|result`, `last_success_at|updated_at`, `checksum_present` and `retention_count`.
+- Derive Healthcheck `status`, `severity`, `freshness_state`, summary and warning text from backend-owned policy.
+- Route adapter output through `HealthcheckSourceRegistry` so label ownership, field allowlisting and sensitive-text fallback still apply.
+- Replace the default fixture-backed `backup-health` record with the adapter snapshot while preserving the rest of the safe catalog.
+- Update Healthcheck docs/read-models/source-policy.
+
+## Out of scope
+- Producing or scheduling the real backup manifest.
+- Drive/private remote backup health.
+- Project health adapter.
+- Gateway/systemd adapter.
+- Cronjob registry adapter.
+- Shell, subprocess, backup command execution, generic filesystem discovery, archive enumeration or URL fetches.
+- Exposing archive paths/names, included paths, backup paths, file sizes, checksums, stdout/stderr, raw output, logs, manifest internals or credentials.
+
+## Manifest contract
+The adapter treats the manifest as an operational input, not a public API. It consumes only:
+
+- `status` or `result`: safe enum-like status values.
+- `last_success_at` or `updated_at`: ISO timestamp.
+- `checksum_present`: boolean.
+- `retention_count`: integer count against the expected local retention of 4.
+
+Other manifest fields are ignored before serialization. If the manifest is missing, output is `not_configured`; if it is unreadable or invalid JSON, output is `unknown`. Neither case becomes healthy output.
+
+## Freshness policy
+Uses the existing backend-owned `backup-health` thresholds:
+
+- warn after 1800 minutes.
+- fail/stale after 4320 minutes.
+
+Recent successful status with checksum available becomes `pass/low/fresh`. Missing checksum or incomplete retention becomes `warn/medium/stale`. Old successful timestamps become `warn` or `stale` depending on age. Error/fail status becomes `fail/high/stale`.
+
+## Definition of done
+- Tests cover recent success, stale timestamp, missing checksum, missing manifest and unreadable manifest.
+- Tests prove noisy manifest fields do not reach the serialized workspace.
+- `/api/v1/healthcheck` continues to return a sanitized read model.
+- Static Healthcheck source-policy guardrail still passes.
+- No new generic host-console pattern appears in Healthcheck source code.
+- Docs and closeout are updated.
+
+## Verify
+Run from repo root:
+
+```bash
+python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/registry.py apps/api/src/modules/healthcheck/source_adapters.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py
+PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q
+PYTHONPATH=. python -m pytest apps/api/tests -q
+npm run verify:healthcheck-source-policy
+npm run verify:perimeter-policy
+npm --prefix apps/web run typecheck
+npm --prefix apps/web run build
+npm run verify:health-dashboard-server-only
+git diff --check
+```
+
+## Review
+Request Franky + Chopper:
+
+- Franky: operational manifest contract, checksum/retention semantics and freshness thresholds.
+- Chopper: leakage boundary, sanitizer preservation and absence of generic host reads.

--- a/openspec/phase-15-3b-verify-checklist.md
+++ b/openspec/phase-15-3b-verify-checklist.md
@@ -1,0 +1,36 @@
+# Phase 15.3b — Verify checklist
+
+## Scope verified
+- [x] `BackupHealthManifestAdapter` added as the second live Healthcheck source adapter.
+- [x] Adapter is source-specific and fixed to `backup-health`; no generic host console, shell, subprocess, backup command, URL fetch or filesystem discovery added.
+- [x] Manifest values are reduced to safe status/timestamp/checksum/retention semantics before entering the public read model.
+- [x] Output still passes through `HealthcheckSourceRegistry` label ownership, allowlist filtering and text sanitizer.
+- [x] Missing manifest degrades to `not_configured`; unreadable/invalid manifest degrades to `unknown`.
+- [x] Docs updated in `docs/api-modules.md`, `docs/read-models.md` and `docs/healthcheck-source-policy.md`.
+
+## Automated verify
+Executed from repo root on branch `zoro/phase-15-3b-backup-adapter`:
+
+```bash
+python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/registry.py apps/api/src/modules/healthcheck/source_adapters.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py
+PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q
+PYTHONPATH=. python -m pytest apps/api/tests -q
+npm run verify:healthcheck-source-policy
+npm run verify:perimeter-policy
+npm --prefix apps/web run typecheck
+npm --prefix apps/web run build
+npm run verify:health-dashboard-server-only
+git diff --check
+```
+
+Result: all passed.
+
+## Security/leakage checks
+- [x] Regression test injects manifest noise containing archive path, included path, stdout/raw output and token markers; serialized workspace remains sanitized.
+- [x] Adapter ignores archive paths/names, included paths, backup paths, stdout/stderr/raw output, file sizes and other manifest internals.
+- [x] No project/gateway/cronjob live reads introduced.
+
+## Review routing
+Request Franky + Chopper before merge:
+- Franky for operational manifest, checksum/retention contract and freshness semantics.
+- Chopper for host/leakage boundary.

--- a/scripts/check-healthcheck-source-policy.mjs
+++ b/scripts/check-healthcheck-source-policy.mjs
@@ -128,7 +128,9 @@ const requiredDocSnippets = [
   '`cronjobs`: warn after 180 minutes, fail after 720 minutes',
   '`hermes-gateways` and `gateway.<mugiwara-slug>`: warn after 15 minutes, fail after 60 minutes',
   '`project-health`: warn after 120 minutes, fail after 480 minutes',
-  'No live manifest reads are implemented in Phase 15.2c',
+  'Phase 15.3b also allows the fixed `backup-health` manifest reader',
+  'Phase 15.3b reads a fixed local backup status manifest and exposes only timestamp/result/checksum/retention-derived summary fields',
+  'These phases still do not add project-health, gateway or cronjob reads',
   'do not include `stdout`, `stderr`, `raw_output`, `command`, `traceback`, `pid`, `unit_content`, `journal`, absolute host paths, `backup_path`, `included_path`, `prompt_body`, `chat_id`, delivery targets, tokens, cookies, credentials, `.env`, Git diffs, untracked file lists or internal remotes',
 ]
 


### PR DESCRIPTION
## Objetivo

Phase 15.3b conecta la segunda fuente viva de Healthcheck: `backup-health`.

## Cambios

- Añade `BackupHealthManifestAdapter` con lectura fija de `/srv/crew-core/runtime/healthcheck/backup-health-status.json`.
- Consume solo semántica segura del manifiesto: `status|result`, `last_success_at|updated_at`, `checksum_present`, `retention_count`.
- Degrada manifiesto ausente a `not_configured` e ilegible/JSON inválido a `unknown`.
- Sustituye el registro fixture-backed de `backup-health` por snapshot del adapter en el catálogo por defecto.
- Añade tests TDD para éxito reciente, stale, checksum ausente, manifiesto ausente/ilegible y ruido sensible ignorado.
- Actualiza docs, OpenSpec, verify checklist y closeout Engram.

## Fuera de alcance

- Productor/writer real del manifiesto de backups.
- Estado de backup remoto/Drive.
- Adapters de project health, gateways o cronjobs.
- Shell/subprocess, comandos de backup, discovery de filesystem, enumeración de archivos o exposición de paths/nombres de archivos.

## Verificación ejecutada

```bash
python -m py_compile apps/api/src/modules/healthcheck/domain.py apps/api/src/modules/healthcheck/registry.py apps/api/src/modules/healthcheck/source_adapters.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py
PYTHONPATH=. python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q
PYTHONPATH=. python -m pytest apps/api/tests -q
npm run verify:healthcheck-source-policy
npm run verify:perimeter-policy
npm --prefix apps/web run typecheck
npm --prefix apps/web run build
npm run verify:health-dashboard-server-only
git diff --check
```

Resultado: todo verde.

## Riesgos / revisión solicitada

- **Franky:** revisar contrato operativo del manifiesto, semántica checksum/retención y umbrales de freshness.
- **Chopper:** revisar frontera host/leakage, ausencia de consola host genérica y preservación del sanitizer.

No mergear hasta recibir Franky + Chopper (`approve` o `mergeable_with_minor_followups`).