### PR TITLE
feat: add project health local adapter

### DIFF
--- a/.engram/phase-15-4a-implementation-closeout.md
+++ b/.engram/phase-15-4a-implementation-closeout.md
@@ -1,0 +1,24 @@
+# Phase 15.4a implementation closeout — project-health local adapter
+
+## Resultado
+Phase 15.4a implementa `ProjectHealthManifestAdapter` como adapter vivo acotado para `project-health`.
+
+## Cambios
+- `apps/api/src/modules/healthcheck/source_adapters.py`: nuevo adapter que lee el manifiesto fijo `/srv/crew-core/runtime/healthcheck/project-health-status.json` y reduce el contenido a semántica segura de estado/timestamp/booleanos.
+- `apps/api/src/modules/healthcheck/service.py`: `HealthcheckService` incluye el snapshot de `project-health` en sus fuentes por defecto junto a `vault-sync` y `backup-health`.
+- `apps/api/tests/test_healthcheck_dashboard_api.py`: tests TDD para pass seguro, estados locales degradados, contrato fail-closed, stale, missing/unreadable y no leakage.
+- `docs/healthcheck-source-policy.md`, `docs/api-modules.md`, `docs/read-models.md`: documentación viva actualizada.
+- `scripts/check-healthcheck-source-policy.mjs`: guardrail actualizado para fijar que 15.4a permite solo el manifest reader fijo y excluye GitHub counts/last-verify.
+
+## Límites conservados
+- No se ejecuta Git desde el backend.
+- No se exponen remotes, ramas crudas, diffs, listas de untracked files, paths host, salidas Git, GitHub counts ni last-verify detail.
+- Gateway y cronjobs siguen fuera de alcance.
+
+## Verify
+Ejecutado en rama `zoro/phase-15-4a-project-health-local-adapter`:
+- `python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` -> 39 passed.
+- `python -m py_compile apps/api/src/modules/healthcheck/source_adapters.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py` -> OK.
+- `npm run verify:healthcheck-source-policy` -> passed.
+- `git diff --check` -> OK.
+- Scan dirigido del diff: solo aparecen marcadores sintéticos de tests/docs (`token`, `.env`, `stdout`, `remote_url`, etc.) usados para verificar saneado; no hay secretos reales ni salidas host crudas.

--- a/apps/api/src/modules/healthcheck/service.py
+++ b/apps/api/src/modules/healthcheck/service.py
@@ -17,7 +17,7 @@ from .domain import (
     validate_healthcheck_status,
 )
 
-from .source_adapters import BackupHealthManifestAdapter, VaultSyncManifestAdapter
+from .source_adapters import BackupHealthManifestAdapter, ProjectHealthManifestAdapter, VaultSyncManifestAdapter
 
 if TYPE_CHECKING:
     from .registry import HealthcheckSourceSnapshot
@@ -71,8 +71,9 @@ class HealthcheckService:
 
     def _default_source_snapshot_state(self) -> dict[str, str]:
         vault_snapshot = VaultSyncManifestAdapter().snapshot()
+        project_snapshot = ProjectHealthManifestAdapter().snapshot()
         backup_snapshot = BackupHealthManifestAdapter().snapshot()
-        snapshots = (vault_snapshot, backup_snapshot)
+        snapshots = (vault_snapshot, project_snapshot, backup_snapshot)
         self._default_source_records = {snapshot.record.module_id: snapshot.record for snapshot in snapshots}
         return {snapshot.record.module_id: snapshot.freshness_state for snapshot in snapshots}
 

--- a/apps/api/src/modules/healthcheck/source_adapters.py
+++ b/apps/api/src/modules/healthcheck/source_adapters.py
@@ -10,6 +10,7 @@ from .registry import HealthcheckSourceRegistry, HealthcheckSourceSnapshot
 
 VAULT_SYNC_STATUS_MANIFEST = Path('/srv/crew-core/runtime/healthcheck/vault-sync-status.json')
 BACKUP_HEALTH_STATUS_MANIFEST = Path('/srv/crew-core/runtime/healthcheck/backup-health-status.json')
