### PR TITLE
feat: add project health manifest producer

### DIFF
--- a/.engram/phase-15-4b-implementation-closeout.md
+++ b/.engram/phase-15-4b-implementation-closeout.md
@@ -1,0 +1,30 @@
+# Phase 15.4b implementation closeout — project-health manifest producer
+
+## Resultado
+Phase 15.4b cierra el follow-up #41 creando un productor operativo Zoro-owned para el manifiesto seguro de `project-health`.
+
+## Cambios
+- `scripts/write-project-health-status.py`: nuevo productor explícito. Consulta Git local fuera del backend Healthcheck y escribe atómicamente `/srv/crew-core/runtime/healthcheck/project-health-status.json`.
+- `package.json`: añade `npm run write:project-health-status` como entrypoint operativo.
+- `apps/api/tests/test_project_health_manifest_producer.py`: tests TDD con repos Git temporales para success, dirty/not-main, unsynced y CLI.
+- `scripts/check-healthcheck-source-policy.mjs`: guardrail ampliado para fijar productor, ruta fija, shape mínimo, escritura atómica y permisos.
+- `docs/healthcheck-source-policy.md`, `docs/api-modules.md`, `docs/read-models.md`: documentación viva actualizada.
+- `openspec/phase-15-4b-project-health-manifest-producer.md`: spec de alcance y verify.
+
+## Límites conservados
+- El backend Healthcheck sigue sin ejecutar Git, shell ni filesystem discovery genérico.
+- El manifiesto serializa solo `status`, `result`, `updated_at`, `workspace_clean`, `main_branch`, `remote_synced`.
+- No se escriben ramas crudas, remotes, SHAs, diffs, untracked files, paths host, stdout/stderr/raw output, GitHub counts ni last-verify detail.
+- Gateway y cronjobs siguen fuera de alcance.
+
+## Verify
+Ejecutado en rama `zoro/phase-15-4b-project-health-manifest-producer`:
+- `python -m pytest apps/api/tests/test_project_health_manifest_producer.py -q` -> 4 passed tras test rojo inicial por script inexistente.
+- `npm run verify:healthcheck-source-policy` -> passed.
+- `python -m pytest apps/api/tests/test_project_health_manifest_producer.py apps/api/tests/test_healthcheck_dashboard_api.py -q` -> 43 passed.
+- `python -m py_compile scripts/write-project-health-status.py apps/api/tests/test_project_health_manifest_producer.py` -> OK.
+- `git diff --check` -> OK.
+- Scan dirigido del diff -> solo aparecen términos sensibles en docs/tests/guardrails como exclusiones o fixtures sintéticas; no hay secretos reales ni salidas host crudas.
+
+## Riesgos / follow-ups
+- Queda pendiente decidir instalación operativa persistente del productor (cron/systemd timer) si Franky quiere automatizar refresco periódico. Esta PR solo deja productor invocable, testeado y seguro.

