### PR TITLE
fix: refine fallback snapshot copy

### DIFF
--- a/.engram/issue-64-fallback-copy-closeout.md
+++ b/.engram/issue-64-fallback-copy-closeout.md
@@ -1,0 +1,20 @@
+# Issue 64 closeout — Fallback snapshot copy refinement
+
+## Resultado
+Cerrado el refinamiento de copy de fallback/snapshot para reducir ambigüedad de telemetría en vivo en páginas API-backed.
+
+## Cambios
+- `StatusBadge` acepta `label` opcional para mantener estado/color semántico mientras el texto visible puede decir `Operativo en último corte` en snapshot.
+- Dashboard: `Lectura operativa` pasa a `Lectura de snapshot` y `lectura activa` a `snapshot disponible` solo en fallback.
+- Healthcheck: `Actualizado`, `Última señal`, `Eventos recientes` y badges verdes se contextualizan como snapshot cuando hay fallback.
+- Vault, Memory y Mugiwaras: fechas y badges verdes se contextualizan como snapshot/corte solo cuando la fuente no está en modo API real.
+
+## Verify
+- `npm --prefix apps/web run typecheck` ✅
+- `npm --prefix apps/web run build` ✅
+- `npm run verify:visual-baseline` ✅ revisado
+- `git diff --check` ✅
+
+## Riesgos / follow-ups
+- No se hizo inspección visual manual con navegador por viewport; el script de baseline se revisó como checklist canónico.
+- No hay cambio backend ni contratos; si Usopp quiere un ajuste de wording fino, queda como follow-up visual menor.

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -67,17 +67,26 @@ async function getInitialDashboardData(): Promise<{ summary: DashboardSummary; a
   }
 }
 
