### PR TITLE
fix: polish dashboard timestamps and metrics

### DIFF
--- a/.engram/phase-16-4-dashboard-polish-closeout.md
+++ b/.engram/phase-16-4-dashboard-polish-closeout.md
@@ -1,0 +1,28 @@
+# Phase 16.4 closeout — Dashboard polish
+
+## Scope
+Issue #47 is treated as a single microphase, not split further.
+
+## Why no further split
+The work is a compact frontend-only polish change on one Dashboard surface:
+- format one freshness timestamp consistently with existing Spanish locale helpers;
+- adjust only the primary metrics grid behavior.
+
+There is no backend, API contract, dependency, security or runtime change. Splitting this would add coordination overhead without reducing meaningful risk.
+
+## Changed files
+- `apps/web/src/app/dashboard/page.tsx` — local timestamp formatter and formatted freshness copy.
+- `apps/web/src/app/globals.css` — Dashboard-specific metrics grid with 4/2/1 column breakpoints.
+- `openspec/phase-16-4-dashboard-polish.md` — phase contract.
+- `openspec/phase-16-4-verify-checklist.md` — verification checklist.
+
+## Verify status
+- `npm --prefix apps/web run typecheck` passed.
+- `npm --prefix apps/web run build` passed.
+- `npm run verify:visual-baseline` passed and includes `/dashboard`.
+- `git diff --check` passed.
+- Browser smoke on `http://127.0.0.1:3100/dashboard` confirmed 4 metric columns at desktop viewport, no horizontal overflow, formatted timestamp (`23/4/26, 16:45`) and no console errors.
+- HTML smoke confirmed no raw ISO timestamp in the Dashboard response.
+
+## Continuity
+If review finds visual imbalance at an exact viewport, prefer tuning only the `layout-grid--dashboard-metrics` breakpoints/class. Do not expand into header metrics (#36), new Dashboard modules or backend Healthcheck work.

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -67,6 +67,19 @@ async function getInitialDashboardData(): Promise<{ summary: DashboardSummary; a
   }
 }
 
