### PR TITLE
fix: tune StatePanel ARIA semantics

### DIFF
--- a/.engram/phase-16-3-statepanel-aria-closeout.md
+++ b/.engram/phase-16-3-statepanel-aria-closeout.md
@@ -1,0 +1,26 @@
+# Phase 16.3 closeout — StatePanel ARIA semantics (#48)
+
+## Resultado
+Issue #48 se cierra como microfase única de accesibilidad frontend. `StatePanel` deja de emitir `role="status"` por defecto y ahora expone `ariaRole`/`ariaLabel` para que cada uso declare semántica accesible solo cuando aporte valor.
+
+## Decisión de división
+No se divide más: el cambio es pequeño, homogéneo y localizado en componente compartido + un override de Healthcheck + guardrail/docs. Se mantiene separado de #47/#46 para no mezclar semántica ARIA con polish visual o UX de Skills.
+
+## Cambios principales
+- `apps/web/src/shared/ui/state/StatePanel.tsx`: default quieto; roles explícitos `status`, `alert`, `region`, `group`; `aria-live` polite/assertive solo para `status`/`alert`.
+- `apps/web/src/app/healthcheck/page.tsx`: el panel de prioridad usa `alert` cuando hay incidencia y `region` cuando es aviso no urgente.
+- `scripts/check-statepanel-aria.mjs` + `npm run verify:statepanel-aria`: guardrail para evitar volver a hardcodear `role="status"`.
+- `docs/frontend-ui-spec.md` y `docs/frontend-implementation-handoff.md`: contrato vivo de semántica accesible de estados.
+
+## Verify
+- `npm run verify:statepanel-aria`
+- `npm --prefix apps/web run typecheck`
+- `npm --prefix apps/web run build`
+- `npm run verify:visual-baseline`
+- Browser smoke `/healthcheck`: HTTP 200, consola limpia, `role="status"` count 0 y prioridad actual con `role="alert"` + `aria-live="assertive"`.
+- `git diff --check`
+
+## Riesgos / follow-ups
+- Riesgo bajo: cambio de atributos ARIA sin cambio visual ni runtime.
+- Usopp debe revisar la intención accesible y confirmar que no conviene anunciar más usos como `status`/`alert`.
+- #47 Dashboard polish y #46 Skills not-configured UX siguen como follow-ups separados.

