### PR TITLE
fix: clarify api source states

### DIFF
--- a/.engram/phase-16-2-source-state-clarity-closeout.md
+++ b/.engram/phase-16-2-source-state-clarity-closeout.md
@@ -1,0 +1,21 @@
+# Phase 16.2 closeout — Source-state clarity (#45)
+
+## Resultado
+#45 se aborda como una microfase única UI/copy-only. Se comprobó que dividir por página generaría overhead sin reducir riesgo real: todas las superficies comparten el mismo problema de vocabulario y se resuelven con un componente visual común y copys consistentes.
+
+## Decisiones
+- No ampliar `AppStatus`; se usa `revision` para fallback visible en vez de `sin-datos` cuando hay snapshot/fixture renderizado.
+- Códigos técnicos (`not_configured`, `invalid_config`, etc.) quedan como `Estado técnico: ...`, secundarios.
+- `SourceStatePills` fija vocabulario visual reusable: `API real conectada`, `Modo fallback local`, `Snapshot saneado`, `No tiempo real`, `Fuente no configurada`, `Error/degradado`.
+- Chopper entra como reviewer de seguridad por wording de config/error, aunque el cambio no expone detalles nuevos.
+
+## Verify
+- `npm --prefix apps/web run typecheck`
+- `npm --prefix apps/web run build`
+- `npm run verify:visual-baseline`
+- `git diff --check`
+- HTTP smoke local sobre `/dashboard`, `/healthcheck`, `/mugiwaras`, `/memory`, `/vault` y `/skills`: todas 200.
+- Browser smoke local sobre las seis rutas: source-state visible y consola JS sin errores.
+
+## Continuidad
+Si Usopp pide compactar algún aviso concreto, hacerlo en una ronda corta. Si Chopper detecta cualquier leakage semántico, corregir copy sin tocar backend.

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -14,6 +14,7 @@ import {
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
 import { StatePanel } from '@/shared/ui/state/StatePanel'
+import { SourceStatePills } from '@/shared/ui/status/SourceStatePills'
 import { StatusBadge } from '@/shared/ui/status/StatusBadge'
 import { appTheme, type AppStatus } from '@/shared/theme/tokens'
 
@@ -34,10 +35,10 @@ async function getInitialDashboardData(): Promise<{ summary: DashboardSummary; a
       return {
         summary: dashboardSummaryFixture,
         apiNotice: {
-          status: 'sin-datos',
-          title: 'API Dashboard sin datos configurados',
-          description: 'La API respondió sin agregado disponible; se mantiene fixture saneado para no romper la navegación.',
-          detail: response.status,
+          status: 'revision',
+          title: 'Dashboard en modo fallback local',
+          description: 'La API respondió sin agregado disponible. Se muestra un snapshot local saneado para mantener la navegación, pero no representa una lectura en tiempo real.',
+          detail: `Estado técnico: ${response.status}`,
         },
       }
     }
@@ -49,15 +50,18 @@ async function getInitialDashboardData(): Promise<{ summary: DashboardSummary; a
     return {
       summary: dashboardSummaryFixture,
       apiNotice: {
-        status: apiError?.code === 'not_configured' ? 'sin-datos' : 'incidencia',
+        status: apiError?.code === 'not_configured' ? 'revision' : 'incidencia',
         title:
           apiError?.code === 'not_configured'
-            ? 'API Dashboard no configurada'
+            ? 'Dashboard en modo fallback local'
             : apiError?.code === 'invalid_config'
               ? 'Configuración server-only de Dashboard inválida'
               : 'API Dashboard no disponible',
-        description: 'La página mantiene fallback saneado local. No se muestran detalles internos del backend ni salidas operativas crudas.',
-        detail: apiError?.code,
+        description:
+          apiError?.code === 'not_configured'
+            ? 'Mostrando snapshot local saneado. Estos datos sostienen la navegación, pero no son lectura real ni tiempo real.'
+            : 'La página mantiene fallback saneado local. No se muestran detalles internos del backend ni salidas operativas crudas.',
+        detail: apiError?.code ? `Estado técnico: ${apiError.code}` : undefined,
       },
     }
   }
@@ -91,8 +95,16 @@ export default async function DashboardPage() {
           title={apiNotice.title}
           description={apiNotice.description}
           detail={apiNotice.detail}
-          eyebrow="Estado de API"
-        />
+          eyebrow="Estado de fuente"
+        >
+          <SourceStatePills
+            items={[
+              { label: 'Modo fallback local', tone: 'fallback' },
+              { label: 'Snapshot saneado', tone: 'snapshot' },
+              { label: 'No tiempo real', tone: 'not-realtime' },
+            ]}
+          />
+        </StatePanel>
       ) : null}
 
       <section className="layout-grid layout-grid--cards-260">

