### PR TITLE
fix: use python3 for project health runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "verify:health-dashboard-server-only": "node scripts/check-health-dashboard-server-only.mjs",
     "verify:healthcheck-source-policy": "node scripts/check-healthcheck-source-policy.mjs",
     "verify:project-health-runner": "node scripts/check-project-health-runner.mjs",
-    "write:project-health-status": "python scripts/write-project-health-status.py",
+    "write:project-health-status": "python3 scripts/write-project-health-status.py",
     "dev:api": "uvicorn apps.api.src.main:app --reload",
     "lint": "echo 'Pending lint setup'",
     "test": "echo 'Pending test setup'",

--- a/scripts/check-healthcheck-source-policy.mjs
+++ b/scripts/check-healthcheck-source-policy.mjs
@@ -71,8 +71,8 @@ if (packageJson && packageJson.scripts?.['verify:healthcheck-source-policy'] !==
   failures.push('package.json must expose verify:healthcheck-source-policy')
 }
 
-if (packageJson && packageJson.scripts?.['write:project-health-status'] !== 'python scripts/write-project-health-status.py') {
-  failures.push('package.json must expose write:project-health-status')
+if (packageJson && packageJson.scripts?.['write:project-health-status'] !== 'python3 scripts/write-project-health-status.py') {
+  failures.push('package.json must expose write:project-health-status with python3')
 }
 
 const forbiddenHostConsolePatterns = [


### PR DESCRIPTION
## Qué cambia
- Cambia `write:project-health-status` de `python` a `python3`.
- Ajusta el guardrail `verify:healthcheck-source-policy` para fijar el contrato con `python3`.

## Por qué
Al instalar y arrancar el timer de #49 en el host, systemd user ejecutaba `npm run write:project-health-status` con un entorno donde `python` no existe, aunque `python3` sí. El servicio falló con:

```text
sh: 1: python: not found
```

Con `python3`, el servicio arranca correctamente.

## Verificación de Zoro
- `PYTHONPATH=. pytest apps/api/tests/test_project_health_manifest_producer.py` — 4 passed
- `npm run verify:healthcheck-source-policy`
- `npm run verify:project-health-runner`
- `npm run write:project-health-status`
- `systemctl --user start mugiwara-project-health-status.service` — success con `python3`
- `git diff --check`

## Riesgo
Bajo. No cambia la lógica del productor ni la frontera host; solo fija el intérprete disponible en systemd user.