--- a/apps/web/src/app/healthcheck/page.tsx
+++ b/apps/web/src/app/healthcheck/page.tsx
@@ -292,6 +292,8 @@ export default async function HealthcheckPage() {
               description={priorityNotice.description}
               detail={priorityNotice.detail}
               eyebrow="Acción requerida"
+              ariaRole={priorityNotice.status === 'incidencia' ? 'alert' : 'region'}
+              ariaLabel="Prioridad actual de Healthcheck"
             />
           ) : healthSummaryNotice ? (
             <StatePanel

--- a/apps/web/src/shared/ui/state/StatePanel.tsx
+++ b/apps/web/src/shared/ui/state/StatePanel.tsx
@@ -3,21 +3,33 @@ import type { ReactNode } from 'react'
 import { StatusBadge } from '@/shared/ui/status/StatusBadge'
 import { appTheme, statusColorMap, type AppStatus } from '@/shared/theme/tokens'
 
+type StatePanelAriaRole = 'status' | 'alert' | 'region' | 'group'
+
 type StatePanelProps = {
   status: AppStatus
   title: string
   description: string
   detail?: string | null
   eyebrow?: string
+  ariaRole?: StatePanelAriaRole
+  ariaLabel?: string
   children?: ReactNode
 }
 
-export function StatePanel({ status, title, description, detail, eyebrow, children }: StatePanelProps) {
+const statePanelAriaLiveByRole: Partial<Record<StatePanelAriaRole, 'polite' | 'assertive'>> = {
+  status: 'polite',
+  alert: 'assertive',
+}
+
+export function StatePanel({ status, title, description, detail, eyebrow, ariaRole, ariaLabel, children }: StatePanelProps) {
   const accentColor = statusColorMap[status]
+  const ariaLive = ariaRole ? statePanelAriaLiveByRole[ariaRole] : undefined
 
   return (
     <div
-      role="status"
+      role={ariaRole}
+      aria-label={ariaLabel}
+      aria-live={ariaLive}
       style={{
         display: 'grid',
         gap: '10px',

--- a/docs/frontend-implementation-handoff.md
+++ b/docs/frontend-implementation-handoff.md
@@ -262,6 +262,17 @@ Card base con variantes:
 Props:
 - `status: 'operativo' | 'revision' | 'incidencia' | 'stale' | 'sin-datos'`
 
+### `StatePanel`
+Shared panel for empty, fallback, degraded, informational and priority states.
+
+Accessibility contract:
+- Default semantics are intentionally quiet: no ARIA live role is emitted unless the caller opts in.
+- Static empty/fallback/explanatory panels should keep the default quiet semantics.
+- Use `ariaRole="status"` only for genuinely dynamic status updates that benefit from polite announcement.
+- Use `ariaRole="alert"` only for urgent incidents or action-required panels that should be announced assertively.
+- Use `ariaRole="region"` or `ariaRole="group"` with `ariaLabel` for named landmark/grouping semantics without live-region noise.
+- `StatePanel` visual status and accessible announcement semantics are separate decisions.
+
 ### `MetricCard`
 Props:
 - `label`

--- a/docs/frontend-ui-spec.md
+++ b/docs/frontend-ui-spec.md
@@ -194,6 +194,13 @@ Las calaveras de cada Mugiwara sustituyen al pixel art como ancla visual princip
 - grid clara y espaciado generoso
 - detalles temáticos mínimos: mapa, bitácora, cubierta, navegación
 
+## 3.7.1 Semántica accesible de estados
+- Los paneles de estado compartidos deben separar tono visual de semántica ARIA.
+- Los estados vacíos, fallback, snapshot o informativos son contenido estático por defecto y no deben anunciarse todos como live regions.
+- Las actualizaciones dinámicas pueden usar semántica `status` con anuncio polite cuando haya beneficio claro.
+- Las incidencias urgentes o bloques de acción requerida pueden usar `alert` de forma explícita y acotada.
+- Si un panel necesita nombre accesible sin anunciarse como live region, usar `region`/`group` con etiqueta explícita.
+
 ## 3.8 Ideas rescatadas de exploración visual de landing
 Se revisó una propuesta de landing temática para `Mugiwara Control Panel`. **No debe tomarse como arquitectura del shell**, pero sí deja hallazgos visuales y narrativos útiles para estas 6 páginas.
 

--- a/openspec/phase-16-3-statepanel-aria-semantics.md
+++ b/openspec/phase-16-3-statepanel-aria-semantics.md
@@ -1,0 +1,50 @@
+# Phase 16.3 — StatePanel ARIA semantics (#48)
+
+## Objetivo
+Cerrar #48 como una microfase de accesibilidad frontend: `StatePanel` deja de anunciar todos los estados como `role="status"` y permite semántica ARIA explícita solo cuando el caso lo justifica.
+
+## Decisión de corte
+Se comprobó el alcance real y **no conviene dividirlo en fases más pequeñas**.
+
+Razones:
+- La superficie principal es un único componente compartido: `apps/web/src/shared/ui/state/StatePanel.tsx`.
+- Los usos existentes son homogéneos: paneles vacíos, fallback, snapshot, explicativos y avisos de prioridad.
+- No hay backend, runtime, API, dependencias ni cambios visuales.
+- Dividirlo generaría dos PRs artificiales: una para el prop y otra para usos/docs/guardrail, con más coordinación que valor.
+
+Sí se mantiene como microfase independiente de #47/#46 para no mezclar accesibilidad semántica con polish visual o UX específica de Skills.
+
+## Alcance
+- Auditar usos de `StatePanel` en Dashboard, Healthcheck, Mugiwaras, Skills, Memory y Vault.
+- Cambiar el default del componente a semántica quieta: sin role/live region por defecto.
+- Añadir override tipado `ariaRole` para `status`, `alert`, `region` o `group`.
+- Añadir `ariaLabel` para regiones/grupos nombrados cuando haga falta.
+- Hacer explícita la semántica del bloque de prioridad de Healthcheck: `alert` si es incidencia, `region` si es aviso no urgente.
+- Añadir guardrail estático `verify:statepanel-aria`.
+- Actualizar docs frontend vivas.
+
+## Fuera de alcance
+- Rediseño visual.
+- Cambios de color/contraste.
+- Keyboard/focus behavior.
+- Backend/API/read-models.
+- Copy amplio o cambios de producto en #47/#46.
+
+## Diseño
+- `StatePanel` separa tono visual (`status`) de semántica accesible (`ariaRole`).
+- Default quieto evita ruido para screen readers en estados estáticos.
+- `role="status"` queda reservado a actualizaciones dinámicas polite.
+- `role="alert"` queda reservado a incidencias/action-required que deban anunciarse assertivamente.
+- `region`/`group` quedan disponibles para agrupación nombrada sin live-region noise.
+
+## Definition of Done
+- [x] `StatePanel` ya no hardcodea `role="status"`.
+- [x] Static empty/fallback panels quedan quietos por defecto.
+- [x] Urgent/action-required Healthcheck panel opta explícitamente a `alert` cuando hay incidencia.
+- [x] El cambio no altera layout/copy visual salvo atributos ARIA.
+- [x] Docs de frontend reflejan el contrato.
+- [x] Verify web + visual baseline ejecutados.
+
+## Review esperado
+- Usopp: accesibilidad básica, intención UX y ausencia de regresión visual.
+- Chopper/Franky: no requeridos; no hay seguridad, runtime, API, dependencias ni operación.

--- a/openspec/phase-16-3-verify-checklist.md
+++ b/openspec/phase-16-3-verify-checklist.md
@@ -1,0 +1,26 @@
+# Phase 16.3 verify checklist — StatePanel ARIA semantics (#48)
+
+## Scope guard
+- [x] Frontend accessibility semantics only.
+- [x] No backend/API/read-model expansion.
+- [x] No runtime config changes.
+- [x] No dependency changes.
+- [x] No broad visual redesign.
+
+## Acceptance
+- [x] Static empty/fallback panels are not all exposed as `role="status"` by default.
+- [x] Loading/dynamic updates can still opt into `ariaRole="status"`.
+- [x] Urgent/action-required panels can opt into `ariaRole="alert"`.
+- [x] Named non-live panels can opt into `region`/`group` with `ariaLabel`.
+- [x] Healthcheck priority notice has explicit alert/region semantics.
+
+## Verify ejecutado
+- [x] `npm run verify:statepanel-aria`
+- [x] `npm --prefix apps/web run typecheck`
+- [x] `npm --prefix apps/web run build`
+- [x] `npm run verify:visual-baseline`
+- [x] Browser smoke `/healthcheck`: HTTP 200, console limpia, `role="status"` count 0, priority notice `role="alert"` + `aria-live="assertive"`.
+- [x] `git diff --check`
+
+## Review esperado
+- Usopp: UI/accessibility semantics and visual no-regression.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "verify:project-health-runner": "node scripts/check-project-health-runner.mjs",
     "verify:gateway-status-runner": "node scripts/check-gateway-status-runner.mjs",
     "verify:cronjobs-status-runner": "node scripts/check-cronjobs-status-runner.mjs",
+    "verify:statepanel-aria": "node scripts/check-statepanel-aria.mjs",
     "write:project-health-status": "python3 scripts/write-project-health-status.py",
     "write:gateway-status": "python3 scripts/write-gateway-status.py",
     "write:cronjobs-status": "python3 scripts/write-cronjobs-status.py",

--- a/scripts/check-statepanel-aria.mjs
+++ b/scripts/check-statepanel-aria.mjs
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+const statePanelPath = join(root, 'apps/web/src/shared/ui/state/StatePanel.tsx')
+const healthcheckPath = join(root, 'apps/web/src/app/healthcheck/page.tsx')
+
+const statePanel = readFileSync(statePanelPath, 'utf8')
+const healthcheck = readFileSync(healthcheckPath, 'utf8')
+
+const failures = []
+
+if (statePanel.includes('role="status"')) {
+  failures.push('StatePanel must not hardcode role="status" for every panel.')
+}
+
+if (!statePanel.includes('ariaRole?: StatePanelAriaRole')) {
+  failures.push('StatePanel must expose a typed ariaRole override for intentional live/alert/region semantics.')
+}
+
+if (!statePanel.includes("aria-live")) {
+  failures.push('StatePanel must map live roles to explicit aria-live behavior.')
+}
+
+if (!healthcheck.includes('ariaRole={priorityNotice.status === \'incidencia\' ? \'alert\' : \'region\'}')) {
+  failures.push('Healthcheck priority notice must opt into alert/region semantics explicitly.')
+}
+
+if (failures.length > 0) {
+  console.error('StatePanel ARIA guardrail failed:')
+  for (const failure of failures) {
+    console.error(`- ${failure}`)
+  }
+  process.exit(1)
+}
+
+console.log('StatePanel ARIA guardrail passed.')


### PR DESCRIPTION
## Objetivo
Cerrar #48 ajustando la semántica ARIA de `StatePanel` sin rediseño visual.

## Qué cambia
- `StatePanel` deja de hardcodear `role="status"` para todos los paneles.
- Añade `ariaRole?: 'status' | 'alert' | 'region' | 'group'` y `ariaLabel?: string`.
- Mapea `status` a `aria-live="polite"` y `alert` a `aria-live="assertive"` solo cuando el caller opta explícitamente.
- Healthcheck priority notice usa `alert` cuando hay incidencia y `region` cuando es aviso no urgente.
- Añade guardrail `npm run verify:statepanel-aria`.
- Actualiza OpenSpec, closeout Engram y docs frontend.

## Decisión de corte
No se divide en fases más pequeñas: la superficie real es un componente compartido + un uso explícito + guardrail/docs. Dividirlo generaría PRs artificiales sin reducir riesgo. Se mantiene separado de #47 y #46.

## Verify ejecutado
- `npm run verify:statepanel-aria`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build`
- `npm run verify:visual-baseline`
- Browser smoke `/healthcheck`: HTTP 200, consola limpia, `role="status"` count 0, priority notice `role="alert"` + `aria-live="assertive"`
- `git diff --check`

## Riesgo
Bajo. Cambio de atributos ARIA y guardrail; sin backend, API, runtime, dependencias ni cambio visual intencionado.

Closes #48