--- a/apps/web/src/app/healthcheck/page.tsx
+++ b/apps/web/src/app/healthcheck/page.tsx
@@ -17,6 +17,7 @@ import type { AppStatus } from '@/shared/theme/tokens'
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
 import { StatePanel } from '@/shared/ui/state/StatePanel'
+import { SourceStatePills } from '@/shared/ui/status/SourceStatePills'
 import { StatusBadge } from '@/shared/ui/status/StatusBadge'
 import { appTheme } from '@/shared/theme/tokens'
 
@@ -37,10 +38,10 @@ async function getInitialHealthcheckData(): Promise<{ workspace: HealthcheckWork
       return {
         workspace: healthcheckWorkspaceFixture,
         apiNotice: {
-          status: 'sin-datos',
-          title: 'API Healthcheck sin datos configurados',
-          description: 'La API respondió sin catálogo disponible; se mantiene fixture saneado para no romper la lectura.',
-          detail: response.status,
+          status: 'revision',
+          title: 'Healthcheck en modo fallback local',
+          description: 'La API respondió sin catálogo disponible. Se muestra un snapshot local saneado para conservar la lectura, pero no representa señales en tiempo real.',
+          detail: `Estado técnico: ${response.status}`,
         },
       }
     }
@@ -52,15 +53,18 @@ async function getInitialHealthcheckData(): Promise<{ workspace: HealthcheckWork
     return {
       workspace: healthcheckWorkspaceFixture,
       apiNotice: {
-        status: apiError?.code === 'not_configured' ? 'sin-datos' : 'incidencia',
+        status: apiError?.code === 'not_configured' ? 'revision' : 'incidencia',
         title:
           apiError?.code === 'not_configured'
-            ? 'API Healthcheck no configurada'
+            ? 'Healthcheck en modo fallback local'
             : apiError?.code === 'invalid_config'
               ? 'Configuración server-only de Healthcheck inválida'
               : 'API Healthcheck no disponible',
-        description: 'La página mantiene fallback saneado local. No se muestran comandos, logs crudos ni detalles internos del host.',
-        detail: apiError?.code,
+        description:
+          apiError?.code === 'not_configured'
+            ? 'Mostrando snapshot local saneado. Estos checks mantienen la navegación, pero no son lectura real ni tiempo real.'
+            : 'La página mantiene fallback saneado local. No se muestran comandos, logs crudos ni detalles internos del host.',
+        detail: apiError?.code ? `Estado técnico: ${apiError.code}` : undefined,
       },
     }
   }
@@ -218,8 +222,16 @@ export default async function HealthcheckPage() {
           title={apiNotice.title}
           description={apiNotice.description}
           detail={apiNotice.detail}
-          eyebrow="Estado de API"
-        />
+          eyebrow="Estado de fuente"
+        >
+          <SourceStatePills
+            items={[
+              { label: 'Modo fallback local', tone: 'fallback' },
+              { label: 'Snapshot saneado', tone: 'snapshot' },
+              { label: 'No tiempo real', tone: 'not-realtime' },
+            ]}
+          />
+        </StatePanel>
       ) : null}
 
       <SurfaceCard title="Resumen de salud" elevated eyebrow="Puesto médico" accent="danger">

--- a/apps/web/src/app/memory/MemoryClient.tsx
+++ b/apps/web/src/app/memory/MemoryClient.tsx
@@ -10,6 +10,7 @@ import { MugiwaraCrest } from '@/shared/mugiwara/MugiwaraCrest'
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
 import { StatePanel } from '@/shared/ui/state/StatePanel'
+import { SourceStatePills } from '@/shared/ui/status/SourceStatePills'
 import { StatusBadge } from '@/shared/ui/status/StatusBadge'
 import { appTheme, type AppStatus } from '@/shared/theme/tokens'
 
@@ -155,8 +156,16 @@ export function MemoryClient({ apiSummaries, apiDetails, apiState, apiNotice }: 
             title={apiNotice.title}
             description={apiNotice.description}
             detail={apiNotice.detail}
-            eyebrow="Estado API Memory"
-          />
+            eyebrow="Estado de fuente"
+          >
+            <SourceStatePills
+              items={[
+                { label: 'Modo fallback local', tone: 'fallback' },
+                { label: 'Snapshot saneado', tone: 'snapshot' },
+                { label: 'No tiempo real', tone: 'not-realtime' },
+              ]}
+            />
+          </StatePanel>
         </section>
       ) : null}
 