+function formatTimestamp(value: string) {
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return 'Fecha no disponible'
+  }
+
+  return new Intl.DateTimeFormat('es-ES', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(date)
+}
+
 function getSnapshotAwareCountNote(note: string, isSnapshotMode: boolean) {
   if (!isSnapshotMode) {
     return note
@@ -116,7 +129,7 @@ export default async function DashboardPage() {
         </StatePanel>
       ) : null}
 
-      <section className="layout-grid layout-grid--cards-260">
+      <section className="layout-grid layout-grid--dashboard-metrics">
         {summary.counts.map((count) => (
           <CountGridItem key={count.label} count={count} isSnapshotMode={isSnapshotMode} />
         ))}
@@ -133,7 +146,7 @@ export default async function DashboardPage() {
         <SurfaceCard title="Frescura" elevated eyebrow="Bitácora" accent="gold">
           <p style={{ marginTop: 0, marginBottom: '8px' }}>{summary.freshness.label}</p>
           <p style={{ marginTop: 0, marginBottom: '8px', color: appTheme.colors.textSecondary }}>
-            {isSnapshotMode ? 'Corte del snapshot' : 'Última actualización'}: {summary.freshness.updated_at}
+            {isSnapshotMode ? 'Corte del snapshot' : 'Última actualización'}: {formatTimestamp(summary.freshness.updated_at)}
           </p>
           <StatusBadge
             status={mapDashboardFreshnessToStatus(summary.freshness)}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -62,6 +62,10 @@ button {
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
 }
 
+.layout-grid--dashboard-metrics {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
 .layout-grid--sidebar-detail {
   grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
 }
@@ -193,6 +197,12 @@ button {
   display: none;
 }
 
+@media (max-width: 1180px) {
+  .layout-grid--dashboard-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 959px) {
   .app-shell {
     grid-template-columns: minmax(0, 1fr);
@@ -258,6 +268,10 @@ button {
 }
 
 @media (max-width: 640px) {
+  .layout-grid--dashboard-metrics {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .topbar {
     padding: 12px 16px !important;
     align-items: flex-start !important;

--- a/openspec/phase-16-4-dashboard-polish.md
+++ b/openspec/phase-16-4-dashboard-polish.md
@@ -1,0 +1,56 @@
+# Phase 16.4 — Dashboard timestamp and metric grid polish
+
+## Issue
+GitHub #47 — Polish Dashboard timestamps and metric grid balance.
+
+## Decision on split
+No further split is required.
+
+Reasoning:
+- The issue is frontend/UI polish only.
+- It touches a single route (`/dashboard`) plus one shared CSS layout rule file.
+- There is no backend, API contract, dependency, security, runtime config or data model change.
+- The two requested changes are tightly coupled to the same Dashboard surface and can be verified together with web typecheck/build and visual baseline.
+
+This remains a single bounded microphase: Phase 16.4.
+
+## Goal
+Make Dashboard feel consistent with the rest of the product by:
+1. rendering freshness timestamps through Spanish locale formatting instead of raw ISO text;
+2. making the four primary metric cards render as an intentional 4-up / 2x2 / 1-column layout instead of an accidental orphan card.
+
+## Scope
+Included:
+- `apps/web/src/app/dashboard/page.tsx`
+- `apps/web/src/app/globals.css`
+- OpenSpec and Engram closeout for continuity.
+
+Out of scope:
+- new Dashboard modules;
+- issue #36 header metrics;
+- backend/API/read-model changes;
+- Healthcheck live-source work;
+- broader responsive redesign.
+
+## Implementation notes
+- Add a local Dashboard `formatTimestamp()` helper matching existing page patterns with `Intl.DateTimeFormat('es-ES', { dateStyle: 'short', timeStyle: 'short' })`.
+- Use `Fecha no disponible` if the timestamp cannot be parsed.
+- Replace the generic `layout-grid--cards-260` for the primary metrics with a Dashboard-specific grid class.
+- The metrics grid is:
+  - 4 columns when desktop width allows;
+  - 2 columns under 1180px;
+  - 1 column under 640px.
+
+## Definition of Done
+- Dashboard no longer shows raw ISO freshness timestamps as primary UI copy.
+- Formatting is consistent with existing `healthcheck`, `memory` and `vault` patterns.
+- Four primary metrics avoid the 3+1 orphan layout on desktop/tablet.
+- No horizontal overflow is introduced by the metric grid.
+- `npm --prefix apps/web run typecheck` passes.
+- `npm --prefix apps/web run build` passes.
+- `npm run verify:visual-baseline` includes `/dashboard` and passes.
+- Usopp review is requested because this is UI/visual polish.
+
+## Risks
+- The formatted date is locale-dependent. This is intended and aligned with existing Spanish UI.
+- The 4-up grid may make cards narrower on some mid-desktop widths; the 2-column breakpoint reduces that risk.

--- a/openspec/phase-16-4-verify-checklist.md
+++ b/openspec/phase-16-4-verify-checklist.md
@@ -1,0 +1,26 @@
+# Phase 16.4 verify checklist — Dashboard polish
+
+## Scope gate
+- [x] Issue #47 inspected from GitHub.
+- [x] Scope kept frontend/UI-only.
+- [x] Decided not to split further: one route + one CSS layout rule, no backend/runtime/security/dependency change.
+
+## Code checks
+- [x] Dashboard freshness timestamp uses Spanish locale formatting instead of raw ISO primary copy.
+- [x] Invalid timestamps degrade to `Fecha no disponible`.
+- [x] Primary metrics use a Dashboard-specific grid class.
+- [x] Grid is 4-up desktop, 2x2 tablet/mid widths and 1-column mobile.
+
+## Verify commands
+- [x] `npm --prefix apps/web run typecheck`
+- [x] `npm --prefix apps/web run build`
+- [x] `npm run verify:visual-baseline`
+- [x] `git diff --check`
+- [x] Browser smoke `/dashboard`: 4 metric columns at desktop viewport, no horizontal overflow, no console errors, formatted timestamp visible.
+- [x] HTML smoke confirms no raw ISO timestamp in `/dashboard` response.
+
+## Review / closeout
+- [ ] Open PR linked to issue #47.
+- [ ] Request Usopp review for visual confirmation.
+- [ ] Update vault Project Summary after merge.
+- [ ] Save Engram observation after merge.


### PR DESCRIPTION
## Summary
- Closes #47.
- Formats Dashboard freshness timestamps with `Intl.DateTimeFormat('es-ES')` instead of exposing raw ISO as primary UI copy.
- Replaces the generic metric-card grid with a Dashboard-specific 4 / 2 / 1 column layout to avoid the 3+1 orphan card pattern.
- Adds Phase 16.4 OpenSpec, verify checklist and Engram closeout.

## Decision on phase split
I kept this as a single microphase, not multiple subphases:
- one visible Dashboard surface;
- one CSS layout class;
- no backend/API/runtime/security/dependency change;
- verify is compact and focused.

## Verification
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build`
- `npm run verify:visual-baseline`
- `git diff --check`
- Browser smoke on `http://127.0.0.1:3100/dashboard`: 4 metric columns at desktop viewport, no horizontal overflow, no console errors, formatted timestamp visible (`23/4/26, 16:45`).
- HTML smoke: no raw ISO timestamp in the Dashboard response.

## Reviewer request
- Usopp: please review UI/UX polish, visual balance, responsive intent and timestamp clarity.

## Risk
Low. Frontend/UI-only; no data contract or runtime behavior change.