### PR TITLE
fix: improve healthcheck triage UI

### DIFF
--- a/.engram/phase-16-1-healthcheck-triage-ui-closeout.md
+++ b/.engram/phase-16-1-healthcheck-triage-ui-closeout.md
@@ -1,0 +1,19 @@
+# Phase 16.1 closeout — Healthcheck triage UI (#44)
+
+## Resultado
+Issue #44 se resolvió como microfase frontend/UI-only: `/healthcheck` prioriza módulos y señales por urgencia, muestra una `Acción requerida` explícita y elimina badges duplicados cuando estado y severidad tienen el mismo significado visual.
+
+## Decisiones
+- El ranking vive en view-model frontend (`healthcheck-mappers.ts`) y no cambia el backend ni los contratos API.
+- La UI ordena copias de arrays para no mutar el workspace recibido.
+- Checks `pass/low` conservan lectura pero bajan peso visual con tono más calmado.
+
+## Verify
+- `npm --prefix apps/web run typecheck`
+- `npm --prefix apps/web run build`
+- `npm run verify:visual-baseline`
+- `git diff --check`
+- Smoke local con navegador en `/healthcheck` y consola sin errores JS.
+
+## Continuidad
+Pedir review a Usopp. Chopper/Franky no son reviewers obligatorios porque no hay cambio backend, seguridad, fuentes, runtime ni semántica operacional; solo se les debe involucrar si Usopp detecta que la jerarquía visual cambia significado operativo.

--- a/apps/web/src/app/healthcheck/page.tsx
+++ b/apps/web/src/app/healthcheck/page.tsx
@@ -1,11 +1,18 @@
 import {
   getHealthcheckSeverityLabel,
   getHealthcheckStatusLabel,
+  getHealthcheckTriageRank,
   mapHealthcheckSeverityToBadgeStatus,
   mapHealthcheckStatusToBadgeStatus,
+  shouldRenderSeparateSeverityBadge,
 } from '@/modules/healthcheck/view-models/healthcheck-mappers'
 import { fetchHealthcheckWorkspace, HealthcheckApiError } from '@/modules/healthcheck/api/healthcheck-http'
-import { healthcheckWorkspaceFixture, type HealthcheckWorkspace } from '@/modules/healthcheck/view-models/healthcheck-summary.fixture'
+import {
+  healthcheckWorkspaceFixture,
+  type HealthcheckModuleCard,
+  type HealthcheckSummaryItem,
+  type HealthcheckWorkspace,
+} from '@/modules/healthcheck/view-models/healthcheck-summary.fixture'
 import type { AppStatus } from '@/shared/theme/tokens'
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
@@ -59,6 +66,103 @@ async function getInitialHealthcheckData(): Promise<{ workspace: HealthcheckWork
   }
 }
 