@@ -168,7 +177,7 @@ export function MemoryClient({ apiSummaries, apiDetails, apiState, apiNotice }: 
                 Memory muestra continuidad por Mugiwara y estado resumido de fuentes. No es una superficie editable ni se mezcla con el canon curado del Vault.
               </p>
               <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                <StatusBadge status={apiState === 'ready' ? 'operativo' : 'sin-datos'} />
+                <StatusBadge status={apiState === 'ready' ? 'operativo' : 'revision'} />
                 <span
                   style={{
                     display: 'inline-flex',

--- a/apps/web/src/app/memory/page.tsx
+++ b/apps/web/src/app/memory/page.tsx
@@ -25,10 +25,10 @@ async function getInitialMemoryData(): Promise<InitialMemoryData> {
         apiDetails: {},
         apiState: 'fallback',
         apiNotice: {
-          status: 'sin-datos',
-          title: 'API Memory sin datos configurados',
-          description: 'La API respondió sin catálogo disponible; se mantiene fixture saneado para no romper la lectura.',
-          detail: summary.status,
+          status: 'revision',
+          title: 'Memory en modo fallback local',
+          description: 'La API respondió sin catálogo disponible. Se muestra un snapshot local saneado para sostener la navegación; no es lectura real ni tiempo real.',
+          detail: `Estado técnico: ${summary.status}`,
         },
       }
     }
@@ -66,18 +66,18 @@ async function getInitialMemoryData(): Promise<InitialMemoryData> {
       apiDetails: {},
       apiState: 'fallback',
       apiNotice: {
-        status: apiError?.code === 'not_configured' ? 'sin-datos' : 'incidencia',
+        status: apiError?.code === 'not_configured' ? 'revision' : 'incidencia',
         title:
           apiError?.code === 'not_configured'
-            ? 'API Memory no configurada'
+            ? 'Memory en modo fallback local'
             : apiError?.code === 'invalid_config'
               ? 'Configuración server-only de Memory inválida'
               : 'API Memory no disponible',
         description:
           apiError?.code === 'not_configured'
-            ? 'Configura `MUGIWARA_CONTROL_PANEL_API_URL` solo en el entorno server para conectar esta vista al backend.'
+            ? 'Mostrando snapshot local saneado. Estos resúmenes sostienen la navegación, pero no son lectura real ni tiempo real.'
             : 'La página mantiene el fallback saneado local. No se muestran dumps crudos ni detalles técnicos de memoria.',
-        detail: apiError?.code,
+        detail: apiError?.code ? `Estado técnico: ${apiError.code}` : undefined,
       },
     }
   }

--- a/apps/web/src/app/mugiwaras/page.tsx
+++ b/apps/web/src/app/mugiwaras/page.tsx
@@ -13,6 +13,7 @@ import { MugiwaraCrest } from '@/shared/mugiwara/MugiwaraCrest'
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
 import { StatePanel } from '@/shared/ui/state/StatePanel'
+import { SourceStatePills } from '@/shared/ui/status/SourceStatePills'
 import { StatusBadge } from '@/shared/ui/status/StatusBadge'
 import { appTheme, type AppStatus } from '@/shared/theme/tokens'
 
@@ -38,11 +39,11 @@ function getMugiwarasConfigNotice(error: MugiwarasApiError | null): MugiwarasVie
     cards: mugiwaraCardFixture,
     crewRulesDocument: null,
     notice: {
-      status: error?.code === 'invalid_config' ? 'incidencia' : 'sin-datos',
-      title: error?.code === 'invalid_config' ? 'Configuración server-only de Mugiwara inválida' : 'Backend de Mugiwara no configurado',
+      status: error?.code === 'invalid_config' ? 'incidencia' : 'revision',
+      title: error?.code === 'invalid_config' ? 'Configuración server-only de Mugiwara inválida' : 'Tripulación en modo fallback local',
       description:
-        'La página mantiene el fixture saneado, pero la lectura canónica de /srv/crew-core/AGENTS.md requiere MUGIWARA_CONTROL_PANEL_API_URL válida en el runtime server.',
-      detail: error?.code ?? 'Variable ausente en el runtime actual.',
+        'Mostrando fixture saneado de tripulación. Mantiene la navegación, pero AGENTS.md canónico solo aparece cuando la API allowlisted está conectada.',
+      detail: error?.code ? `Estado técnico: ${error.code}` : 'Estado técnico: not_configured',
     },
   }
 }