-function CountGridItem({ count }: { count: DashboardCount }) {
+function getSnapshotAwareCountNote(note: string, isSnapshotMode: boolean) {
+  if (!isSnapshotMode) {
+    return note
+  }
+
+  return note === 'lectura activa' ? 'snapshot disponible' : note
+}
+
+function CountGridItem({ count, isSnapshotMode }: { count: DashboardCount; isSnapshotMode: boolean }) {
   return (
-    <SurfaceCard title={count.label} elevated accent="sky" eyebrow="Lectura operativa">
+    <SurfaceCard title={count.label} elevated accent="sky" eyebrow={isSnapshotMode ? 'Lectura de snapshot' : 'Lectura operativa'}>
       <p style={{ margin: '0 0 6px', fontSize: '30px', fontWeight: 700 }}>{count.value}</p>
-      <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>{count.note}</p>
+      <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>{getSnapshotAwareCountNote(count.note, isSnapshotMode)}</p>
     </SurfaceCard>
   )
 }
 
 export default async function DashboardPage() {
   const { summary, apiNotice } = await getInitialDashboardData()
+  const isSnapshotMode = Boolean(apiNotice)
 
   return (
     <>
@@ -109,7 +118,7 @@ export default async function DashboardPage() {
 
       <section className="layout-grid layout-grid--cards-260">
         {summary.counts.map((count) => (
-          <CountGridItem key={count.label} count={count} />
+          <CountGridItem key={count.label} count={count} isSnapshotMode={isSnapshotMode} />
         ))}
       </section>
 
@@ -124,9 +133,12 @@ export default async function DashboardPage() {
         <SurfaceCard title="Frescura" elevated eyebrow="Bitácora" accent="gold">
           <p style={{ marginTop: 0, marginBottom: '8px' }}>{summary.freshness.label}</p>
           <p style={{ marginTop: 0, marginBottom: '8px', color: appTheme.colors.textSecondary }}>
-            Última actualización: {summary.freshness.updated_at}
+            {isSnapshotMode ? 'Corte del snapshot' : 'Última actualización'}: {summary.freshness.updated_at}
           </p>
-          <StatusBadge status={mapDashboardFreshnessToStatus(summary.freshness)} />
+          <StatusBadge
+            status={mapDashboardFreshnessToStatus(summary.freshness)}
+            label={isSnapshotMode && mapDashboardFreshnessToStatus(summary.freshness) === 'operativo' ? 'Operativo en último corte' : undefined}
+          />
         </SurfaceCard>
 
         <SurfaceCard title="Módulos monitoreados" eyebrow="Cubierta" accent="sky">

--- a/apps/web/src/app/healthcheck/page.tsx
+++ b/apps/web/src/app/healthcheck/page.tsx
@@ -152,13 +152,24 @@ function getPriorityCopy(module: HealthcheckModuleCard | null) {
   return null
 }
 
-function HealthcheckStatusBadges({ status, severity }: Pick<HealthcheckModuleCard | HealthcheckSummaryItem, 'status' | 'severity'>) {
+function getSnapshotAwareHealthcheckStatusLabel(status: HealthcheckModuleCard['status'], isSnapshotMode: boolean) {
+  if (!isSnapshotMode) {
+    return getHealthcheckStatusLabel(status)
+  }
+
+  return status === 'pass' ? 'Operativo en último corte' : getHealthcheckStatusLabel(status)
+}
+
+function HealthcheckStatusBadges({ status, severity, isSnapshotMode = false }: Pick<HealthcheckModuleCard | HealthcheckSummaryItem, 'status' | 'severity'> & { isSnapshotMode?: boolean }) {
   const statusBadge = mapHealthcheckStatusToBadgeStatus(status)
   const severityBadge = mapHealthcheckSeverityToBadgeStatus(severity)
 
   return (
     <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
-      <StatusBadge status={statusBadge} />
+      <StatusBadge
+        status={statusBadge}
+        label={isSnapshotMode && statusBadge === 'operativo' ? 'Operativo en último corte' : undefined}
+      />
       {shouldRenderSeparateSeverityBadge(status, severity) ? <StatusBadge status={severityBadge} /> : null}
       <span style={{ color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 700 }}>
         Severidad {getHealthcheckSeverityLabel(severity)}
@@ -186,6 +197,7 @@ function formatTimestamp(value: string | null) {
 
 export default async function HealthcheckPage() {
   const { workspace, apiNotice } = await getInitialHealthcheckData()
+  const isSnapshotMode = Boolean(apiNotice)
   const sortedModules = sortByHealthcheckTriage(workspace.modules)
   const sortedSignals = sortByHealthcheckTriage(workspace.signals)
   const priorityNotice = getPriorityCopy(sortedModules[0] ?? null)
@@ -240,8 +252,15 @@ export default async function HealthcheckPage() {
             <div style={{ display: 'grid', gap: '8px' }}>
               <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Estado general</span>
               <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
-                <StatusBadge status={mapHealthcheckStatusToBadgeStatus(workspace.summary_bar.overall_status)} />
-                <span style={{ color: appTheme.colors.textSecondary }}>{getHealthcheckStatusLabel(workspace.summary_bar.overall_status)}</span>
+                <StatusBadge
+                  status={mapHealthcheckStatusToBadgeStatus(workspace.summary_bar.overall_status)}
+                  label={
+                    isSnapshotMode && mapHealthcheckStatusToBadgeStatus(workspace.summary_bar.overall_status) === 'operativo'
+                      ? 'Operativo en último corte'
+                      : undefined
+                  }
+                />
+                <span style={{ color: appTheme.colors.textSecondary }}>{getSnapshotAwareHealthcheckStatusLabel(workspace.summary_bar.overall_status, isSnapshotMode)}</span>
               </div>
             </div>
 
@@ -261,7 +280,7 @@ export default async function HealthcheckPage() {
             </div>
 
             <div style={{ display: 'grid', gap: '8px' }}>
-              <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Actualizado</span>
+              <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>{isSnapshotMode ? 'Corte del snapshot' : 'Actualizado'}</span>
               <span style={{ color: appTheme.colors.textSecondary }}>{formatTimestamp(workspace.summary_bar.updated_at)}</span>
             </div>
           </div>
@@ -302,12 +321,12 @@ export default async function HealthcheckPage() {
             >
               <SurfaceCard title={module.label} elevated={index < 3} eyebrow={index === 0 ? 'Prioridad actual' : 'Check'} accent={getHealthcheckAccent(module.status, module.severity)}>
                 <div style={{ display: 'grid', gap: '10px' }}>
-                  <HealthcheckStatusBadges status={module.status} severity={module.severity} />
+                  <HealthcheckStatusBadges status={module.status} severity={module.severity} isSnapshotMode={isSnapshotMode} />
                   <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                    Estado: <strong>{getHealthcheckStatusLabel(module.status)}</strong>
+                    Estado: <strong>{getSnapshotAwareHealthcheckStatusLabel(module.status, isSnapshotMode)}</strong>
                   </span>
                   <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>
-                    Última señal: {formatTimestamp(module.updated_at)}
+                    {isSnapshotMode ? 'Última señal del snapshot' : 'Última señal'}: {formatTimestamp(module.updated_at)}
                   </span>
                   <p style={{ margin: 0, color: module.status === 'pass' && module.severity === 'low' ? appTheme.colors.textMuted : appTheme.colors.textSecondary }}>{module.summary}</p>
                 </div>
@@ -318,7 +337,7 @@ export default async function HealthcheckPage() {
       </section>
 
       <section className="section-block layout-grid layout-grid--content-aside">
-        <SurfaceCard title="Eventos recientes" elevated eyebrow="Bitácora" accent="gold">
+        <SurfaceCard title={isSnapshotMode ? 'Eventos del snapshot' : 'Eventos recientes'} elevated eyebrow="Bitácora" accent="gold">
           {workspace.events.length > 0 ? (
             <div style={{ display: 'grid', gap: '10px' }}>
               {workspace.events.map((event) => (
@@ -334,7 +353,14 @@ export default async function HealthcheckPage() {
                 >
                   <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
                     <strong>{event.source}</strong>
-                    <StatusBadge status={mapHealthcheckStatusToBadgeStatus(event.status)} />
+                    <StatusBadge
+                      status={mapHealthcheckStatusToBadgeStatus(event.status)}
+                      label={
+                        isSnapshotMode && mapHealthcheckStatusToBadgeStatus(event.status) === 'operativo'
+                          ? 'Operativo en último corte'
+                          : undefined
+                      }
+                    />
                   </div>
                   <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>{formatTimestamp(event.timestamp)}</span>
                   <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>{event.detail}</p>
@@ -370,7 +396,7 @@ export default async function HealthcheckPage() {
                       <strong>{check.label}</strong>
                       <code style={{ fontSize: '12px', color: appTheme.colors.textMuted }}>{check.check_id}</code>
                     </div>
-                    <HealthcheckStatusBadges status={check.status} severity={check.severity} />
+                    <HealthcheckStatusBadges status={check.status} severity={check.severity} isSnapshotMode={isSnapshotMode} />
                     <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{check.warning_text}</span>
                     <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>
                       {check.source_label} · {check.freshness.label}

--- a/apps/web/src/app/memory/MemoryClient.tsx
+++ b/apps/web/src/app/memory/MemoryClient.tsx
@@ -138,6 +138,7 @@ export function MemoryClient({ apiSummaries, apiDetails, apiState, apiNotice }: 
   const selectedSummary = summaries.find((item) => item.mugiwara_slug === selectedMugiwara)
   const selectedBadges = selectedSummary?.badges ?? []
   const sourceNotice = getMemoryStateNotice(selectedSnapshot, sourceLabelMap[selectedSource], selectedProfile.name)
+  const isSnapshotMode = apiState !== 'ready'
 
   return (
     <>
@@ -177,7 +178,10 @@ export function MemoryClient({ apiSummaries, apiDetails, apiState, apiNotice }: 
                 Memory muestra continuidad por Mugiwara y estado resumido de fuentes. No es una superficie editable ni se mezcla con el canon curado del Vault.
               </p>
               <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                <StatusBadge status={apiState === 'ready' ? 'operativo' : 'revision'} />
+                <StatusBadge
+                  status={apiState === 'ready' ? 'operativo' : 'revision'}
+                  label={isSnapshotMode ? 'Snapshot local visible' : undefined}
+                />
                 <span
                   style={{
                     display: 'inline-flex',
@@ -230,13 +234,16 @@ export function MemoryClient({ apiSummaries, apiDetails, apiState, apiNotice }: 
                           <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>{profile.role}</span>
                         </div>
                       </div>
-                      <StatusBadge status={summary && summary.fact_count >= 5 ? 'operativo' : 'revision'} />
+                      <StatusBadge
+                        status={summary && summary.fact_count >= 5 ? 'operativo' : 'revision'}
+                        label={isSnapshotMode && summary && summary.fact_count >= 5 ? 'Operativo en último corte' : undefined}
+                      />
                     </div>
                     {summary ? (
                       <>
                         <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{summary.summary}</span>
                         <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>
-                          {summary.fact_count} facts · actualizado {formatTimestamp(summary.last_updated)}
+                          {summary.fact_count} facts · {isSnapshotMode ? 'corte del snapshot' : 'actualizado'} {formatTimestamp(summary.last_updated)}
                         </span>
                       </>
                     ) : (
@@ -260,7 +267,10 @@ export function MemoryClient({ apiSummaries, apiDetails, apiState, apiNotice }: 
                     <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>{selectedProfile.role}</span>
                   </div>
                 </div>
-                <StatusBadge status={mapSourceStateToStatus(selectedSnapshot.state)} />
+                <StatusBadge
+                  status={mapSourceStateToStatus(selectedSnapshot.state)}
+                  label={isSnapshotMode && mapSourceStateToStatus(selectedSnapshot.state) === 'operativo' ? 'Operativo en último corte' : undefined}
+                />
               </div>
 
               <div role="tablist" aria-label="Fuente de memoria" style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
@@ -301,10 +311,13 @@ export function MemoryClient({ apiSummaries, apiDetails, apiState, apiNotice }: 
               >
                 <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Estado de fuente</span>
                 <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
-                  <StatusBadge status={mapSourceStateToStatus(selectedSnapshot.state)} />
+                  <StatusBadge
+                    status={mapSourceStateToStatus(selectedSnapshot.state)}
+                    label={isSnapshotMode && mapSourceStateToStatus(selectedSnapshot.state) === 'operativo' ? 'Operativo en último corte' : undefined}
+                  />
                   <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{selectedSnapshot.availability}</span>
                   <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>
-                    Última actualización: {formatTimestamp(selectedSnapshot.updated_at)}
+                    {isSnapshotMode ? 'Corte del snapshot' : 'Última actualización'}: {formatTimestamp(selectedSnapshot.updated_at)}
                   </span>
                 </div>
                 <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>{selectedSnapshot.summary}</p>

--- a/apps/web/src/app/mugiwaras/page.tsx
+++ b/apps/web/src/app/mugiwaras/page.tsx
@@ -94,6 +94,7 @@ function formatLineCount(markdown: string) {
 
 export default async function MugiwarasPage() {
   const viewModel = await getMugiwarasViewModel()
+  const isSnapshotMode = viewModel.state !== 'ready'
 
   return (
     <>
@@ -109,7 +110,10 @@ export default async function MugiwarasPage() {
         <p style={{ marginTop: 0, marginBottom: '10px', color: appTheme.colors.textSecondary }}>
           Esta vista agrega solo resúmenes saneados por agente. No abre controles de edición y solo muestra el AGENTS.md canónico de crew-core cuando llega desde la API allowlisted.
         </p>
-        <StatusBadge status={viewModel.state === 'ready' ? 'operativo' : 'revision'} />
+        <StatusBadge
+          status={viewModel.state === 'ready' ? 'operativo' : 'revision'}
+          label={isSnapshotMode ? 'Snapshot local visible' : undefined}
+        />
       </SurfaceCard>
 
       {viewModel.notice ? (
@@ -208,11 +212,14 @@ export default async function MugiwarasPage() {
                       <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>{profile?.role ?? 'Mugiwara'}</span>
                     </div>
                   </div>
-                  <StatusBadge status={mapMugiwaraStatusToBadgeStatus(mugiwara.status)} />
+                  <StatusBadge
+                    status={mapMugiwaraStatusToBadgeStatus(mugiwara.status)}
+                    label={isSnapshotMode && mapMugiwaraStatusToBadgeStatus(mugiwara.status) === 'operativo' ? 'Operativo en último corte' : undefined}
+                  />
                 </div>
 
                 <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
-                  Estado visible: <strong>{getMugiwaraStatusLabel(mugiwara.status)}</strong>
+                  Estado visible: <strong>{isSnapshotMode && mugiwara.status === 'operativo' ? 'Operativo en último corte' : getMugiwaraStatusLabel(mugiwara.status)}</strong>
                 </p>
 
                 <div>

--- a/apps/web/src/app/vault/VaultClient.tsx
+++ b/apps/web/src/app/vault/VaultClient.tsx
@@ -54,6 +54,7 @@ export function VaultClient({ initialWorkspace, apiState, apiErrorCode }: VaultC
   const workspace = initialWorkspace
   const [selectedDocumentId, setSelectedDocumentId] = useState(workspace.active_document_id)
   const apiNotice = getVaultApiNotice(apiState, apiErrorCode)
+  const isSnapshotMode = Boolean(apiNotice)
 
   const activeDocument = useMemo(
     () => workspace.documents.find((document) => document.id === selectedDocumentId) ?? workspace.documents[0],
@@ -106,7 +107,14 @@ export function VaultClient({ initialWorkspace, apiState, apiErrorCode }: VaultC
                 Vault es una capa editorial y navegable. Resume decisiones duraderas y project summaries; no funciona como memoria operativa por fuente.
               </p>
               <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                <StatusBadge status={getVaultFreshnessStatus(workspace.freshness.state)} />
+                <StatusBadge
+                  status={getVaultFreshnessStatus(workspace.freshness.state)}
+                  label={
+                    isSnapshotMode && getVaultFreshnessStatus(workspace.freshness.state) === 'operativo'
+                      ? 'Operativo en último corte'
+                      : undefined
+                  }
+                />
                 <span
                   style={{
                     display: 'inline-flex',
@@ -125,7 +133,7 @@ export function VaultClient({ initialWorkspace, apiState, apiErrorCode }: VaultC
                 <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{workspace.freshness.label}</span>
               </div>
               <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>
-                Última actualización: {formatTimestamp(workspace.freshness.updated_at)}
+                {isSnapshotMode ? 'Corte del snapshot' : 'Última actualización'}: {formatTimestamp(workspace.freshness.updated_at)}
               </span>
               {freshnessNotice ? (
                 <StatePanel
@@ -173,7 +181,10 @@ export function VaultClient({ initialWorkspace, apiState, apiErrorCode }: VaultC
                     >
                       <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
                         <strong>{entry.label}</strong>
-                        <StatusBadge status={entry.kind === 'directory' ? 'revision' : 'operativo'} />
+                        <StatusBadge
+                          status={entry.kind === 'directory' ? 'revision' : 'operativo'}
+                          label={isSnapshotMode && entry.kind !== 'directory' ? 'Operativo en último corte' : undefined}
+                        />
                       </div>
                       <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>{entry.path_segment}</span>
                       <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{entry.summary}</span>
@@ -279,7 +290,7 @@ export function VaultClient({ initialWorkspace, apiState, apiErrorCode }: VaultC
                 </div>
 
                 <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                  Actualizado: {formatTimestamp(activeDocument.meta.updated_at)}
+                  {isSnapshotMode ? 'Corte del snapshot' : 'Actualizado'}: {formatTimestamp(activeDocument.meta.updated_at)}
                 </span>
                 <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{activeDocument.meta.context}</span>
               </div>

--- a/apps/web/src/shared/ui/status/StatusBadge.tsx
+++ b/apps/web/src/shared/ui/status/StatusBadge.tsx
@@ -2,6 +2,7 @@ import { appTheme, statusColorMap, type AppStatus } from '@/shared/theme/tokens'
 
 type StatusBadgeProps = {
   status: AppStatus
+  label?: string
 }
 
 const statusLabelMap: Record<AppStatus, string> = {
@@ -12,8 +13,9 @@ const statusLabelMap: Record<AppStatus, string> = {
   'sin-datos': 'Sin datos',
 }
 
-export function StatusBadge({ status }: StatusBadgeProps) {
+export function StatusBadge({ status, label }: StatusBadgeProps) {
   const color = statusColorMap[status]
+  const displayLabel = label ?? statusLabelMap[status]
 
   return (
     <span
@@ -28,9 +30,9 @@ export function StatusBadge({ status }: StatusBadgeProps) {
         letterSpacing: '0.01em',
         background: appTheme.colors.bgSurface2,
       }}
-      aria-label={`Estado ${statusLabelMap[status]}`}
+      aria-label={`Estado ${displayLabel}`}
     >
-      {statusLabelMap[status]}
+      {displayLabel}
     </span>
   )
 }

--- a/openspec/issue-64-fallback-copy.md
+++ b/openspec/issue-64-fallback-copy.md
@@ -1,0 +1,38 @@
+# Issue 64 — Fallback snapshot copy refinement
+
+## Objetivo
+Refinar labels secundarios en páginas API-backed cuando caen a fallback/snapshot local para que no parezcan telemetría en vivo en un escaneo rápido.
+
+## Alcance
+- Frontend/UI/copy únicamente.
+- Mantener la lectura natural en modo API real.
+- No tocar backend, contratos, runtime config, adapters ni read-models.
+
+## Decisión de implementación
+- Usar el estado de fuente ya existente (`apiNotice`, `apiState`, `viewModel.state`) como señal de `snapshot/fallback`.
+- En modo snapshot, cambiar labels secundarios a términos explícitos como `Lectura de snapshot`, `Corte del snapshot`, `Eventos del snapshot`, `Última señal del snapshot` y `Operativo en último corte`.
+- En modo API real, conservar lenguaje operativo normal (`Lectura operativa`, `Última actualización`, `Eventos recientes`, `Operativo`).
+- Permitir override de texto en `StatusBadge` mediante prop opcional `label` sin cambiar el estado semántico/color.
+
+## Superficies afectadas
+- `/dashboard`
+- `/healthcheck`
+- `/vault`
+- `/memory`
+- `/mugiwaras`
+- `StatusBadge` compartido
+
+## Definition of Done
+- [x] Los labels secundarios bajo fallback/snapshot no implican tiempo real.
+- [x] El modo API real conserva copy natural.
+- [x] No se exponen detalles host/backend.
+- [x] `npm --prefix apps/web run typecheck` pasa.
+- [x] `npm --prefix apps/web run build` pasa.
+- [x] `npm run verify:visual-baseline` revisado.
+- [x] `git diff --check` pasa.
+
+## Fuera de alcance
+- Cambios backend/API/read-model.
+- Nuevos adapters de fuente.
+- Cambios de runtime config.
+- Rediseño visual o baseline de screenshots.


### PR DESCRIPTION
## Qué cambia
- Refina copy secundaria en fallback/snapshot para que no parezca telemetría live.
- Añade `label` opcional a `StatusBadge` para mantener estado/color semántico pero mostrar `Operativo en último corte` cuando el dato viene de snapshot.
- Ajusta `/dashboard`, `/healthcheck`, `/vault`, `/memory` y `/mugiwaras` con labels snapshot-aware sin tocar backend/API/runtime.
- Añade OpenSpec y closeout Engram de la microfase.

Closes #64.

## Fuera de alcance
- Backend/API/read-models.
- Runtime config.
- Nuevos adapters.
- Rediseño visual o screenshots baseline.

## Verificación
- ✅ `git diff --check`
- ✅ `npm --prefix apps/web run typecheck`
- ✅ `npm --prefix apps/web run build`
- ✅ `npm run verify:visual-baseline` revisado

## Riesgo
Bajo. Cambio frontend/copy y prop opcional retrocompatible en `StatusBadge`. Riesgo principal: wording visual fino; pido revisión de Usopp.