+
+function getHealthcheckAccent(status: HealthcheckModuleCard['status'], severity: HealthcheckModuleCard['severity']) {
+  if (status === 'fail' || severity === 'critical' || severity === 'high') {
+    return 'danger' as const
+  }
+
+  if (status === 'warn' || severity === 'medium') {
+    return 'warning' as const
+  }
+
+  if (status === 'stale') {
+    return 'gold' as const
+  }
+
+  return 'sky' as const
+}
+
+function getHealthcheckCardTone(status: HealthcheckModuleCard['status'], severity: HealthcheckModuleCard['severity']) {
+  if (status === 'pass' && severity === 'low') {
+    return {
+      borderColor: 'rgba(255,255,255,0.08)',
+      background: 'rgba(255,255,255,0.015)',
+      opacity: 0.86,
+    }
+  }
+
+  if (status === 'fail' || severity === 'critical' || severity === 'high') {
+    return {
+      borderColor: 'rgba(201,65,40,0.55)',
+      background: 'rgba(201,65,40,0.08)',
+      opacity: 1,
+    }
+  }
+
+  return {
+    borderColor: appTheme.colors.borderSubtle,
+    background: appTheme.colors.bgSurface1,
+    opacity: 1,
+  }
+}
+
+function sortByHealthcheckTriage<T extends { status: HealthcheckModuleCard['status']; severity: HealthcheckModuleCard['severity']; updated_at?: string; freshness?: { updated_at: string } }>(items: T[]) {
+  return [...items].sort((left, right) => {
+    const rankDelta = getHealthcheckTriageRank(right.status, right.severity) - getHealthcheckTriageRank(left.status, left.severity)
+
+    if (rankDelta !== 0) {
+      return rankDelta
+    }
+
+    const leftDate = new Date(left.updated_at ?? left.freshness?.updated_at ?? '').getTime()
+    const rightDate = new Date(right.updated_at ?? right.freshness?.updated_at ?? '').getTime()
+
+    return (Number.isNaN(rightDate) ? 0 : rightDate) - (Number.isNaN(leftDate) ? 0 : leftDate)
+  })
+}
+
+function getPriorityCopy(module: HealthcheckModuleCard | null) {
+  if (!module) {
+    return null
+  }
+
+  if (module.status === 'fail' || module.severity === 'critical' || module.severity === 'high') {
+    return {
+      status: 'incidencia' as const,
+      title: `Prioridad actual: ${module.label}`,
+      description: module.summary,
+      detail: `${getHealthcheckStatusLabel(module.status)} · Severidad ${getHealthcheckSeverityLabel(module.severity)} · ${formatTimestamp(module.updated_at)}`,
+    }
+  }
+
+  if (module.status === 'warn' || module.status === 'stale' || module.severity === 'medium') {
+    return {
+      status: module.status === 'stale' ? ('stale' as const) : ('revision' as const),
+      title: `Acción requerida: revisar ${module.label}`,
+      description: module.summary,
+      detail: `${getHealthcheckStatusLabel(module.status)} · Severidad ${getHealthcheckSeverityLabel(module.severity)} · ${formatTimestamp(module.updated_at)}`,
+    }
+  }
+
+  return null
+}
+
+function HealthcheckStatusBadges({ status, severity }: Pick<HealthcheckModuleCard | HealthcheckSummaryItem, 'status' | 'severity'>) {
+  const statusBadge = mapHealthcheckStatusToBadgeStatus(status)
+  const severityBadge = mapHealthcheckSeverityToBadgeStatus(severity)
+
+  return (
+    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
+      <StatusBadge status={statusBadge} />
+      {shouldRenderSeparateSeverityBadge(status, severity) ? <StatusBadge status={severityBadge} /> : null}
+      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 700 }}>
+        Severidad {getHealthcheckSeverityLabel(severity)}
+      </span>
+    </div>
+  )
+}
+
 function formatTimestamp(value: string | null) {
   if (!value) {
     return 'Sin actualización'
@@ -78,6 +182,9 @@ function formatTimestamp(value: string | null) {
 
 export default async function HealthcheckPage() {
   const { workspace, apiNotice } = await getInitialHealthcheckData()
+  const sortedModules = sortByHealthcheckTriage(workspace.modules)
+  const sortedSignals = sortByHealthcheckTriage(workspace.signals)
+  const priorityNotice = getPriorityCopy(sortedModules[0] ?? null)
   const healthSummaryNotice =
     workspace.summary_bar.incidents > 0
       ? {
@@ -147,7 +254,15 @@ export default async function HealthcheckPage() {
             </div>
           </div>
 
-          {healthSummaryNotice ? (
+          {priorityNotice ? (
+            <StatePanel
+              status={priorityNotice.status}
+              title={priorityNotice.title}
+              description={priorityNotice.description}
+              detail={priorityNotice.detail}
+              eyebrow="Acción requerida"
+            />
+          ) : healthSummaryNotice ? (
             <StatePanel
               status={healthSummaryNotice.status}
               title={healthSummaryNotice.title}
@@ -159,27 +274,35 @@ export default async function HealthcheckPage() {
         </div>
       </SurfaceCard>
 
-      <section className="section-block layout-grid layout-grid--cards-240">
-        {workspace.modules.map((module) => (
-          <SurfaceCard key={module.module_id} title={module.label} elevated eyebrow="Check" accent={module.status === 'fail' ? 'danger' : module.status === 'warn' ? 'warning' : module.status === 'stale' ? 'gold' : 'sky'}>
-            <div style={{ display: 'grid', gap: '10px' }}>
-              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
-                <StatusBadge status={mapHealthcheckStatusToBadgeStatus(module.status)} />
-                <StatusBadge status={mapHealthcheckSeverityToBadgeStatus(module.severity)} />
-              </div>
-              <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                Estado: <strong>{getHealthcheckStatusLabel(module.status)}</strong>
-              </span>
-              <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                Severidad: <strong>{getHealthcheckSeverityLabel(module.severity)}</strong>
-              </span>
-              <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>
-                Última señal: {formatTimestamp(module.updated_at)}
-              </span>
-              <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>{module.summary}</p>
+      <section className="section-block layout-grid layout-grid--cards-240" aria-label="Checks priorizados">
+        {sortedModules.map((module, index) => {
+          const tone = getHealthcheckCardTone(module.status, module.severity)
+
+          return (
+            <div
+              key={module.module_id}
+              style={{
+                border: `1px solid ${tone.borderColor}`,
+                borderRadius: appTheme.radius.lg,
+                background: tone.background,
+                opacity: tone.opacity,
+              }}
+            >
+              <SurfaceCard title={module.label} elevated={index < 3} eyebrow={index === 0 ? 'Prioridad actual' : 'Check'} accent={getHealthcheckAccent(module.status, module.severity)}>
+                <div style={{ display: 'grid', gap: '10px' }}>
+                  <HealthcheckStatusBadges status={module.status} severity={module.severity} />
+                  <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
+                    Estado: <strong>{getHealthcheckStatusLabel(module.status)}</strong>
+                  </span>
+                  <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>
+                    Última señal: {formatTimestamp(module.updated_at)}
+                  </span>
+                  <p style={{ margin: 0, color: module.status === 'pass' && module.severity === 'low' ? appTheme.colors.textMuted : appTheme.colors.textSecondary }}>{module.summary}</p>
+                </div>
+              </SurfaceCard>
             </div>
-          </SurfaceCard>
-        ))}
+          )
+        })}
       </section>
 
       <section className="section-block layout-grid layout-grid--content-aside">
@@ -220,7 +343,7 @@ export default async function HealthcheckPage() {
           <SurfaceCard title="Señales del sistema" elevated eyebrow="Diagnóstico" accent="sky">
             {workspace.signals.length > 0 ? (
               <div style={{ display: 'grid', gap: '10px' }}>
-                {workspace.signals.map((check) => (
+                {sortedSignals.map((check) => (
                   <div
                     key={check.check_id}
                     style={{
@@ -235,10 +358,7 @@ export default async function HealthcheckPage() {
                       <strong>{check.label}</strong>
                       <code style={{ fontSize: '12px', color: appTheme.colors.textMuted }}>{check.check_id}</code>
                     </div>
-                    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
-                      <StatusBadge status={mapHealthcheckStatusToBadgeStatus(check.status)} />
-                      <StatusBadge status={mapHealthcheckSeverityToBadgeStatus(check.severity)} />
-                    </div>
+                    <HealthcheckStatusBadges status={check.status} severity={check.severity} />
                     <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{check.warning_text}</span>
                     <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>
                       {check.source_label} · {check.freshness.label}

--- a/apps/web/src/modules/healthcheck/view-models/healthcheck-mappers.ts
+++ b/apps/web/src/modules/healthcheck/view-models/healthcheck-mappers.ts
@@ -45,3 +45,26 @@ export function getHealthcheckSeverityLabel(severity: HealthcheckSeverity): stri
 
   return map[severity]
 }
+
+
+const statusTriageRank: Record<HealthcheckStatus, number> = {
+  fail: 90,
+  stale: 55,
+  warn: 50,
+  pass: 10,
+}
+
+const severityTriageRank: Record<HealthcheckSeverity, number> = {
+  critical: 100,
+  high: 80,
+  medium: 45,
+  low: 5,
+}
+
+export function getHealthcheckTriageRank(status: HealthcheckStatus, severity: HealthcheckSeverity): number {
+  return Math.max(statusTriageRank[status], severityTriageRank[severity])
+}
+
+export function shouldRenderSeparateSeverityBadge(status: HealthcheckStatus, severity: HealthcheckSeverity): boolean {
+  return mapHealthcheckStatusToBadgeStatus(status) !== mapHealthcheckSeverityToBadgeStatus(severity)
+}

--- a/docs/frontend-states.md
+++ b/docs/frontend-states.md
@@ -42,6 +42,9 @@ Cada vista del frontend debe contemplar al menos:
 ### Healthcheck
 - `stale`: healthchecks o cron con frescura fuera del umbral
 - `error`: fuente de estado no disponible
+- La vista debe priorizar visualmente `fail`, `high` y `critical` antes que checks sanos.
+- Cuando haya degradación, debe existir una señal superior de `Acción requerida` o prioridad actual sin añadir controles operativos.
+- Los badges de estado/severidad no deben duplicar el mismo significado visual; si coinciden, se muestra un solo badge y la severidad queda como texto de apoyo.
 
 ## Contratos frontend esperados del backend
 - listas resumidas para navegación

--- a/docs/visual-verify-baseline.md
+++ b/docs/visual-verify-baseline.md
@@ -33,6 +33,7 @@ Este comando imprime la checklist canónica por **viewport** y por **ruta**.
 - header, subtitle, pills y badges legibles
 - cards con ritmo visual consistente
 - estados vacíos/error/stale sin colapsar el layout
+- en `/healthcheck`, la prioridad actual debe verse antes del grid y los checks sanos no deben competir visualmente con incidencias o advertencias
 
 ### Responsive fino
 - grids apilan paneles con dignidad

--- a/openspec/phase-16-1-healthcheck-triage-ui.md
+++ b/openspec/phase-16-1-healthcheck-triage-ui.md
@@ -1,0 +1,39 @@
+# Phase 16.1 — Healthcheck triage UI polish (#44)
+
+## Objetivo
+Cerrar el follow-up UX/UI de la issue #44 haciendo que `/healthcheck` funcione como superficie de respuesta priorizada, no como grid plano de checks.
+
+## Por qué ahora
+Phase 15 cerró el bloque de fuentes reales Healthcheck y dejó estable la semántica de módulos/señales. El siguiente paso seguro es pulir la jerarquía visual sin tocar backend, adapters ni nuevas lecturas host.
+
+## Alcance
+- Ordenar módulos y señales por prioridad visual usando `status` + `severity`.
+- Mostrar un bloque explícito de `Acción requerida` cuando exista un módulo degradado.
+- Evitar badges duplicados cuando `status` y `severity` mapean al mismo significado visual.
+- Rebajar el peso visual de checks sanos `pass/low`.
+- Actualizar documentación viva y baseline visual.
+
+## Fuera de alcance
+- Nuevas fuentes Healthcheck.
+- Cambios backend/API/read-model.
+- Controles operativos o acciones de remediación.
+- Cambios de seguridad/perímetro.
+
+## Diseño
+La UI conserva los contratos existentes y añade lógica de view-model frontend:
+- `getHealthcheckTriageRank(status, severity)` prioriza `critical/high/fail` sobre `stale/warn` y estos sobre `pass/low`.
+- `shouldRenderSeparateSeverityBadge(status, severity)` evita duplicar visualmente badges equivalentes.
+- La página ordena copias defensivas de `modules` y `signals`; no muta datos recibidos.
+- El primer módulo ordenado alimenta el bloque `Acción requerida` si existe degradación.
+
+## Definition of Done
+- [x] Un `fail` o `high/critical` aparece antes que checks sanos.
+- [x] Las tarjetas dejan de mostrar badges duplicados de mismo significado.
+- [x] La prioridad actual es visible arriba del grid en menos de 3 segundos.
+- [x] Checks sanos siguen legibles con menor peso visual.
+- [x] Sin cambios backend/API ni nuevas lecturas host.
+- [x] Typecheck, build y visual baseline ejecutados.
+
+## Riesgos
+- El ranking es intencionalmente frontend-only; si el backend cambia el vocabulario de estados, TypeScript debe fallar antes de producción.
+- La baseline visual sigue siendo manual; no hay snapshot visual automatizado todavía.

--- a/openspec/phase-16-1-verify-checklist.md
+++ b/openspec/phase-16-1-verify-checklist.md
@@ -1,0 +1,23 @@
+# Phase 16.1 verify checklist — Healthcheck triage UI (#44)
+
+## Scope guard
+- [x] Cambio limitado a frontend UI/view-model + docs.
+- [x] Sin backend/API/read-model expansion.
+- [x] Sin host reads, comandos, controles operativos ni remediación.
+
+## UX acceptance
+- [x] Módulos ordenados por prioridad `fail/high/critical` > `stale/warn/medium` > `pass/low`.
+- [x] Bloque `Acción requerida` muestra la prioridad actual cuando hay degradación.
+- [x] Badges de estado/severidad no se duplican si tienen el mismo significado visual.
+- [x] Checks sanos `pass/low` quedan calmados sin desaparecer.
+
+## Verify ejecutado
+- [x] `npm --prefix apps/web run typecheck`
+- [x] `npm --prefix apps/web run build`
+- [x] `npm run verify:visual-baseline`
+- [x] `git diff --check`
+- [x] Smoke visual local `/healthcheck` con browser y consola sin errores JS.
+
+## Review esperado
+- Usopp: UI/UX hierarchy y claridad de respuesta.
+- Chopper/Franky: no requeridos salvo que el reviewer detecte cambio semántico o perímetro operativo.

--- a/scripts/visual-verify-baseline.mjs
+++ b/scripts/visual-verify-baseline.mjs
@@ -84,6 +84,9 @@ const routes = [
     title: 'Salud del sistema',
     checks: [
       'resumen agregado, módulos, eventos y señales respetan wrap y stacking',
+      'la prioridad actual aparece antes del grid cuando hay incidencia o advertencia',
+      'badges de estado/severidad no duplican el mismo significado visual',
+      'checks sanos mantienen menor peso visual que incidencias o advertencias',
       'principios de seguridad y badges semánticos siguen legibles en móvil',
       'ninguna card crítica rompe el grid en tablet',
     ],


### PR DESCRIPTION
## Objetivo
Cierra #44 como microfase Phase 16.1 UI-only: mejorar la priorización de `/healthcheck` y eliminar duplicidad visual de badges sin tocar backend ni fuentes Healthcheck.

## Cambios
- Añade ranking frontend por `status` + `severity` para ordenar módulos y señales.
- Añade bloque `Acción requerida` basado en el elemento más urgente.
- Evita renderizar badge de severidad separado cuando mapea al mismo estado visual que el badge de status.
- Rebaja peso visual de checks sanos `pass/low`.
- Actualiza baseline visual, docs de estados frontend, OpenSpec y closeout Engram.

## Scope guard
- Frontend/UI/view-model only.
- Sin cambios backend/API/read-model.
- Sin nuevas lecturas host, comandos, remediación ni controles operativos.

## Verificación Zoro
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build`
- `npm run verify:visual-baseline`
- `git diff --check`
- Smoke visual local en `/healthcheck` con navegador: prioridad visible, System aparece antes que checks sanos, consola sin errores JS.

## Review solicitada
- Usopp: UI/UX hierarchy, claridad de respuesta operativa, reducción de duplicados visuales y peso relativo de checks sanos.
- Chopper/Franky no solicitados de entrada: no hay cambio de seguridad, backend, runtime ni semántica operacional.