+PROJECT_HEALTH_STATUS_MANIFEST = Path('/srv/crew-core/runtime/healthcheck/project-health-status.json')
 
 
 class VaultSyncManifestAdapter:
@@ -282,6 +283,155 @@ class BackupHealthManifestAdapter:
             return 'Actualizado hace menos de 1 min'
         rounded_minutes = int(age_minutes)
         return f'Actualizado hace {rounded_minutes} min'
+
+class ProjectHealthManifestAdapter:
+    """Fixed, allowlisted reader for Zoro-owned repo-local project health manifests."""
+
+    source_id = 'project-health'
+
+    def __init__(
+        self,
+        *,
+        manifest_path: Path = PROJECT_HEALTH_STATUS_MANIFEST,
+        registry: HealthcheckSourceRegistry | None = None,
+    ) -> None:
+        self._manifest_path = manifest_path
+        self._registry = registry or HealthcheckSourceRegistry()
+
+    def snapshot(self, *, now: str | datetime | None = None) -> HealthcheckSourceSnapshot:
+        if not self._manifest_path.exists():
+            return self._registry.normalize_absent(self.source_id)
+
+        try:
+            manifest = json.loads(self._manifest_path.read_text(encoding='utf-8'))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return self._registry.normalize_unreadable(self.source_id)
+
+        if not isinstance(manifest, Mapping):
+            return self._registry.normalize_unreadable(self.source_id)
+
+        raw = self._manifest_to_raw(manifest, now=self._parse_now(now))
+        return self._registry.normalize(self.source_id, raw)
+
+    def _manifest_to_raw(self, manifest: Mapping[object, object], *, now: datetime) -> dict[str, str]:
+        updated_at = self._safe_timestamp(manifest.get('updated_at')) or self._safe_timestamp(manifest.get('last_success_at'))
+        if updated_at is None:
+            return {
+                'status': 'unknown',
+                'severity': 'unknown',
+                'updated_at': '',
+                'summary': 'Repo local sin timestamp seguro disponible.',
+                'warning_text': 'Project health sin timestamp seguro.',
+                'source_label': 'Project health safe manifest',
+                'freshness_label': 'Frescura desconocida',
+                'freshness_state': 'unknown',
+            }
+
+        result = self._safe_result(manifest.get('status')) or self._safe_result(manifest.get('result'))
+        workspace_clean = self._safe_bool(manifest.get('workspace_clean'))
+        main_branch = self._safe_bool(manifest.get('main_branch'))
+        remote_synced = self._safe_bool(manifest.get('remote_synced'))
+        age_minutes = (now - _parse_timestamp(updated_at)).total_seconds() / 60
+        thresholds = HEALTHCHECK_SOURCE_FRESHNESS_THRESHOLDS[self.source_id]
+
+        if result in {'error', 'failed', 'fail'}:
+            status = 'fail'
+            severity = 'high'
+            summary = 'Repo local reporta fallo en su manifiesto seguro.'
+            warning = 'Project health falló; revisar repo local.'
+            freshness_state = 'stale'
+        elif result in {'dirty', 'diverged', 'ahead', 'behind', 'stale', 'warning', 'warn'}:
+            status = 'warn'
+            severity = 'medium'
+            summary = 'Repo local requiere revisión según manifiesto seguro.'
+            warning = 'Repo local con degradación explícita.'
+            freshness_state = 'stale'
+        elif result not in {'success', 'ok', 'pass'} or workspace_clean is None or main_branch is None or remote_synced is None:
+            status = 'warn'
+            severity = 'medium'
+            summary = 'Repo local sin estado seguro completo disponible.'
+            warning = 'Project health sin resultado completo.'
+            freshness_state = 'stale'
+        elif workspace_clean is not True:
+            status = 'warn'
+            severity = 'medium'
+            summary = 'Repo local con cambios pendientes según manifiesto seguro.'
+            warning = 'Repo local con cambios pendientes.'
+            freshness_state = 'stale'
+        elif main_branch is not True:
+            status = 'warn'
+            severity = 'medium'
+            summary = 'Repo local fuera de la rama estable esperada.'
+            warning = 'Repo local no está en main según manifiesto seguro.'
+            freshness_state = 'stale'
+        elif remote_synced is not True:
+            status = 'warn'
+            severity = 'medium'
+            summary = 'Repo local pendiente de sincronización remota según manifiesto seguro.'
+            warning = 'Repo local pendiente de sincronización.'
+            freshness_state = 'stale'
+        elif age_minutes >= thresholds['fail_after_minutes']:
+            status = 'stale'
+            severity = 'high'
+            summary = 'Repo local stale según manifiesto seguro.'
+            warning = 'Project health stale; revisar fuente operacional.'
+            freshness_state = 'stale'
+        elif age_minutes >= thresholds['warn_after_minutes']:
+            status = 'warn'
+            severity = 'medium'
+            summary = 'Repo local se acerca al umbral de frescura.'
+            warning = 'Project health próximo a stale.'
+            freshness_state = 'stale'
+        else:
+            status = 'pass'
+            severity = 'low'
+            summary = 'Repo local revisado recientemente sin incidencias visibles.'
+            warning = 'Sin alerta activa.'
+            freshness_state = 'fresh'
+
+        return {
+            'status': status,
+            'severity': severity,
+            'updated_at': updated_at,
+            'summary': summary,
+            'warning_text': warning,
+            'source_label': 'Project health safe manifest',
+            'freshness_label': self._freshness_label(age_minutes),
+            'freshness_state': freshness_state,
+        }
+
+    def _parse_now(self, value: str | datetime | None) -> datetime:
+        if value is None:
+            return datetime.now(timezone.utc)
+        if isinstance(value, datetime):
+            return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+        return _parse_timestamp(value)
+
+    def _safe_timestamp(self, value: object) -> str | None:
+        if not isinstance(value, str):
+            return None
+        try:
+            _parse_timestamp(value)
+        except ValueError:
+            return None
+        return value
+
+    def _safe_result(self, value: object) -> str | None:
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip().lower()
+        allowed = {'success', 'ok', 'pass', 'error', 'failed', 'fail', 'dirty', 'diverged', 'ahead', 'behind', 'stale', 'warning', 'warn'}
+        return normalized if normalized in allowed else None
+
+    def _safe_bool(self, value: object) -> bool | None:
+        return value if isinstance(value, bool) else None
+
+    def _freshness_label(self, age_minutes: float) -> str:
+        if age_minutes < 1:
+            return 'Actualizado hace menos de 1 min'
+        rounded_minutes = int(age_minutes)
+        return f'Actualizado hace {rounded_minutes} min'
+
 
 
 def _parse_timestamp(value: str) -> datetime:

--- a/apps/api/tests/test_healthcheck_dashboard_api.py
+++ b/apps/api/tests/test_healthcheck_dashboard_api.py
@@ -15,7 +15,7 @@ from apps.api.src.modules.healthcheck.domain import (
     HealthcheckRecord,
 )
 from apps.api.src.modules.healthcheck.registry import HealthcheckSourceRegistry
-from apps.api.src.modules.healthcheck.source_adapters import BackupHealthManifestAdapter, VaultSyncManifestAdapter
+from apps.api.src.modules.healthcheck.source_adapters import BackupHealthManifestAdapter, ProjectHealthManifestAdapter, VaultSyncManifestAdapter
 from apps.api.src.modules.healthcheck.service import HealthcheckService
 from apps.api.src.modules.dashboard.service import DashboardService
 
@@ -459,6 +459,109 @@ def test_backup_health_manifest_adapter_models_missing_or_unreadable_manifest(tm
     assert status_by_module == {
         'Fuente Healthcheck ausente o todavía no configurada.': 'not_configured',
         'Fuente Healthcheck no legible; no se expone salida cruda.': 'unknown',
+    }
+    _assert_no_sensitive_host_output(payload)
+
+
+def test_project_health_manifest_adapter_maps_clean_synced_workspace_to_safe_pass(tmp_path):
+    manifest = tmp_path / 'project-health-status.json'
+    manifest.write_text(
+        '{"status":"success","updated_at":"2026-04-24T07:30:00Z","workspace_clean":true,"main_branch":true,"remote_synced":true,"branch":"main","remote_url":"git@github.com:private/repo.git","git_diff":"diff --git a/.env b/.env","untracked_files":[".env"],"stdout":"token secret raw_output"}',
+        encoding='utf-8',
+    )
+
+    snapshot = ProjectHealthManifestAdapter(manifest_path=manifest).snapshot(now='2026-04-24T08:00:00Z')
+    payload = HealthcheckService.from_source_snapshots((snapshot,)).get_workspace()
+
+    assert payload['modules'] == [
+        {
+            'module_id': 'project-health',
+            'label': 'Project health',
+            'status': 'pass',
+            'severity': 'low',
+            'updated_at': '2026-04-24T07:30:00Z',
+            'summary': 'Repo local revisado recientemente sin incidencias visibles.',
+        }
+    ]
+    assert payload['signals'] == []
+    _assert_no_sensitive_host_output(payload)
+
+
+@pytest.mark.parametrize(
+    ('manifest_body', 'expected_summary'),
+    [
+        (
+            '{"status":"success","updated_at":"2026-04-24T07:30:00Z","workspace_clean":false,"main_branch":true,"remote_synced":true,"untracked_files":[".env"],"git_diff":"secret diff"}',
+            'Repo local con cambios pendientes según manifiesto seguro.',
+        ),
+        (
+            '{"status":"success","updated_at":"2026-04-24T07:30:00Z","workspace_clean":true,"main_branch":false,"remote_synced":true,"branch":"feature/private"}',
+            'Repo local fuera de la rama estable esperada.',
+        ),
+        (
+            '{"status":"success","updated_at":"2026-04-24T07:30:00Z","workspace_clean":true,"main_branch":true,"remote_synced":false,"remote_url":"git@github.com:private/repo.git"}',
+            'Repo local pendiente de sincronización remota según manifiesto seguro.',
+        ),
+    ],
+)
+def test_project_health_manifest_adapter_degrades_unsafe_repo_states_without_leaking_details(tmp_path, manifest_body, expected_summary):
+    manifest = tmp_path / 'project-health-status.json'
+    manifest.write_text(manifest_body, encoding='utf-8')
+
+    snapshot = ProjectHealthManifestAdapter(manifest_path=manifest).snapshot(now='2026-04-24T08:00:00Z')
+    payload = HealthcheckService.from_source_snapshots((snapshot,)).get_workspace()
+
+    module = payload['modules'][0]
+    assert module['status'] == 'warn'
+    assert module['severity'] == 'medium'
+    assert module['summary'] == expected_summary
+    assert payload['signals'][0]['check_id'] == 'project-health.workspace'
+    assert payload['signals'][0]['freshness']['state'] == 'stale'
+    _assert_no_sensitive_host_output(payload)
+
+
+@pytest.mark.parametrize(
+    'manifest_body',
+    [
+        '{"updated_at":"2026-04-24T07:30:00Z","workspace_clean":true,"main_branch":true,"remote_synced":true}',
+        '{"status":"green","updated_at":"2026-04-24T07:30:00Z","workspace_clean":true,"main_branch":true,"remote_synced":true}',
+        '{"status":"success","updated_at":"2026-04-24T07:30:00Z","main_branch":true,"remote_synced":true}',
+    ],
+)
+def test_project_health_manifest_adapter_requires_explicit_safe_result_and_booleans(tmp_path, manifest_body):
+    manifest = tmp_path / 'project-health-partial.json'
+    manifest.write_text(manifest_body, encoding='utf-8')
+
+    snapshot = ProjectHealthManifestAdapter(manifest_path=manifest).snapshot(now='2026-04-24T08:00:00Z')
+    payload = HealthcheckService.from_source_snapshots((snapshot,)).get_workspace()
+
+    module = payload['modules'][0]
+    assert module['status'] == 'warn'
+    assert module['severity'] == 'medium'
+    assert module['summary'] == 'Repo local sin estado seguro completo disponible.'
+    assert payload['signals'][0]['freshness']['state'] == 'stale'
+    _assert_no_sensitive_host_output(payload)
+
+
+def test_project_health_manifest_adapter_models_stale_missing_or_unreadable_manifest(tmp_path):
+    stale_manifest = tmp_path / 'project-health-stale.json'
+    stale_manifest.write_text(
+        '{"status":"success","updated_at":"2026-04-23T23:00:00Z","workspace_clean":true,"main_branch":true,"remote_synced":true}',
+        encoding='utf-8',
+    )
+    missing = ProjectHealthManifestAdapter(manifest_path=tmp_path / 'missing.json').snapshot(now='2026-04-24T08:00:00Z')
+    unreadable_manifest = tmp_path / 'project-health-status.json'
+    unreadable_manifest.write_text('{not-json', encoding='utf-8')
+    unreadable = ProjectHealthManifestAdapter(manifest_path=unreadable_manifest).snapshot(now='2026-04-24T08:00:00Z')
+    stale = ProjectHealthManifestAdapter(manifest_path=stale_manifest).snapshot(now='2026-04-24T08:00:00Z')
+
+    payload = HealthcheckService.from_source_snapshots((missing, unreadable, stale)).get_workspace()
+
+    status_by_summary = {module['summary']: module['status'] for module in payload['modules']}
+    assert status_by_summary == {
+        'Fuente Healthcheck ausente o todavía no configurada.': 'not_configured',
+        'Fuente Healthcheck no legible; no se expone salida cruda.': 'unknown',
+        'Repo local stale según manifiesto seguro.': 'stale',
     }
     _assert_no_sensitive_host_output(payload)
 

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -47,7 +47,8 @@
 - consumir solo fuentes saneadas y timestamps de frescura
 - conectar en Phase 15.3a el primer adapter vivo `vault-sync` desde manifiesto fijo Franky-owned, sin exponer rutas, ramas, remotes, Git output ni campos raw
 - conectar en Phase 15.3b el adapter vivo `backup-health` desde manifiesto fijo Franky-owned, sin exponer rutas de archivo, nombres de archivos, paths incluidos, stdout/stderr, tamaños ni campos raw
-- mantener project/gateway/cronjob reads fuera hasta sus microfases revisadas
+- conectar en Phase 15.4a el adapter vivo `project-health` desde manifiesto fijo Zoro-owned, consumiendo solo timestamp/result y booleanos `workspace_clean`, `main_branch`, `remote_synced`, sin exponer rama cruda, remotes, diffs, untracked file lists, GitHub counts ni last-verify detail
+- mantener gateway/cronjob reads fuera hasta sus microfases revisadas
 - documentar y verificar manifest ownership and freshness thresholds antes de cualquier lectura viva (`docs/healthcheck-source-policy.md`)
 - bloquear crecimiento accidental hacia consola host genérica con `npm run verify:healthcheck-source-policy`
 - no ejecutar shell, Docker, systemd ni leer logs/salidas crudas del host en esta fase

--- a/docs/healthcheck-source-policy.md
+++ b/docs/healthcheck-source-policy.md
@@ -1,7 +1,7 @@
 # Healthcheck source policy
 
 ## Purpose
-Phase 15.2c closed the final foundation slice before live Healthcheck source adapters. It defines the source-policy contract that adapters must satisfy. Phase 15.3a started live reads with the `vault-sync` adapter only; Phase 15.3b adds the `backup-health` adapter. Both consume fixed Franky-owned manifests and route through the existing registry sanitizer.
+Phase 15.2c closed the final foundation slice before live Healthcheck source adapters. It defines the source-policy contract that adapters must satisfy. Phase 15.3a started live reads with the `vault-sync` adapter; Phase 15.3b added the `backup-health` adapter; Phase 15.4a adds the `project-health` local repo adapter. These adapters consume fixed reviewed manifests and route through the existing registry sanitizer.
 
 ## No generic host console
 Healthcheck must not become a generic host console. New source code in `apps/api/src/modules/healthcheck` must not introduce generic shell, process, command execution, arbitrary URL-fetch adapters or generic filesystem discovery without a reviewed, allowlisted phase.
@@ -13,7 +13,7 @@ Blocked by `npm run verify:healthcheck-source-policy`:
 - command-parameter based host adapters;
 - generic filesystem discovery or reads such as `glob`, `os.listdir`, `os.scandir`, `os.walk`, ambient `Path.home()` / `Path.cwd()`, recursive `rglob()` or direct `open()` in the Healthcheck module.
 
-Adapters remain explicit, source-family-specific and reviewed. No live manifest reads are implemented in Phase 15.2c. Phase 15.3a allows the fixed `vault-sync` manifest reader in `source_adapters.py`; Phase 15.3b also allows the fixed `backup-health` manifest reader. These phases still do not add project-health, gateway or cronjob reads.
+Adapters remain explicit, source-family-specific and reviewed. No live manifest reads are implemented in Phase 15.2c. Phase 15.3a allows the fixed `vault-sync` manifest reader in `source_adapters.py`; Phase 15.3b also allows the fixed `backup-health` manifest reader; Phase 15.4a also allows the fixed `project-health` repo-local manifest reader. These phases still do not add gateway or cronjob reads, and Phase 15.4a does not add GitHub issue/PR counts or last-verify aggregation.
 
 ## Text field sanitization
 Future adapters must sanitize summaries before handing them to Healthcheck. As defense in depth, `HealthcheckSourceRegistry` ignores adapter-provided labels and always resolves `label` from backend-owned `HEALTHCHECK_SOURCE_LABELS[source_id]`. It also applies a final sensitive-marker filter to allowed textual fields: `summary`, `warning_text`, `source_label` and `freshness_label`.
@@ -30,7 +30,7 @@ Future live adapters may consume only sanitized summaries from reviewed sources.
 | `cronjobs` | Franky | shared manifest registry, not Zoro profile-local `cronjob list` | Must represent global scheduled jobs safely, not one profile's local runtime view. |
 | `hermes-gateways` | Franky | systemd user gateway summary | Aggregated gateway status only. |
 | `gateway.<mugiwara-slug>` | Franky | allowlisted gateway status summary | One allowlisted process summary per Mugiwara slug. |
-| `project-health` | Zoro | repo-local project health summary | Project health remains repo-scope and must not expose raw Git internals. |
+| `project-health` | Zoro | repo-local project health summary | Phase 15.4a reads a fixed Zoro-owned repo-local status manifest and exposes only timestamp/result plus boolean workspace/main/sync semantics. It must not expose branch names beyond allowlisted booleans, remotes, diffs, untracked file lists, GitHub counts or last-verify detail. |
 
 Source manifests or wrappers do not include `stdout`, `stderr`, `raw_output`, `command`, `traceback`, `pid`, `unit_content`, `journal`, absolute host paths, `backup_path`, `included_path`, `prompt_body`, `chat_id`, delivery targets, tokens, cookies, credentials, `.env`, Git diffs, untracked file lists or internal remotes.
 
@@ -43,7 +43,7 @@ Thresholds are intentionally backend-owned policy before Phase 15.3+ live adapte
 - `hermes-gateways` and `gateway.<mugiwara-slug>`: warn after 15 minutes, fail after 60 minutes.
 - `cronjobs`: warn after 180 minutes, fail after 720 minutes.
 
-These thresholds are not applied to live data in Phase 15.2c. Phase 15.3a/15.3b apply them only to fixed `vault-sync` and `backup-health` manifests. Future adapters must parse timestamps explicitly, normalize to the existing Healthcheck freshness vocabulary and degrade absent/unreadable data to `not_configured`, `unknown` or `stale`, never to healthy output.
+These thresholds are not applied to live data in Phase 15.2c. Phase 15.3a/15.3b apply them only to fixed `vault-sync` and `backup-health` manifests. Phase 15.4a applies the `project-health` thresholds only to the fixed repo-local status manifest. Future adapters must parse timestamps explicitly, normalize to the existing Healthcheck freshness vocabulary and degrade absent/unreadable data to `not_configured`, `unknown` or `stale`, never to healthy output.
 
 ## Verify
 Run after changes that touch Healthcheck source adapters, docs or source-policy boundaries:

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -74,6 +74,8 @@ Phase 15.3a connects the first live source: `vault-sync`. The adapter reads only
 
 Phase 15.3b connects the second live source: `backup-health`. The adapter reads only a fixed Franky-owned local backup status manifest, consumes safe status/timestamp/checksum/retention fields, routes output through `HealthcheckSourceRegistry`, and degrades missing or unreadable manifests to `not_configured`/`unknown`. It does not expose archive names, backup paths, included paths, stdout/stderr, raw output, file sizes or runtime manifest internals, and it does not add project/gateway/cronjob reads.
 
+Phase 15.4a connects the third live source: `project-health`. The adapter reads only a fixed Zoro-owned repo-local status manifest, consumes safe status/timestamp plus boolean `workspace_clean`, `main_branch` and `remote_synced` semantics, routes output through `HealthcheckSourceRegistry`, and degrades missing or unreadable manifests to `not_configured`/`unknown`. It does not execute Git, expose raw branch names, remotes, diffs, untracked file lists, GitHub counts or last-verify detail, and it does not add gateway/cronjob reads.
+
 ### `memory.agent_summary`
 Campos esperados:
 - `mugiwara_slug`

--- a/openspec/phase-15-4a-project-health-local-adapter.md
+++ b/openspec/phase-15-4a-project-health-local-adapter.md
@@ -1,0 +1,44 @@
+# Phase 15.4a — Project health local adapter
+
+## Objetivo
+Conectar `project-health` como tercera fuente viva de Healthcheck mediante un adapter local y acotado, sin convertir Healthcheck en consola Git ni exponer internals del repositorio.
+
+## Alcance
+- Añadir `ProjectHealthManifestAdapter` en `apps/api/src/modules/healthcheck/source_adapters.py`.
+- Leer solo un manifiesto fijo Zoro-owned: `/srv/crew-core/runtime/healthcheck/project-health-status.json`.
+- Consumir únicamente semántica segura:
+  - `status`/`result` allowlisted.
+  - `updated_at` o `last_success_at` como timestamp parseable.
+  - `workspace_clean`, `main_branch`, `remote_synced` como booleanos.
+- Enrutar el resultado por `HealthcheckSourceRegistry` para conservar label backend-owned, allowlist de campos y saneado textual.
+- Integrar el snapshot en el catálogo por defecto de `HealthcheckService`.
+- Actualizar docs vivas y guardrail `verify:healthcheck-source-policy`.
+
+## Fuera de alcance
+- Ejecutar Git desde el backend.
+- Exponer rama cruda, remotes, diffs, listas de untracked files, paths host o salidas Git.
+- Conectar GitHub issue/PR counts.
+- Agregar last-verify/status aggregation.
+- Conectar gateways o cronjobs.
+- Crear productor operativo del manifiesto; esta microfase solo consume el contrato fijo si existe.
+
+## Decisiones técnicas
+- Estado ausente -> `not_configured` vía registry.
+- Manifiesto ilegible/no JSON/no mapping -> `unknown` vía registry.
+- Timestamp ausente/ilegible -> `unknown` sin salida cruda.
+- `pass` solo si hay resultado positivo explícito, booleanos completos y verdaderos, y frescura dentro de threshold.
+- `workspace_clean=false`, `main_branch=false` o `remote_synced=false` degradan a `warn` sin detallar rama, remotos, diffs o ficheros.
+- Threshold de `project-health`: warn 120 min, fail 480 min.
+
+## Verify esperado
+- `python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q`
+- `python -m py_compile apps/api/src/modules/healthcheck/source_adapters.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py`
+- `npm run verify:healthcheck-source-policy`
+- `git diff --check`
+- scan dirigido de secretos/salidas host en el diff.
+
+## Review requerido
+Franky + Chopper.
+
+- Franky: contrato operativo del manifiesto, semántica de frescura y degradaciones.
+- Chopper: frontera host/Git, no leakage, ausencia de consola genérica.

--- a/scripts/check-healthcheck-source-policy.mjs
+++ b/scripts/check-healthcheck-source-policy.mjs
@@ -129,8 +129,11 @@ const requiredDocSnippets = [
   '`hermes-gateways` and `gateway.<mugiwara-slug>`: warn after 15 minutes, fail after 60 minutes',
   '`project-health`: warn after 120 minutes, fail after 480 minutes',
   'Phase 15.3b also allows the fixed `backup-health` manifest reader',
+  'Phase 15.4a also allows the fixed `project-health` repo-local manifest reader',
   'Phase 15.3b reads a fixed local backup status manifest and exposes only timestamp/result/checksum/retention-derived summary fields',
-  'These phases still do not add project-health, gateway or cronjob reads',
+  'Phase 15.4a reads a fixed Zoro-owned repo-local status manifest and exposes only timestamp/result plus boolean workspace/main/sync semantics',
+  'These phases still do not add gateway or cronjob reads',
+  'does not add GitHub issue/PR counts or last-verify aggregation',
   'do not include `stdout`, `stderr`, `raw_output`, `command`, `traceback`, `pid`, `unit_content`, `journal`, absolute host paths, `backup_path`, `included_path`, `prompt_body`, `chat_id`, delivery targets, tokens, cookies, credentials, `.env`, Git diffs, untracked file lists or internal remotes',
 ]
 


### PR DESCRIPTION
## Resumen
- Añade `ProjectHealthManifestAdapter` para `project-health` como tercera fuente viva de Healthcheck.
- Consume solo un manifiesto fijo Zoro-owned (`/srv/crew-core/runtime/healthcheck/project-health-status.json`) con semántica segura: `status`/`result`, timestamp y booleanos `workspace_clean`, `main_branch`, `remote_synced`.
- Integra el snapshot en `HealthcheckService`, tests TDD, docs vivas, OpenSpec, closeout Engram y guardrail `verify:healthcheck-source-policy`.

## Seguridad / límites
- No ejecuta Git desde backend.
- No expone rama cruda, remotes, diffs, untracked file lists, paths host, salidas Git, GitHub counts ni last-verify detail.
- Gateways y cronjobs quedan fuera de alcance.
- GitHub issue/PR counts y last-verify quedan para 15.4b/15.4c.

## Verify de Zoro
- `python -m pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` -> 39 passed.
- `python -m pytest apps/api/tests -q` -> 64 passed.
- `python -m py_compile apps/api/src/modules/healthcheck/source_adapters.py apps/api/src/modules/healthcheck/service.py apps/api/tests/test_healthcheck_dashboard_api.py` -> OK.
- `npm run verify:healthcheck-source-policy` -> passed.
- `git diff --check` -> OK.
- Scan dirigido del diff: solo marcadores sintéticos de tests/docs para verificar saneado; sin secretos reales ni salidas host crudas.

## Review solicitado
Franky + Chopper.

- Franky: contrato operativo del manifiesto, thresholds/frescura y degradaciones.
- Chopper: frontera host/Git, no leakage y ausencia de consola genérica.