@@ -76,8 +77,8 @@ async function getMugiwarasViewModel(): Promise<MugiwarasViewModel> {
         status: 'incidencia',
         title: 'No se pudo cargar la API read-only de Mugiwara',
         description:
-          'La UI cae al fixture saneado para no romper el shell. No se muestra AGENTS.md si la fuente backend no está disponible.',
-        detail,
+          'La UI cae al fixture saneado para no romper el shell. No se muestra AGENTS.md si la fuente backend no está disponible y no se exponen detalles host.',
+        detail: `Estado técnico: ${detail}`,
       },
     }
   }
@@ -108,7 +109,7 @@ export default async function MugiwarasPage() {
         <p style={{ marginTop: 0, marginBottom: '10px', color: appTheme.colors.textSecondary }}>
           Esta vista agrega solo resúmenes saneados por agente. No abre controles de edición y solo muestra el AGENTS.md canónico de crew-core cuando llega desde la API allowlisted.
         </p>
-        <StatusBadge status={viewModel.state === 'ready' ? 'operativo' : 'sin-datos'} />
+        <StatusBadge status={viewModel.state === 'ready' ? 'operativo' : 'revision'} />
       </SurfaceCard>
 
       {viewModel.notice ? (
@@ -119,7 +120,15 @@ export default async function MugiwarasPage() {
             description={viewModel.notice.description}
             detail={viewModel.notice.detail}
             eyebrow="Estado de fuente"
-          />
+          >
+            <SourceStatePills
+              items={[
+                { label: 'Modo fallback local', tone: 'fallback' },
+                { label: 'Snapshot saneado', tone: 'snapshot' },
+                { label: viewModel.state === 'error' ? 'Error/degradado' : 'Fuente no configurada', tone: viewModel.state === 'error' ? 'degraded' : 'not-configured' },
+              ]}
+            />
+          </StatePanel>
         </section>
       ) : null}
 

--- a/apps/web/src/app/mugiwaras/page.tsx
+++ b/apps/web/src/app/mugiwaras/page.tsx
@@ -68,7 +68,7 @@ async function getMugiwarasViewModel(): Promise<MugiwarasViewModel> {
       return getMugiwarasConfigNotice(error)
     }
 
-    const detail = error instanceof MugiwarasApiError ? `${error.code}: ${error.message}` : error instanceof Error ? error.message : 'Error desconocido'
+    const errorCode = error instanceof MugiwarasApiError ? error.code : 'fetch_failed'
     return {
       state: 'error',
       cards: mugiwaraCardFixture,
@@ -78,7 +78,7 @@ async function getMugiwarasViewModel(): Promise<MugiwarasViewModel> {
         title: 'No se pudo cargar la API read-only de Mugiwara',
         description:
           'La UI cae al fixture saneado para no romper el shell. No se muestra AGENTS.md si la fuente backend no está disponible y no se exponen detalles host.',
-        detail: `Estado técnico: ${detail}`,
+        detail: `Estado técnico: ${errorCode}`,
       },
     }
   }

--- a/apps/web/src/app/skills/page.tsx
+++ b/apps/web/src/app/skills/page.tsx
@@ -86,7 +86,7 @@ function getSkillsViewNotice(state: SkillsViewState, connectionLabel: string, er
         status: 'incidencia' as const,
         title: 'Skills con fuente degradada',
         description: 'La superficie mantiene el shell, pero la conectividad o la respuesta saneada del BFF impiden mostrar catálogo y detalle con garantías. No se exponen URLs internas ni salidas crudas.',
-        detail: errorMessage ? `Estado técnico: ${errorMessage}` : 'Estado técnico: error',
+        detail: 'Estado técnico: error',
       }
     case 'empty':
       return {
@@ -386,7 +386,7 @@ export default function SkillsPage() {
       <PageHeader
         eyebrow="Skills"
         title="Skills"
-        subtitle="Catálogo conectado a backend real con preview y guardado controlado: actor visible, PUT allowlisted y manejo explícito de conflicto stale."
+        subtitle="Catálogo preparado para backend real con preview y guardado controlado; el estado de origen indica si la fuente está conectada."
         mugiwaraSlug="zoro"
         detailPills={["Edición allowlisted", "Diff explícito", "Auditoría visible"]}
       />

--- a/apps/web/src/app/skills/page.tsx
+++ b/apps/web/src/app/skills/page.tsx
@@ -23,6 +23,7 @@ import { skillSurfaceFixture } from '@/modules/skills/view-models/skill-surface.
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
 import { StatePanel } from '@/shared/ui/state/StatePanel'
+import { SourceStatePills } from '@/shared/ui/status/SourceStatePills'
 import { StatusBadge } from '@/shared/ui/status/StatusBadge'
 import { appTheme, type AppStatus } from '@/shared/theme/tokens'
 
@@ -75,17 +76,17 @@ function getSkillsViewNotice(state: SkillsViewState, connectionLabel: string, er
       }
     case 'not_configured':
       return {
-        status: 'sin-datos' as const,
-        title: 'BFF de Skills sin configuración server-only',
-        description: 'Configura `MUGIWARA_CONTROL_PANEL_API_URL` solo en el runtime server para conectar esta vista al backend real.',
-        detail: 'El navegador no necesita conocer la URL del backend.',
+        status: 'revision' as const,
+        title: 'Skills con fuente no configurada',
+        description: 'El BFF same-origin está disponible, pero falta la configuración server-only hacia el backend. No se muestran datos productivos ni URL interna al navegador.',
+        detail: 'Estado técnico: not_configured',
       }
     case 'error':
       return {
         status: 'incidencia' as const,
-        title: 'No se pudo cargar la fuente real de skills',
-        description: 'La superficie mantiene el shell, pero la conectividad o la respuesta saneada del BFF impiden mostrar catálogo y detalle con garantías.',
-        detail: errorMessage ?? 'Sin detalle adicional.',
+        title: 'Skills con fuente degradada',
+        description: 'La superficie mantiene el shell, pero la conectividad o la respuesta saneada del BFF impiden mostrar catálogo y detalle con garantías. No se exponen URLs internas ni salidas crudas.',
+        detail: errorMessage ? `Estado técnico: ${errorMessage}` : 'Estado técnico: error',
       }
     case 'empty':
       return {
@@ -567,15 +568,27 @@ export default function SkillsPage() {
                 description={sourceNotice.description}
                 detail={sourceNotice.detail}
                 eyebrow="Estado de fuente"
-              />
+              >
+                <SourceStatePills
+                  items={
+                    viewState === 'not_configured'
+                      ? [{ label: 'Fuente no configurada', tone: 'not-configured' }]
+                      : viewState === 'empty'
+                        ? [{ label: 'API real conectada', tone: 'connected' }, { label: 'Sin datos productivos', tone: 'not-configured' }]
+                        : [{ label: 'Error/degradado', tone: 'degraded' }]
+                  }
+                />
+              </StatePanel>
             ) : (
               <StatePanel
                 status="operativo"
                 title="BFF same-origin conectado"
-                description="Catálogo, detalle y auditoría están listos para operar sobre la allowlist activa sin exponer la URL del backend al navegador."
+                description="Catálogo, detalle y auditoría llegan desde la API real a través de la allowlist activa sin exponer la URL del backend al navegador."
                 detail={`Conexión: ${apiConnectionLabel}`}
                 eyebrow="Estado de fuente"
-              />
+              >
+                <SourceStatePills items={[{ label: 'API real conectada', tone: 'connected' }]} />
+              </StatePanel>
             )}
           </div>
         </SurfaceCard>

--- a/apps/web/src/app/vault/VaultClient.tsx
+++ b/apps/web/src/app/vault/VaultClient.tsx
@@ -6,6 +6,7 @@ import type { VaultWorkspace } from '@/modules/vault/view-models/vault-workspace
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
 import { StatePanel } from '@/shared/ui/state/StatePanel'
+import { SourceStatePills } from '@/shared/ui/status/SourceStatePills'
 import { StatusBadge } from '@/shared/ui/status/StatusBadge'
 import { appTheme } from '@/shared/theme/tokens'
 
@@ -40,12 +41,12 @@ function getVaultApiNotice(apiState: VaultClientProps['apiState'], apiErrorCode?
   const isNotConfigured = apiErrorCode === 'not_configured'
 
   return {
-    status: isNotConfigured ? ('sin-datos' as const) : ('incidencia' as const),
-    title: isNotConfigured ? 'Vault API no configurada' : 'Vault en fallback saneado',
+    status: isNotConfigured ? ('revision' as const) : ('incidencia' as const),
+    title: isNotConfigured ? 'Vault en modo fallback local' : 'Vault en fallback saneado',
     description: isNotConfigured
-      ? 'La página muestra fixture documental local porque falta la configuración server-only de la API. No se exponen rutas internas ni detalles del backend.'
-      : 'La carga real del Vault no está disponible y la página muestra un fallback documental local. Este estado degradado queda visible para no ocultar misconfiguración operativa.',
-    detail: apiErrorCode ? `Estado controlado: ${apiErrorCode}` : null,
+      ? 'Mostrando snapshot documental local saneado. Mantiene la navegación del canon, pero no representa lectura real ni tiempo real de la API.'
+      : 'La carga real del Vault no está disponible y la página muestra un fallback documental local. Este estado degradado queda visible sin exponer rutas internas ni detalles del backend.',
+    detail: apiErrorCode ? `Estado técnico: ${apiErrorCode}` : null,
   }
 }
 
@@ -87,8 +88,16 @@ export function VaultClient({ initialWorkspace, apiState, apiErrorCode }: VaultC
               title={apiNotice.title}
               description={apiNotice.description}
               detail={apiNotice.detail}
-              eyebrow="Estado de API"
-            />
+              eyebrow="Estado de fuente"
+            >
+              <SourceStatePills
+                items={[
+                  { label: 'Modo fallback local', tone: 'fallback' },
+                  { label: 'Snapshot saneado', tone: 'snapshot' },
+                  { label: 'No tiempo real', tone: 'not-realtime' },
+                ]}
+              />
+            </StatePanel>
           ) : null}
 
           <SurfaceCard title="Canon curado" elevated eyebrow="Archivo" accent="gold">

--- a/apps/web/src/modules/skills/view-models/skill-surface.mappers.ts
+++ b/apps/web/src/modules/skills/view-models/skill-surface.mappers.ts
@@ -45,8 +45,9 @@ export function mapSkillsViewStateToBadgeStatus(state: 'loading' | 'ready' | 'em
     case 'ready':
       return 'operativo'
     case 'empty':
-    case 'not_configured':
       return 'sin-datos'
+    case 'not_configured':
+      return 'revision'
     case 'error':
       return 'incidencia'
     case 'loading':

--- a/apps/web/src/shared/ui/status/SourceStatePills.tsx
+++ b/apps/web/src/shared/ui/status/SourceStatePills.tsx
@@ -1,0 +1,46 @@
+import { appTheme } from '@/shared/theme/tokens'
+
+export type SourceStatePillTone = 'connected' | 'fallback' | 'snapshot' | 'not-realtime' | 'not-configured' | 'degraded'
+
+export type SourceStatePill = {
+  label: string
+  tone?: SourceStatePillTone
+}
+
+const sourceStateToneColorMap: Record<SourceStatePillTone, string> = {
+  connected: appTheme.colors.stateSuccess,
+  fallback: appTheme.colors.stateWarning,
+  snapshot: appTheme.colors.brandSky500,
+  'not-realtime': appTheme.colors.stateStale,
+  'not-configured': appTheme.colors.stateNeutral,
+  degraded: appTheme.colors.stateDanger,
+}
+
+export function SourceStatePills({ items }: { items: SourceStatePill[] }) {
+  return (
+    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+      {items.map((item) => {
+        const color = sourceStateToneColorMap[item.tone ?? 'snapshot']
+
+        return (
+          <span
+            key={`${item.label}-${item.tone ?? 'snapshot'}`}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              borderRadius: '999px',
+              padding: '4px 10px',
+              background: appTheme.colors.bgSurface2,
+              border: `1px solid ${color}`,
+              color,
+              fontSize: '12px',
+              fontWeight: 700,
+            }}
+          >
+            {item.label}
+          </span>
+        )
+      })}
+    </div>
+  )
+}

--- a/docs/frontend-states.md
+++ b/docs/frontend-states.md
@@ -11,7 +11,9 @@ Cada vista del frontend debe contemplar al menos:
 ## Reglas
 - `loading` no debe bloquear navegación completa del shell si solo falla un módulo.
 - `error` debe ser visible sin filtrar detalles internos del host.
-- `empty` debe distinguir “sin datos” de “sin permiso” y de “fuente no configurada”.
+- `empty` debe distinguir “sin datos”, “sin permiso” y “fuente no configurada”.
+- Si una página muestra fixture, fallback o snapshot visible, no debe presentarlo como simple “Sin datos”: debe etiquetarlo como `Modo fallback local`, `Snapshot saneado` y/o `No tiempo real`.
+- Códigos técnicos como `not_configured` pueden mostrarse como detalle secundario (`Estado técnico: ...`), nunca como explicación principal para el usuario.
 - `stale` aplica a healthcheck, system y cualquier dato con timestamp operativo.
 
 ## Por módulo

--- a/docs/visual-verify-baseline.md
+++ b/docs/visual-verify-baseline.md
@@ -33,6 +33,7 @@ Este comando imprime la checklist canónica por **viewport** y por **ruta**.
 - header, subtitle, pills y badges legibles
 - cards con ritmo visual consistente
 - estados vacíos/error/stale sin colapsar el layout
+- cuando haya fallback visible, las pills `Modo fallback local`, `Snapshot saneado` y/o `No tiempo real` deben aclarar que el contenido no es API real
 - en `/healthcheck`, la prioridad actual debe verse antes del grid y los checks sanos no deben competir visualmente con incidencias o advertencias
 
 ### Responsive fino

--- a/openspec/phase-16-2-source-state-clarity.md
+++ b/openspec/phase-16-2-source-state-clarity.md
@@ -1,0 +1,44 @@
+# Phase 16.2 — Source-state clarity across API-backed pages (#45)
+
+## Objetivo
+Cerrar #45 como una microfase UI/copy-only para que las páginas API-backed distingan claramente entre lectura real, fallback local, snapshot saneado, no tiempo real, fuente no configurada y error degradado.
+
+## Decisión de corte
+Se comprobó el alcance real y **no se divide en varias PRs** por ahora. Aunque afecta varias rutas, el cambio es homogéneo y limitado a vocabulario UI/copy + un componente compartido de pills de estado de fuente. No toca backend, runtime, adapters, datos expuestos ni contratos API.
+
+Si durante review Usopp/Chopper pidieran cambios de semántica o tratamiento específico para Skills, se cortaría una subfase posterior; no se mezcla ahora con nuevas fuentes ni controles.
+
+## Alcance
+- Dashboard: aclarar cuándo muestra snapshot local saneado en vez de lectura real.
+- Healthcheck: aclarar fallback/snapshot/no tiempo real sin competir con el triage cerrado en #44.
+- Memory: aclarar fallback local y snapshots saneados cuando API Memory no responde o no está configurada.
+- Vault: aclarar fallback documental local y no tiempo real.
+- Mugiwaras: aclarar fixture saneado vs AGENTS.md canónico desde API allowlisted.
+- Skills: aclarar BFF conectado, fuente no configurada, sin datos productivos o error degradado.
+- Añadir pills compartidas de source-state.
+
+## Fuera de alcance
+- Nuevas API calls.
+- Nuevas fuentes Healthcheck.
+- Runtime config changes.
+- Backend adapters.
+- Exponer URLs internas, rutas host, logs, comandos, stdout/stderr o raw errors.
+
+## Diseño
+- Crear `SourceStatePills` como componente visual pequeño y reutilizable.
+- Evitar usar `Sin datos` como estado primario cuando se está mostrando fallback/snapshot visible; preferir `revision` con copy explícita.
+- Mantener códigos técnicos como detalle secundario `Estado técnico: ...`.
+- Conservar StatusBadge general del sistema sin ampliar `AppStatus`.
+
+## Definition of Done
+- [x] Dashboard distingue API real vs snapshot/fallback.
+- [x] Healthcheck distingue API real vs snapshot/fallback.
+- [x] Skills, Memory, Vault y Mugiwaras usan vocabulario source-state coherente donde aplica.
+- [x] `not_configured` queda como detalle técnico secundario, no mensaje principal.
+- [x] No se exponen detalles sensibles.
+- [x] Verify web + visual baseline ejecutados.
+
+## Review
+- Usopp: UX/copy clarity y consistencia cross-surface.
+- Chopper: safety review porque se toca wording de estados/config/error, aunque no se expone detalle nuevo.
+- Franky: no requerido; no hay runtime/operación/config change.

--- a/openspec/phase-16-2-verify-checklist.md
+++ b/openspec/phase-16-2-verify-checklist.md
@@ -1,0 +1,28 @@
+# Phase 16.2 verify checklist — Source-state clarity (#45)
+
+## Scope guard
+- [x] UI/copy-only.
+- [x] Sin backend/API/read-model expansion.
+- [x] Sin runtime config changes.
+- [x] Sin nuevas fuentes ni host reads.
+- [x] Sin URLs internas, rutas host, logs, comandos, stdout/stderr o raw errors expuestos.
+
+## UX acceptance
+- [x] Dashboard distingue snapshot local saneado de lectura real.
+- [x] Healthcheck distingue snapshot local saneado de señales en tiempo real.
+- [x] Skills distingue BFF conectado, fuente no configurada, sin datos productivos y error degradado.
+- [x] Memory distingue fallback local/snapshot de lectura real.
+- [x] Vault distingue fallback documental local de lectura API real.
+- [x] Mugiwaras distingue fixture saneado de AGENTS.md canónico API-backed.
+- [x] `not_configured` aparece solo como detalle técnico secundario.
+
+## Verify ejecutado
+- [x] `npm --prefix apps/web run typecheck`
+- [x] `npm --prefix apps/web run build`
+- [x] `npm run verify:visual-baseline`
+- [x] `git diff --check`
+- [x] Browser smoke sobre `/dashboard`, `/healthcheck`, `/mugiwaras`, `/skills`, `/memory` y `/vault` con HTTP 200 y consola sin errores JS.
+
+## Review esperado
+- Usopp: claridad de copy/source-state.
+- Chopper: no leakage en wording de config/error/source-state.

--- a/scripts/visual-verify-baseline.mjs
+++ b/scripts/visual-verify-baseline.mjs
@@ -41,6 +41,7 @@ const routes = [
       'KPIs visibles sin truncados torpes',
       'cards de severidad/frescura/módulos mantienen ritmo visual',
       'accesos rápidos envuelven bien en tablet/mobile',
+      'si la API no está configurada, el aviso indica Modo fallback local, Snapshot saneado y No tiempo real',
     ],
   },
   {
@@ -50,6 +51,7 @@ const routes = [
       'cards de agentes no cortan slug/rol/skills enlazadas',
       'chips de skills y links secundarios hacen wrap limpio',
       'la identidad Mugiwara sigue visible sin saturar el layout',
+      'si cae a fixture, el aviso distingue fixture saneado de AGENTS.md canónico API-backed',
     ],
   },
   {
@@ -59,6 +61,7 @@ const routes = [
       'workspace, frontera de edición y auditoría conservan orden al apilarse',
       'skill_id, fingerprint, repo_path y preview largo no rompen el contenedor',
       'estados vacíos/no configurados siguen siendo legibles en viewport estrecho',
+      'la fuente distingue API real conectada, fuente no configurada, sin datos productivos o error degradado',
     ],
   },
   {
@@ -68,6 +71,7 @@ const routes = [
       'selector de Mugiwara y panel de fuentes bajan bien a stacked layout',
       'facts, badges y tabs mantienen lectura clara en móvil',
       'estados stale/error/sin datos no desplazan mal la jerarquía',
+      'fallback visible queda marcado como snapshot saneado/no tiempo real',
     ],
   },
   {
@@ -77,6 +81,7 @@ const routes = [
       'árbol, documento y metadatos colapsan sin forzar tres columnas en ancho medio',
       'breadcrumbs, path y TOC no producen overflow horizontal',
       'la lectura documental sigue siendo dominante frente a la ficha lateral',
+      'fallback documental local queda distinguido de lectura API real',
     ],
   },
   {
@@ -87,6 +92,7 @@ const routes = [
       'la prioridad actual aparece antes del grid cuando hay incidencia o advertencia',
       'badges de estado/severidad no duplican el mismo significado visual',
       'checks sanos mantienen menor peso visual que incidencias o advertencias',
+      'si la API no está configurada, queda claro que los checks son snapshot local saneado y no tiempo real',
       'principios de seguridad y badges semánticos siguen legibles en móvil',
       'ninguna card crítica rompe el grid en tablet',
     ],


### PR DESCRIPTION
## Objetivo
Cierra #45 como Phase 16.2 UI/copy-only: aclarar estados de fuente/fallback en páginas API-backed sin tocar backend, runtime, adapters ni contratos API.

## Decisión de corte
He comprobado el alcance y **no lo he dividido en varias PRs**: aunque cruza varias rutas, el cambio es homogéneo y pequeño — vocabulario UI + componente compartido `SourceStatePills`. Dividir por página aumentaría overhead sin reducir riesgo, porque no hay lógica backend ni superficie operacional nueva.

## Cambios
- Añade `SourceStatePills` con vocabulario consistente:
  - `API real conectada`
  - `Modo fallback local`
  - `Snapshot saneado`
  - `No tiempo real`
  - `Fuente no configurada`
  - `Error/degradado`
- Dashboard, Healthcheck, Memory, Vault y Mugiwaras dejan de presentar fallback visible como simple `Sin datos`.
- Skills distingue BFF conectado, fuente no configurada, sin datos productivos y error degradado.
- `not_configured` queda como detalle técnico secundario (`Estado técnico: ...`), no como explicación principal.
- Actualiza docs, visual baseline, OpenSpec y closeout Engram.

## Scope guard
- Frontend/UI/copy only.
- Sin nuevas API calls.
- Sin backend/API/read-model expansion.
- Sin runtime config changes.
- Sin nuevas fuentes, host reads, logs, comandos, URLs internas ni raw errors.

## Verificación Zoro
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build`
- `npm run verify:visual-baseline`
- `git diff --check`
- HTTP smoke local: `/dashboard`, `/healthcheck`, `/mugiwaras`, `/memory`, `/vault`, `/skills` → 200.
- Browser smoke local en las seis rutas: source-state visible y consola JS sin errores.

## Review solicitada
- Usopp: claridad UX/copy, consistencia cross-surface y jerarquía visual.
- Chopper: seguridad/no leakage del wording de config/error/source-state.
- Franky no solicitado: no hay cambio runtime/operación/config.