--- a/apps/api/tests/test_project_health_manifest_producer.py
+++ b/apps/api/tests/test_project_health_manifest_producer.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+import subprocess
+from pathlib import Path
+
+
+def _load_producer_module():
+    module_path = Path(__file__).resolve().parents[3] / 'scripts' / 'write-project-health-status.py'
+    spec = importlib.util.spec_from_file_location('write_project_health_status', module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(['git', '-C', str(repo), *args], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / 'repo'
+    repo.mkdir()
+    _git(repo, 'init', '-b', 'main')
+    _git(repo, 'config', 'user.name', 'Test Zoro')
+    _git(repo, 'config', 'user.email', 'zoro@example.invalid')
+    (repo / 'README.md').write_text('safe\n', encoding='utf-8')
+    _git(repo, 'add', 'README.md')
+    _git(repo, 'commit', '-m', 'initial')
+    origin = tmp_path / 'origin.git'
+    subprocess.run(['git', 'init', '--bare', str(origin)], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    _git(repo, 'remote', 'add', 'origin', str(origin))
+    _git(repo, 'push', '-u', 'origin', 'main')
+    return repo
+
+
+def test_project_health_manifest_producer_writes_minimal_safe_atomic_json(tmp_path):
+    producer = _load_producer_module()
+    repo = _init_repo(tmp_path)
+    output = tmp_path / 'runtime' / 'healthcheck' / 'project-health-status.json'
+
+    result = producer.write_project_health_status(repo_path=repo, output_path=output, now='2026-04-25T20:15:00Z')
+
+    assert result == {
+        'status': 'success',
+        'result': 'success',
+        'updated_at': '2026-04-25T20:15:00Z',
+        'workspace_clean': True,
+        'main_branch': True,
+        'remote_synced': True,
+    }
+    manifest = json.loads(output.read_text(encoding='utf-8'))
+    assert manifest == result
+    assert set(manifest) == {'status', 'result', 'updated_at', 'workspace_clean', 'main_branch', 'remote_synced'}
+    serialized = json.dumps(manifest)
+    assert '"main"' not in serialized
+    assert 'origin' not in serialized
+    assert 'README' not in serialized
+    assert 'diff' not in serialized
+    assert 'stdout' not in serialized
+    assert 'stderr' not in serialized
+    assert output.parent.stat().st_mode & stat.S_IROTH == 0
+    assert output.stat().st_mode & stat.S_IROTH == 0
+
+
+def test_project_health_manifest_producer_degrades_dirty_not_main_and_unsynced_without_leaking(tmp_path):
+    producer = _load_producer_module()
+    repo = _init_repo(tmp_path)
+    _git(repo, 'switch', '-c', 'feature/private-branch')
+    (repo / '.env').write_text('TOKEN=secret\n', encoding='utf-8')
+    output = tmp_path / 'runtime' / 'healthcheck' / 'project-health-status.json'
+
+    result = producer.write_project_health_status(repo_path=repo, output_path=output, now='2026-04-25T20:20:00Z')
+
+    assert result['status'] == 'dirty'
+    assert result['result'] == 'dirty'
+    assert result['workspace_clean'] is False
+    assert result['main_branch'] is False
+    assert result['remote_synced'] is False
+    serialized = output.read_text(encoding='utf-8')
+    assert 'feature/private-branch' not in serialized
+    assert '.env' not in serialized
+    assert 'TOKEN' not in serialized
+    assert 'secret' not in serialized
+    assert 'origin' not in serialized
+
+
+def test_project_health_manifest_producer_reports_unsynced_main_without_raw_remote_details(tmp_path):
+    producer = _load_producer_module()
+    repo = _init_repo(tmp_path)
+    (repo / 'README.md').write_text('safe\nnext\n', encoding='utf-8')
+    _git(repo, 'add', 'README.md')
+    _git(repo, 'commit', '-m', 'local ahead')
+    output = tmp_path / 'runtime' / 'healthcheck' / 'project-health-status.json'
+
+    result = producer.write_project_health_status(repo_path=repo, output_path=output, now='2026-04-25T20:25:00Z')
+
+    assert result['status'] == 'diverged'
+    assert result['result'] == 'diverged'
+    assert result['workspace_clean'] is True
+    assert result['main_branch'] is True
+    assert result['remote_synced'] is False
+    serialized = output.read_text(encoding='utf-8')
+    assert 'origin' not in serialized
+    assert 'HEAD' not in serialized
+    assert 'local ahead' not in serialized
+
+
+def test_project_health_manifest_producer_cli_accepts_safe_paths(tmp_path):
+    producer = _load_producer_module()
+    repo = _init_repo(tmp_path)
+    output = tmp_path / 'status.json'
+
+    exit_code = producer.main(['--repo', str(repo), '--output', str(output), '--now', '2026-04-25T20:30:00Z'])
+
+    assert exit_code == 0
+    manifest = json.loads(output.read_text(encoding='utf-8'))
+    assert manifest['status'] == 'success'

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -48,6 +48,7 @@
 - conectar en Phase 15.3a el primer adapter vivo `vault-sync` desde manifiesto fijo Franky-owned, sin exponer rutas, ramas, remotes, Git output ni campos raw
 - conectar en Phase 15.3b el adapter vivo `backup-health` desde manifiesto fijo Franky-owned, sin exponer rutas de archivo, nombres de archivos, paths incluidos, stdout/stderr, tamaños ni campos raw
 - conectar en Phase 15.4a el adapter vivo `project-health` desde manifiesto fijo Zoro-owned, consumiendo solo timestamp/result y booleanos `workspace_clean`, `main_branch`, `remote_synced`, sin exponer rama cruda, remotes, diffs, untracked file lists, GitHub counts ni last-verify detail
+- producir en Phase 15.4b ese manifiesto mediante `scripts/write-project-health-status.py` con escritura atómica, permisos no públicos y JSON mínimo; Git se consulta solo en el productor operativo, nunca desde el backend Healthcheck
 - mantener gateway/cronjob reads fuera hasta sus microfases revisadas
 - documentar y verificar manifest ownership and freshness thresholds antes de cualquier lectura viva (`docs/healthcheck-source-policy.md`)
 - bloquear crecimiento accidental hacia consola host genérica con `npm run verify:healthcheck-source-policy`

--- a/docs/healthcheck-source-policy.md
+++ b/docs/healthcheck-source-policy.md
@@ -1,7 +1,7 @@
 # Healthcheck source policy
 
 ## Purpose
-Phase 15.2c closed the final foundation slice before live Healthcheck source adapters. It defines the source-policy contract that adapters must satisfy. Phase 15.3a started live reads with the `vault-sync` adapter; Phase 15.3b added the `backup-health` adapter; Phase 15.4a adds the `project-health` local repo adapter. These adapters consume fixed reviewed manifests and route through the existing registry sanitizer.
+Phase 15.2c closed the final foundation slice before live Healthcheck source adapters. It defines the source-policy contract that adapters must satisfy. Phase 15.3a started live reads with the `vault-sync` adapter; Phase 15.3b added the `backup-health` adapter; Phase 15.4a added the `project-health` local repo adapter; Phase 15.4b adds the Zoro-owned producer for that fixed project-health manifest. These adapters consume fixed reviewed manifests and route through the existing registry sanitizer.
 
 ## No generic host console
 Healthcheck must not become a generic host console. New source code in `apps/api/src/modules/healthcheck` must not introduce generic shell, process, command execution, arbitrary URL-fetch adapters or generic filesystem discovery without a reviewed, allowlisted phase.
@@ -13,7 +13,7 @@ Blocked by `npm run verify:healthcheck-source-policy`:
 - command-parameter based host adapters;
 - generic filesystem discovery or reads such as `glob`, `os.listdir`, `os.scandir`, `os.walk`, ambient `Path.home()` / `Path.cwd()`, recursive `rglob()` or direct `open()` in the Healthcheck module.
 
-Adapters remain explicit, source-family-specific and reviewed. No live manifest reads are implemented in Phase 15.2c. Phase 15.3a allows the fixed `vault-sync` manifest reader in `source_adapters.py`; Phase 15.3b also allows the fixed `backup-health` manifest reader; Phase 15.4a also allows the fixed `project-health` repo-local manifest reader. These phases still do not add gateway or cronjob reads, and Phase 15.4a does not add GitHub issue/PR counts or last-verify aggregation.
+Adapters remain explicit, source-family-specific and reviewed. No live manifest reads are implemented in Phase 15.2c. Phase 15.3a allows the fixed `vault-sync` manifest reader in `source_adapters.py`; Phase 15.3b also allows the fixed `backup-health` manifest reader; Phase 15.4a also allows the fixed `project-health` repo-local manifest reader. Phase 15.4b adds `scripts/write-project-health-status.py` as the reviewed producer for that fixed manifest; it may query Git outside the backend, but writes only status/result, updated_at and boolean workspace/main/sync semantics. These phases still do not add gateway or cronjob reads, and Phase 15.4b still does not add GitHub issue/PR counts or last-verify aggregation.
 
 ## Text field sanitization
 Future adapters must sanitize summaries before handing them to Healthcheck. As defense in depth, `HealthcheckSourceRegistry` ignores adapter-provided labels and always resolves `label` from backend-owned `HEALTHCHECK_SOURCE_LABELS[source_id]`. It also applies a final sensitive-marker filter to allowed textual fields: `summary`, `warning_text`, `source_label` and `freshness_label`.
@@ -30,7 +30,7 @@ Future live adapters may consume only sanitized summaries from reviewed sources.
 | `cronjobs` | Franky | shared manifest registry, not Zoro profile-local `cronjob list` | Must represent global scheduled jobs safely, not one profile's local runtime view. |
 | `hermes-gateways` | Franky | systemd user gateway summary | Aggregated gateway status only. |
 | `gateway.<mugiwara-slug>` | Franky | allowlisted gateway status summary | One allowlisted process summary per Mugiwara slug. |
-| `project-health` | Zoro | repo-local project health summary | Phase 15.4a reads a fixed Zoro-owned repo-local status manifest and exposes only timestamp/result plus boolean workspace/main/sync semantics. It must not expose branch names beyond allowlisted booleans, remotes, diffs, untracked file lists, GitHub counts or last-verify detail. |
+| `project-health` | Zoro | repo-local project health summary | Phase 15.4a reads a fixed Zoro-owned repo-local status manifest and exposes only timestamp/result plus boolean workspace/main/sync semantics. Phase 15.4b produces that manifest with atomic writes and non-public file permissions via `scripts/write-project-health-status.py`. It must not expose branch names beyond allowlisted booleans, remotes, diffs, untracked file lists, GitHub counts or last-verify detail. |
 
 Source manifests or wrappers do not include `stdout`, `stderr`, `raw_output`, `command`, `traceback`, `pid`, `unit_content`, `journal`, absolute host paths, `backup_path`, `included_path`, `prompt_body`, `chat_id`, delivery targets, tokens, cookies, credentials, `.env`, Git diffs, untracked file lists or internal remotes.
 
@@ -43,7 +43,7 @@ Thresholds are intentionally backend-owned policy before Phase 15.3+ live adapte
 - `hermes-gateways` and `gateway.<mugiwara-slug>`: warn after 15 minutes, fail after 60 minutes.
 - `cronjobs`: warn after 180 minutes, fail after 720 minutes.
 
-These thresholds are not applied to live data in Phase 15.2c. Phase 15.3a/15.3b apply them only to fixed `vault-sync` and `backup-health` manifests. Phase 15.4a applies the `project-health` thresholds only to the fixed repo-local status manifest. Future adapters must parse timestamps explicitly, normalize to the existing Healthcheck freshness vocabulary and degrade absent/unreadable data to `not_configured`, `unknown` or `stale`, never to healthy output.
+These thresholds are not applied to live data in Phase 15.2c. Phase 15.3a/15.3b apply them only to fixed `vault-sync` and `backup-health` manifests. Phase 15.4a applies the `project-health` thresholds only to the fixed repo-local status manifest; Phase 15.4b only refreshes that manifest timestamp and safe boolean semantics. Future adapters must parse timestamps explicitly, normalize to the existing Healthcheck freshness vocabulary and degrade absent/unreadable data to `not_configured`, `unknown` or `stale`, never to healthy output.
 
 ## Verify
 Run after changes that touch Healthcheck source adapters, docs or source-policy boundaries:

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -76,6 +76,8 @@ Phase 15.3b connects the second live source: `backup-health`. The adapter reads 
 
 Phase 15.4a connects the third live source: `project-health`. The adapter reads only a fixed Zoro-owned repo-local status manifest, consumes safe status/timestamp plus boolean `workspace_clean`, `main_branch` and `remote_synced` semantics, routes output through `HealthcheckSourceRegistry`, and degrades missing or unreadable manifests to `not_configured`/`unknown`. It does not execute Git, expose raw branch names, remotes, diffs, untracked file lists, GitHub counts or last-verify detail, and it does not add gateway/cronjob reads.
 
+Phase 15.4b adds the Zoro-owned manifest producer for `project-health`. `scripts/write-project-health-status.py` may query the local Git repo outside the backend, but the manifest still serializes only `status`, `result`, `updated_at`, `workspace_clean`, `main_branch` and `remote_synced`. It writes atomically with non-public permissions and does not include branch names, remotes, SHAs, diffs, untracked files, stdout/stderr, paths, GitHub counts or last-verify detail.
+
 ### `memory.agent_summary`
 Campos esperados:
 - `mugiwara_slug`

--- a/openspec/phase-15-4b-project-health-manifest-producer.md
+++ b/openspec/phase-15-4b-project-health-manifest-producer.md
@@ -1,0 +1,45 @@
+# Phase 15.4b — Project health manifest producer
+
+## Objetivo
+Cerrar el follow-up operativo de PR #39 / issue #41 creando un productor Zoro-owned para el manifiesto fijo `project-health-status.json`, sin ampliar la superficie backend de Healthcheck ni publicar internals Git.
+
+## Alcance
+- Añadir un script operativo explícito en `scripts/write-project-health-status.py`.
+- Leer el estado local del repo mediante comandos Git acotados ejecutados fuera del backend Healthcheck.
+- Escribir de forma atómica el manifiesto fijo `/srv/crew-core/runtime/healthcheck/project-health-status.json`.
+- Crear el directorio padre con permisos mínimos razonables y dejar el fichero con permisos no públicos.
+- Serializar solo JSON mínimo:
+  - `status`/`result`.
+  - `updated_at`.
+  - `workspace_clean`.
+  - `main_branch`.
+  - `remote_synced`.
+- Añadir tests del productor con Git repo temporal.
+- Actualizar docs vivas y guardrail `verify:healthcheck-source-policy`.
+
+## Fuera de alcance
+- Cambiar `ProjectHealthManifestAdapter` o el read model público salvo documentación/guardrail.
+- Escribir rama cruda, remotes, SHAs, diffs, untracked files, paths host, stdout/stderr o raw Git output en el manifiesto.
+- Conectar GitHub issue/PR counts.
+- Agregar last-verify/status aggregation.
+- Ejecutar Git desde el backend Healthcheck.
+- Instalar systemd/cron real; esta microfase deja el productor invocable y testeado, no una automatización persistente nueva.
+
+## Decisiones técnicas
+- `status/result = success` solo si el repo está limpio, en `main` y sincronizado con upstream remoto.
+- Estados degradados (`dirty`, `diverged`, `warning`) pueden emitirse explícitamente por el productor; el adapter 15.4a ya los interpreta como `warn` sin leakage.
+- Si no hay upstream o no puede resolverse la sincronización remota, `remote_synced=false` y el estado degrada a `diverged`/`warning`; no se escriben detalles.
+- El productor puede devolver exit code no cero solo ante fallo operativo de escritura/lectura Git que impide producir un manifiesto válido; un repo dirty/not-main/not-synced produce manifiesto válido degradado.
+
+## Verify esperado
+- `python -m pytest apps/api/tests/test_project_health_manifest_producer.py apps/api/tests/test_healthcheck_dashboard_api.py -q`
+- `python -m py_compile scripts/write-project-health-status.py apps/api/tests/test_project_health_manifest_producer.py`
+- `npm run verify:healthcheck-source-policy`
+- `git diff --check`
+- scan dirigido del diff contra secretos/salidas host reales.
+
+## Review requerido
+Franky + Chopper.
+
+- Franky: ejecución operativa, atomicidad, permisos, semántica de sincronización y degradaciones.
+- Chopper: no leakage de Git/host, frontera backend intacta y ausencia de datos sensibles en manifiesto/docs.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "verify:vault-server-only": "node scripts/check-vault-server-only.mjs",
     "verify:health-dashboard-server-only": "node scripts/check-health-dashboard-server-only.mjs",
     "verify:healthcheck-source-policy": "node scripts/check-healthcheck-source-policy.mjs",
+    "write:project-health-status": "python scripts/write-project-health-status.py",
     "dev:api": "uvicorn apps.api.src.main:app --reload",
     "lint": "echo 'Pending lint setup'",
     "test": "echo 'Pending test setup'",

--- a/scripts/check-healthcheck-source-policy.mjs
+++ b/scripts/check-healthcheck-source-policy.mjs
@@ -16,6 +16,7 @@ const paths = {
   sourcePolicyDoc: join(repoRoot, 'docs/healthcheck-source-policy.md'),
   apiModulesDoc: join(repoRoot, 'docs/api-modules.md'),
   readModelsDoc: join(repoRoot, 'docs/read-models.md'),
+  projectHealthProducer: join(repoRoot, 'scripts/write-project-health-status.py'),
 }
 
 const failures = []
@@ -57,6 +58,7 @@ const packageJsonText = read(paths.packageJson, 'package.json')
 const sourcePolicyDoc = read(paths.sourcePolicyDoc, 'Healthcheck source policy document')
 const apiModulesDoc = read(paths.apiModulesDoc, 'API modules document')
 const readModelsDoc = read(paths.readModelsDoc, 'read models document')
+const projectHealthProducer = read(paths.projectHealthProducer, 'project-health manifest producer')
 
 let packageJson
 try {
@@ -67,6 +69,10 @@ try {
 
 if (packageJson && packageJson.scripts?.['verify:healthcheck-source-policy'] !== 'node scripts/check-healthcheck-source-policy.mjs') {
   failures.push('package.json must expose verify:healthcheck-source-policy')
+}
+
+if (packageJson && packageJson.scripts?.['write:project-health-status'] !== 'python scripts/write-project-health-status.py') {
+  failures.push('package.json must expose write:project-health-status')
 }
 
 const forbiddenHostConsolePatterns = [
@@ -114,6 +120,19 @@ for (const filePath of listPythonFiles(paths.healthcheckModule)) {
   }
 }
 
+const requiredProjectHealthProducerSnippets = [
+  "DEFAULT_OUTPUT_PATH = Path('/srv/crew-core/runtime/healthcheck/project-health-status.json')",
+  "SAFE_MANIFEST_KEYS = ('status', 'result', 'updated_at', 'workspace_clean', 'main_branch', 'remote_synced')",
+  "os.replace(temp_path, output)",
+  "os.chmod(output, 0o640)",
+  "os.chmod(output.parent, 0o750)",
+  "'git', '-C', str(repo)",
+]
+
+for (const snippet of requiredProjectHealthProducerSnippets) {
+  mustInclude(projectHealthProducer, snippet, 'project-health manifest producer')
+}
+
 const requiredDocSnippets = [
   'No generic host console',
   'Text field sanitization',
@@ -130,6 +149,9 @@ const requiredDocSnippets = [
   '`project-health`: warn after 120 minutes, fail after 480 minutes',
   'Phase 15.3b also allows the fixed `backup-health` manifest reader',
   'Phase 15.4a also allows the fixed `project-health` repo-local manifest reader',
+  'Phase 15.4b adds `scripts/write-project-health-status.py` as the reviewed producer',
+  'writes only status/result, updated_at and boolean workspace/main/sync semantics',
+  'Phase 15.4b produces that manifest with atomic writes and non-public file permissions',
   'Phase 15.3b reads a fixed local backup status manifest and exposes only timestamp/result/checksum/retention-derived summary fields',
   'Phase 15.4a reads a fixed Zoro-owned repo-local status manifest and exposes only timestamp/result plus boolean workspace/main/sync semantics',
   'These phases still do not add gateway or cronjob reads',

--- a/scripts/write-project-health-status.py
+++ b/scripts/write-project-health-status.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Write the safe project-health Healthcheck manifest.
+
+This producer is intentionally outside the backend Healthcheck module. It may query
+Git locally, but the manifest it writes contains only boolean/timestamp/status
+semantics consumed later by ProjectHealthManifestAdapter.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_REPO_PATH = Path('/srv/crew-core/projects/mugiwara-control-panel')
+DEFAULT_OUTPUT_PATH = Path('/srv/crew-core/runtime/healthcheck/project-health-status.json')
+SAFE_MANIFEST_KEYS = ('status', 'result', 'updated_at', 'workspace_clean', 'main_branch', 'remote_synced')
+
+
+class ProjectHealthProducerError(RuntimeError):
+    """Raised when the producer cannot compute or write a safe manifest."""
+
+
+def write_project_health_status(
+    *,
+    repo_path: Path = DEFAULT_REPO_PATH,
+    output_path: Path = DEFAULT_OUTPUT_PATH,
+    now: str | datetime | None = None,
+) -> dict[str, object]:
+    repo = repo_path.resolve()
+    output = output_path.resolve()
+    updated_at = _safe_timestamp(now)
+
+    workspace_clean = _git_workspace_clean(repo)
+    main_branch = _git_on_main(repo)
+    remote_synced = _git_remote_synced(repo)
+    status = _derive_status(
+        workspace_clean=workspace_clean,
+        main_branch=main_branch,
+        remote_synced=remote_synced,
+    )
+
+    manifest: dict[str, object] = {
+        'status': status,
+        'result': status,
+        'updated_at': updated_at,
+        'workspace_clean': workspace_clean,
+        'main_branch': main_branch,
+        'remote_synced': remote_synced,
+    }
+    _write_atomic_json(output, manifest)
+    return manifest
+
+
+def _derive_status(*, workspace_clean: bool, main_branch: bool, remote_synced: bool) -> str:
+    if not workspace_clean:
+        return 'dirty'
+    if not main_branch:
+        return 'warning'
+    if not remote_synced:
+        return 'diverged'
+    return 'success'
+
+
+def _git_workspace_clean(repo: Path) -> bool:
+    result = _run_git(repo, 'status', '--porcelain=v1')
+    return result.stdout == ''
+
+
+def _git_on_main(repo: Path) -> bool:
+    result = _run_git(repo, 'branch', '--show-current')
+    return result.stdout.strip() == 'main'
+
+
+def _git_remote_synced(repo: Path) -> bool:
+    upstream = _run_git(repo, 'rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}', check=False)
+    if upstream.returncode != 0:
+        return False
+
+    head = _run_git(repo, 'rev-parse', 'HEAD', check=False)
+    remote_head = _run_git(repo, 'rev-parse', '@{u}', check=False)
+    if head.returncode != 0 or remote_head.returncode != 0:
+        return False
+    return head.stdout.strip() == remote_head.stdout.strip()
+
+
+def _run_git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            ['git', '-C', str(repo), *args],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError as exc:
+        raise ProjectHealthProducerError('git execution failed') from exc
+
+    if check and result.returncode != 0:
+        raise ProjectHealthProducerError('git state could not be read safely')
+    return result
+
+
+def _safe_timestamp(value: str | datetime | None) -> str:
+    if value is None:
+        moment = datetime.now(timezone.utc)
+    elif isinstance(value, datetime):
+        moment = value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    else:
+        normalized = value.replace('Z', '+00:00') if value.endswith('Z') else value
+        moment = datetime.fromisoformat(normalized)
+        if moment.tzinfo is None:
+            moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc).isoformat(timespec='seconds').replace('+00:00', 'Z')
+
+
+def _write_atomic_json(output: Path, manifest: dict[str, object]) -> None:
+    if tuple(manifest.keys()) != SAFE_MANIFEST_KEYS:
+        raise ProjectHealthProducerError('unsafe manifest shape')
+
+    output.parent.mkdir(mode=0o750, parents=True, exist_ok=True)
+    os.chmod(output.parent, 0o750)
+
+    payload = json.dumps(manifest, ensure_ascii=False, separators=(',', ':'), sort_keys=False) + '\n'
+    fd = -1
+    temp_path = ''
+    try:
+        fd, temp_path = tempfile.mkstemp(prefix='.project-health-status.', suffix='.tmp', dir=output.parent)
+        with os.fdopen(fd, 'w', encoding='utf-8') as handle:
+            fd = -1
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temp_path, 0o640)
+        os.replace(temp_path, output)
+        os.chmod(output, 0o640)
+    except OSError as exc:
+        if fd >= 0:
+            os.close(fd)
+        if temp_path:
+            try:
+                os.unlink(temp_path)
+            except FileNotFoundError:
+                pass
+        raise ProjectHealthProducerError('manifest could not be written atomically') from exc
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description='Write safe project-health Healthcheck manifest.')
+    parser.add_argument('--repo', type=Path, default=DEFAULT_REPO_PATH, help='Git repository to inspect.')
+    parser.add_argument('--output', type=Path, default=DEFAULT_OUTPUT_PATH, help='Manifest path to write atomically.')
+    parser.add_argument('--now', default=None, help='Optional ISO timestamp for deterministic tests.')
+    args = parser.parse_args(argv)
+
+    manifest = write_project_health_status(repo_path=args.repo, output_path=args.output, now=args.now)
+    print(
+        'project-health manifest written '
+        f"status={manifest['status']} "
+        f"workspace_clean={str(manifest['workspace_clean']).lower()} "
+        f"main_branch={str(manifest['main_branch']).lower()} "
+        f"remote_synced={str(manifest['remote_synced']).lower()}"
+    )
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Objetivo
Cerrar Phase 15.4b / issue #41: crear el productor operativo seguro del manifiesto `project-health-status.json` que consume el adapter añadido en Phase 15.4a.

## Cambios
- Añade `scripts/write-project-health-status.py`.
- Añade `npm run write:project-health-status`.
- Añade tests TDD con repos Git temporales.
- Amplía `verify:healthcheck-source-policy` para fijar productor, shape mínimo, ruta fija, atomicidad y permisos.
- Actualiza docs vivas y closeout Engram/OpenSpec.

## Frontera de seguridad
- Git se consulta solo en el productor operativo, fuera del backend Healthcheck.
- El manifiesto serializa solo: `status`, `result`, `updated_at`, `workspace_clean`, `main_branch`, `remote_synced`.
- No serializa ramas crudas, remotes, SHAs, diffs, untracked files, paths host, stdout/stderr/raw output, GitHub counts ni last-verify detail.
- No instala cron/systemd/timer persistente en esta PR.

## Verify de Zoro
- `python -m pytest apps/api/tests/test_project_health_manifest_producer.py -q` -> 4 passed.
- `npm run verify:healthcheck-source-policy` -> passed.
- `python -m pytest apps/api/tests/test_project_health_manifest_producer.py apps/api/tests/test_healthcheck_dashboard_api.py -q` -> 43 passed.
- `python -m py_compile scripts/write-project-health-status.py apps/api/tests/test_project_health_manifest_producer.py` -> OK.
- `git diff --check` -> OK.
- Scan dirigido del diff -> solo aparecen términos sensibles como exclusiones o fixtures sintéticas; no hay secretos reales ni salidas host crudas.

## Review solicitado
- Franky: operabilidad, atomicidad, permisos, semántica de sincronización y degradación.
- Chopper: no leakage de Git/host, frontera backend intacta, manifiesto mínimo.

No mergear sin Franky + Chopper (`approve` o `mergeable_with_minor_followups`).

Closes #41.
