### PR TITLE
fix: clarify Skills not-configured UX

### DIFF
--- a/.engram/phase-16-5-skills-not-configured-ux-closeout.md
+++ b/.engram/phase-16-5-skills-not-configured-ux-closeout.md
@@ -1,0 +1,27 @@
+# Phase 16.5 closeout — Skills not-configured UX (#46)
+
+## Contexto
+Issue #46 venía de revisión UX de Usopp: `/skills` en estado `not_configured` parecía un editor productivo vacío y repetía el mismo problema raíz en varias zonas.
+
+## Decisión de fase
+Se ejecutó como microfase única, no se dividió más. La frontera era homogénea y UI-only: una ruta Skills, copy/jerarquía de estados y docs. No toca backend, BFF, runtime config, seguridad efectiva, dependencias ni escritura nueva.
+
+## Cambios cerrados
+- Se añadió un panel superior dominante `Acción requerida` para `not_configured`/error raíz.
+- El workspace pasa a `Workspace bloqueado` y deja de pedir selección cuando no hay catálogo real.
+- Catálogo, editor y preview/auditoría mantienen estructura secundaria con copy bloqueado sin repetir todo el diagnóstico raíz.
+- Se mantienen frontera BFF, edición allowlisted y auditoría como contexto visible.
+- Se actualizaron `docs/frontend-states.md` y `docs/frontend-ui-spec.md`.
+
+## Verify
+- `npm --prefix apps/web run typecheck` — OK.
+- `npm --prefix apps/web run build` — OK.
+- `npm run verify:visual-baseline` — OK, checklist incluye `/skills`.
+- `git diff --check` — OK.
+- Browser smoke `/skills` en `not_configured` — panel raíz dominante, workspace bloqueado, sin overflow evidente; consola sin errores JS, con 503 esperados de BFF no configurado.
+
+## Continuidad
+Reviewer esperado: Usopp. Chopper no es necesario en esta microfase porque no cambió plumbing de errores, runtime config, BFF ni superficie de seguridad.
+
+## Pendiente externo
+Tras merge, cerrar GitHub #46 y actualizar el Project Summary del vault retirando #46 de follow-ups.

--- a/.engram/phase-16-5-skills-not-configured-ux-closeout.md
+++ b/.engram/phase-16-5-skills-not-configured-ux-closeout.md
@@ -19,6 +19,7 @@ Se ejecutó como microfase única, no se dividió más. La frontera era homogén
 - `npm run verify:visual-baseline` — OK, checklist incluye `/skills`.
 - `git diff --check` — OK.
 - Browser smoke `/skills` en `not_configured` — panel raíz dominante, workspace bloqueado, sin overflow evidente; consola sin errores JS, con 503 esperados de BFF no configurado.
+- Ronda Usopp 1 pidió cambios: reducir peso repetido en `Estado del origen` y corregir overflow interno en desktop medio. Se resolvió compactando esa tarjeta como contexto BFF secundario y verificando DOM sin `article` con `scrollWidth > clientWidth`.
 
 ## Continuidad
 Reviewer esperado: Usopp. Chopper no es necesario en esta microfase porque no cambió plumbing de errores, runtime config, BFF ni superficie de seguridad.

--- a/apps/web/src/app/skills/page.tsx
+++ b/apps/web/src/app/skills/page.tsx
@@ -77,16 +77,16 @@ function getSkillsViewNotice(state: SkillsViewState, connectionLabel: string, er
     case 'not_configured':
       return {
         status: 'revision' as const,
-        title: 'Skills con fuente no configurada',
-        description: 'El BFF same-origin está disponible, pero falta la configuración server-only hacia el backend. No se muestran datos productivos ni URL interna al navegador.',
-        detail: 'Estado técnico: not_configured',
+        title: 'Skills no está conectado al backend',
+        description: 'No se puede cargar el catálogo ni habilitar edición porque falta configurar MUGIWARA_CONTROL_PANEL_API_URL en el runtime server. La página conserva el shell y el perímetro seguro, pero no hay skills reales disponibles en este estado.',
+        detail: 'Bloqueado: catálogo, detalle, preview y guardado. Seguro: BFF same-origin, sin URL interna en el navegador.',
       }
     case 'error':
       return {
         status: 'incidencia' as const,
-        title: 'Skills con fuente degradada',
-        description: 'La superficie mantiene el shell, pero la conectividad o la respuesta saneada del BFF impiden mostrar catálogo y detalle con garantías. No se exponen URLs internas ni salidas crudas.',
-        detail: 'Estado técnico: error',
+        title: 'Skills no puede cargar la fuente real',
+        description: 'La página mantiene el shell y el perímetro seguro, pero la fuente real no permite cargar catálogo, detalle ni edición con garantías.',
+        detail: errorMessage ?? 'Bloqueado: catálogo, detalle, preview y guardado. Seguro: errores saneados sin URL interna ni salidas crudas.',
       }
     case 'empty':
       return {
@@ -243,6 +243,7 @@ export default function SkillsPage() {
   }, [audit, selectedSkill])
 
   const sourceNotice = getSkillsViewNotice(viewState, apiConnectionLabel, errorMessage)
+  const isRootUnavailable = viewState === 'not_configured' || viewState === 'error'
   const hasDraftChanges = selectedSkill ? draftContent !== selectedSkill.content : false
   const normalizedActor = actorInput.trim()
   const canSave = Boolean(selectedSkill?.editable && hasDraftChanges && normalizedActor && saveState !== 'saving')
@@ -391,12 +392,41 @@ export default function SkillsPage() {
         detailPills={["Edición allowlisted", "Diff explícito", "Auditoría visible"]}
       />
 
-      <SurfaceCard title="Workspace de edición" elevated eyebrow="Dojo" accent="success">
+      {isRootUnavailable && sourceNotice ? (
+        <SurfaceCard title="Acción requerida" elevated eyebrow="Fuente raíz" accent={viewState === 'error' ? 'danger' : 'gold'}>
+          <StatePanel
+            status={sourceNotice.status}
+            title={sourceNotice.title}
+            description={sourceNotice.description}
+            detail={sourceNotice.detail}
+            eyebrow="Estado principal"
+            ariaRole={viewState === 'error' ? 'alert' : 'status'}
+          >
+            <div style={{ display: 'grid', gap: '10px' }}>
+              <SourceStatePills items={[{ label: viewState === 'not_configured' ? 'Configurar backend server-only' : 'Revisar fuente Skills', tone: viewState === 'not_configured' ? 'not-configured' : 'degraded' }]} />
+              <ul style={{ margin: 0, paddingLeft: '18px', color: appTheme.colors.textSecondary, display: 'grid', gap: '6px' }}>
+                <li>Falta una fuente real: no se ofrece selección de skill ni edición productiva.</li>
+                <li>La frontera BFF sigue same-origin y no expone la URL interna del backend.</li>
+                <li>Siguiente paso operativo: configurar el runtime server y recargar la página.</li>
+              </ul>
+            </div>
+          </StatePanel>
+        </SurfaceCard>
+      ) : null}
+
+      <SurfaceCard
+        title={isRootUnavailable ? 'Workspace bloqueado' : 'Workspace de edición'}
+        elevated
+        eyebrow="Dojo"
+        accent={isRootUnavailable ? 'sky' : 'success'}
+      >
         <div style={{ display: 'grid', gap: '14px' }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap', alignItems: 'start' }}>
             <div style={{ display: 'grid', gap: '8px', maxWidth: '720px' }}>
               <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
-                Esta vista no es un catálogo pasivo: aquí existe edición controlada sobre skills allowlisted, con preview de diff, actor visible y guardado auditado.
+                {isRootUnavailable
+                  ? 'La edición controlada queda bloqueada hasta que el catálogo real de skills esté disponible desde el backend configurado.'
+                  : 'Esta vista no es un catálogo pasivo: aquí existe edición controlada sobre skills allowlisted, con preview de diff, actor visible y guardado auditado.'}
               </p>
               <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
                 <StatusBadge status={workspaceStatus} />
@@ -411,7 +441,7 @@ export default function SkillsPage() {
                     fontWeight: 700,
                   }}
                 >
-                  {selectedSkill?.editable ? 'Modo edición allowlisted' : selectedSkill ? 'Modo referencia' : 'Selecciona una skill'}
+                  {isRootUnavailable ? 'Fuente real no disponible' : selectedSkill?.editable ? 'Modo edición allowlisted' : selectedSkill ? 'Modo referencia' : 'Selecciona una skill'}
                 </span>
                 <span
                   style={{
@@ -424,7 +454,7 @@ export default function SkillsPage() {
                     fontWeight: 700,
                   }}
                 >
-                  {editableCount} editable(s) · {readOnlyCount} referencia(s)
+                  {isRootUnavailable ? 'catálogo bloqueado' : `${editableCount} editable(s) · ${readOnlyCount} referencia(s)`}
                 </span>
               </div>
             </div>
@@ -433,11 +463,13 @@ export default function SkillsPage() {
               <span style={{ color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 700 }}>Skill activa</span>
               <strong className="text-break" style={{ fontSize: '18px' }}>{selectedSkill?.display_name ?? 'Ninguna seleccionada'}</strong>
               <span className="text-break" style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                {selectedSkill?.editable
-                  ? 'Lista para edición controlada cuando haya cambios y actor visible.'
-                  : selectedSkill
-                    ? 'Se muestra como referencia documental: sin escritura productiva.'
-                    : 'Selecciona una entrada del catálogo para abrir el workspace.'}
+                {isRootUnavailable
+                  ? 'No hay selección posible hasta conectar la fuente real de skills.'
+                  : selectedSkill?.editable
+                    ? 'Lista para edición controlada cuando haya cambios y actor visible.'
+                    : selectedSkill
+                      ? 'Se muestra como referencia documental: sin escritura productiva.'
+                      : 'Selecciona una entrada del catálogo para abrir el workspace.'}
               </span>
             </div>
           </div>
@@ -615,9 +647,13 @@ export default function SkillsPage() {
             {sourceNotice ? (
               <StatePanel
                 status={sourceNotice.status}
-                title={sourceNotice.title}
-                description={sourceNotice.description}
-                detail={sourceNotice.detail}
+                title={isRootUnavailable ? 'Catálogo bloqueado por fuente raíz' : sourceNotice.title}
+                description={
+                  isRootUnavailable
+                    ? 'No hay catálogo real que seleccionar en este estado. La causa se explica arriba; aquí solo se mantiene el hueco de navegación sin duplicar el diagnóstico.'
+                    : sourceNotice.description
+                }
+                detail={isRootUnavailable ? null : sourceNotice.detail}
                 eyebrow="Catálogo"
               />
             ) : null}
@@ -681,10 +717,10 @@ export default function SkillsPage() {
 
         <div style={{ display: 'grid', gap: '14px' }}>
           <SurfaceCard
-            title={selectedSkill?.editable ? 'Editor allowlisted' : selectedSkill ? 'Detalle de referencia' : 'Editor allowlisted'}
+            title={isRootUnavailable ? 'Editor bloqueado' : selectedSkill?.editable ? 'Editor allowlisted' : selectedSkill ? 'Detalle de referencia' : 'Editor allowlisted'}
             elevated
-            eyebrow={selectedSkill?.editable ? 'Forja' : selectedSkill ? 'Referencia' : 'Forja'}
-            accent={selectedSkill?.editable ? 'success' : selectedSkill ? 'sky' : 'success'}
+            eyebrow={isRootUnavailable ? 'En espera' : selectedSkill?.editable ? 'Forja' : selectedSkill ? 'Referencia' : 'Forja'}
+            accent={isRootUnavailable ? 'sky' : selectedSkill?.editable ? 'success' : selectedSkill ? 'sky' : 'success'}
           >
             {selectedSkill ? (
               <div style={{ display: 'grid', gap: '12px' }}>
@@ -1003,9 +1039,13 @@ export default function SkillsPage() {
             ) : (
               <StatePanel
                 status={sourceNotice?.status ?? 'revision'}
-                title={sourceNotice?.title ?? 'Detalle pendiente de fuente real'}
-                description={sourceNotice?.description ?? 'El detalle aparecerá aquí cuando la fuente real esté disponible.'}
-                detail={sourceNotice?.detail ?? null}
+                title={isRootUnavailable ? 'Editor deshabilitado hasta conectar Skills' : sourceNotice?.title ?? 'Detalle pendiente de fuente real'}
+                description={
+                  isRootUnavailable
+                    ? 'Sin catálogo real no se muestra editor, detalle ni referencia productiva. La acción principal es resolver la conexión de fuente, no seleccionar una skill.'
+                    : sourceNotice?.description ?? 'El detalle aparecerá aquí cuando la fuente real esté disponible.'
+                }
+                detail={isRootUnavailable ? null : sourceNotice?.detail ?? null}
                 eyebrow="Estado de detalle"
               />
             )}
@@ -1026,10 +1066,10 @@ export default function SkillsPage() {
                   <StatusBadge status={getSaveStateStatus(saveState)} />
                 </div>
                 <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                  Actor visible: <strong>{normalizedActor || 'sin definir'}</strong>
+                  Actor visible: <strong>{isRootUnavailable ? 'no aplica' : normalizedActor || 'sin definir'}</strong>
                 </span>
                 <span style={{ color: saveState === 'error' ? appTheme.colors.stateDanger : appTheme.colors.textSecondary, fontSize: '13px' }}>
-                  {saveMessage ?? 'Todavía no se ha ejecutado un guardado en esta selección.'}
+                  {isRootUnavailable ? 'Sin operación disponible hasta conectar la fuente real de Skills.' : saveMessage ?? 'Todavía no se ha ejecutado un guardado en esta selección.'}
                 </span>
                 {saveState === 'stale' ? (
                   <span style={{ color: appTheme.colors.stateStale, fontSize: '13px' }}>
@@ -1054,7 +1094,14 @@ export default function SkillsPage() {
                 />
               ) : null}
 
-              {previewResponse ? (
+              {isRootUnavailable ? (
+                <StatePanel
+                  status={sourceNotice?.status ?? 'revision'}
+                  title="Preview y auditoría en espera de fuente real"
+                  description="No hay skill editable, preview ni rastro auditado que consultar hasta que el catálogo real esté conectado. El panel queda visible como contexto secundario, no como llamada a la acción."
+                  eyebrow="Estado bloqueado"
+                />
+              ) : previewResponse ? (
                 <>
                   <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
                     <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
@@ -1102,7 +1149,7 @@ export default function SkillsPage() {
                   gap: '10px',
                 }}
               >
-                {latestAudit ? (
+                {isRootUnavailable ? null : latestAudit ? (
                   <>
                     <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
                       <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>

--- a/apps/web/src/app/skills/page.tsx
+++ b/apps/web/src/app/skills/page.tsx
@@ -584,33 +584,41 @@ export default function SkillsPage() {
         </SurfaceCard>
 
         <SurfaceCard title="Estado del origen" elevated eyebrow="Enlace" accent="sky">
-          <div style={{ display: 'grid', gap: '10px' }}>
-            <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
+          <div style={{ display: 'grid', gap: '10px', minWidth: 0 }}>
+            <p className="text-break" style={{ margin: 0, color: appTheme.colors.textSecondary }}>
               El navegador habla con una frontera BFF same-origin; la URL real del backend queda solo en configuración server-only
               y los errores llegan saneados sin romper el shell ni el build.
             </p>
             <StatusBadge status={mapSkillsViewStateToBadgeStatus(viewState)} />
-            <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
+            <span className="text-break" style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
               Conexión: {apiConnectionLabel}
             </span>
             {sourceNotice ? (
-              <StatePanel
-                status={sourceNotice.status}
-                title={sourceNotice.title}
-                description={sourceNotice.description}
-                detail={sourceNotice.detail}
-                eyebrow="Estado de fuente"
-              >
-                <SourceStatePills
-                  items={
-                    viewState === 'not_configured'
-                      ? [{ label: 'Fuente no configurada', tone: 'not-configured' }]
-                      : viewState === 'empty'
+              isRootUnavailable ? (
+                <div style={{ display: 'grid', gap: '8px', minWidth: 0 }}>
+                  <strong className="text-break" style={{ color: appTheme.colors.textPrimary, fontSize: '15px' }}>Frontera BFF conservada</strong>
+                  <p className="text-break" style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.5 }}>
+                    El diagnóstico principal está arriba. Aquí solo se confirma que el navegador sigue usando same-origin y que la URL interna del backend no se expone.
+                  </p>
+                  <SourceStatePills items={[{ label: viewState === 'not_configured' ? 'Fuente no configurada' : 'Error/degradado', tone: viewState === 'not_configured' ? 'not-configured' : 'degraded' }]} />
+                </div>
+              ) : (
+                <StatePanel
+                  status={sourceNotice.status}
+                  title={sourceNotice.title}
+                  description={sourceNotice.description}
+                  detail={sourceNotice.detail}
+                  eyebrow="Estado de fuente"
+                >
+                  <SourceStatePills
+                    items={
+                      viewState === 'empty'
                         ? [{ label: 'API real conectada', tone: 'connected' }, { label: 'Sin datos productivos', tone: 'not-configured' }]
                         : [{ label: 'Error/degradado', tone: 'degraded' }]
-                  }
-                />
-              </StatePanel>
+                    }
+                  />
+                </StatePanel>
+              )
             ) : (
               <StatePanel
                 status="operativo"

--- a/apps/web/src/shared/ui/state/StatePanel.tsx
+++ b/apps/web/src/shared/ui/state/StatePanel.tsx
@@ -33,6 +33,7 @@ export function StatePanel({ status, title, description, detail, eyebrow, ariaRo
       style={{
         display: 'grid',
         gap: '10px',
+        minWidth: 0,
         padding: '14px',
         borderRadius: appTheme.radius.md,
         border: `1px solid ${accentColor}`,
@@ -40,21 +41,22 @@ export function StatePanel({ status, title, description, detail, eyebrow, ariaRo
       }}
     >
       <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap', alignItems: 'center' }}>
-        <div style={{ display: 'grid', gap: '4px' }}>
+        <div style={{ display: 'grid', gap: '4px', minWidth: 0 }}>
           {eyebrow ? <span style={{ color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 700, letterSpacing: '0.04em', textTransform: 'uppercase' }}>{eyebrow}</span> : null}
-          <strong style={{ fontSize: '16px', letterSpacing: '-0.01em' }}>{title}</strong>
+          <strong className="text-break" style={{ fontSize: '16px', letterSpacing: '-0.01em' }}>{title}</strong>
         </div>
         <StatusBadge status={status} />
       </div>
 
-      <p style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.5 }}>{description}</p>
-      {detail ? <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{detail}</span> : null}
+      <p className="text-break" style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.5 }}>{description}</p>
+      {detail ? <span className="text-break" style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{detail}</span> : null}
 
       {children ? (
         <div
           style={{
             display: 'grid',
             gap: '8px',
+            minWidth: 0,
             paddingTop: '10px',
             borderTop: `1px solid ${appTheme.colors.borderSubtle}`,
           }}

--- a/apps/web/src/shared/ui/status/SourceStatePills.tsx
+++ b/apps/web/src/shared/ui/status/SourceStatePills.tsx
@@ -18,7 +18,7 @@ const sourceStateToneColorMap: Record<SourceStatePillTone, string> = {
 
 export function SourceStatePills({ items }: { items: SourceStatePill[] }) {
   return (
-    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', minWidth: 0 }}>
       {items.map((item) => {
         const color = sourceStateToneColorMap[item.tone ?? 'snapshot']
 
@@ -28,6 +28,7 @@ export function SourceStatePills({ items }: { items: SourceStatePill[] }) {
             style={{
               display: 'inline-flex',
               alignItems: 'center',
+              maxWidth: '100%',
               borderRadius: '999px',
               padding: '4px 10px',
               background: appTheme.colors.bgSurface2,
@@ -35,6 +36,8 @@ export function SourceStatePills({ items }: { items: SourceStatePill[] }) {
               color,
               fontSize: '12px',
               fontWeight: 700,
+              overflowWrap: 'anywhere',
+              whiteSpace: 'normal',
             }}
           >
             {item.label}

--- a/docs/frontend-states.md
+++ b/docs/frontend-states.md
@@ -29,9 +29,11 @@ Cada vista del frontend debe contemplar al menos:
 - `error`: fallo al cargar la ficha o el índice
 
 ### Skills
-- `empty`: sin skills en la categoría/filtro
-- `error`: fallo de listado o detalle
-- `ready`: detalle editable solo si el backend lo autoriza
+- `not_configured`: la primera señal visible debe explicar que falta `MUGIWARA_CONTROL_PANEL_API_URL` en runtime server; catálogo, detalle, preview y guardado quedan bloqueados sin pedir seleccionar una skill.
+- `empty`: sin skills en la categoría/filtro con API real conectada.
+- `error`: fallo de listado o detalle; mostrar una causa raíz saneada y mantener catálogo/editor/preview como estados secundarios, sin repetir el diagnóstico en cada zona.
+- `ready`: detalle editable solo si el backend lo autoriza.
+- En `not_configured` o error raíz, la información de BFF/frontera sigue visible como contexto secundario: no debe dominar la acción requerida ni exponer URL interna del backend.
 
 ### Memory
 - `empty`: memoria no inicializada para ese agente

--- a/docs/frontend-ui-spec.md
+++ b/docs/frontend-ui-spec.md
@@ -374,6 +374,13 @@ Lista compacta de últimas señales o cambios.
 - guardar
 - validación visual de permisos
 
+### Estado raíz no configurado
+- Si Skills no está conectado al backend (`not_configured`) o la fuente real falla antes de cargar catálogo, la vista prioriza un único panel superior de `Acción requerida`.
+- Ese panel explica qué falta, qué queda bloqueado y qué se mantiene seguro; los códigos técnicos quedan como detalle secundario o desaparecen de la explicación principal.
+- El workspace no debe pedir “Selecciona una skill” cuando el catálogo no está disponible.
+- Catálogo, editor y preview/auditoría pueden conservar su hueco estructural, pero con copy secundario y sin repetir la misma causa raíz.
+- Las tarjetas de frontera BFF, edición allowlisted y auditoría permanecen visibles como contexto de seguridad, no como llamada principal a la acción.
+
 ## 4.6 Memory
 ### `MemorySourceTabs`
 - Built-in

--- a/openspec/phase-16-5-skills-not-configured-ux.md
+++ b/openspec/phase-16-5-skills-not-configured-ux.md
@@ -1,0 +1,48 @@
+# Phase 16.5 — Skills not-configured UX (#46)
+
+## Objetivo
+Cerrar la issue #46 con una microfase UI-only sobre `/skills`: cuando la fuente Skills no está configurada o está degradada, la página debe explicar una única causa raíz dominante, no pedir seleccionar una skill inexistente y mantener la información de seguridad como contexto secundario.
+
+## Decisión de corte
+No se divide en fases más pequeñas.
+
+Motivo: el alcance real es homogéneo y pequeño:
+- una ruta frontend (`apps/web/src/app/skills/page.tsx`),
+- copy/jerarquía visual de estados,
+- documentación viva de estados/UI,
+- sin backend, runtime, dependencias, API, permisos ni seguridad efectiva nueva.
+
+Dividirlo más aumentaría coordinación y PRs sin reducir riesgo. Sí se mantiene como microfase independiente de futuras ampliaciones de Skills editing.
+
+## Alcance incluido
+- Panel raíz dominante para `not_configured` / error de fuente.
+- Evitar copy de selección cuando el catálogo no existe.
+- Reducir repetición de la misma causa raíz en catálogo, editor y preview/auditoría.
+- Dejar frontera BFF/security visible pero secundaria.
+- Actualizar docs frontend relevantes.
+
+## Fuera de alcance
+- Nuevos endpoints backend.
+- Cambios de allowlist o escritura.
+- Settings page o configuración desde UI.
+- Cambios de seguridad/BFF, CORS, Origin/CSRF o runtime config.
+- Rediseño general de Skills.
+
+## Definition of done
+- `not_configured` muestra primero una explicación raíz clara.
+- La UI no pide seleccionar una skill cuando el catálogo no está disponible.
+- Los paneles secundarios no repiten ruidosamente el mismo mensaje técnico.
+- La edición productiva solo domina cuando hay skill real cargada.
+- Seguridad/frontera sigue visible sin dominar el fallo de conexión.
+- Issue #46 puede cerrarse con review Usopp.
+
+## Verify esperado
+- `npm --prefix apps/web run typecheck`
+- `npm --prefix apps/web run build`
+- `npm run verify:visual-baseline` incluyendo `/skills`
+- `git diff --check`
+- smoke visual/browser de `/skills` si la app puede levantarse localmente.
+
+## Review
+- Reviewer principal: Usopp por jerarquía UX/copy.
+- Chopper no es obligatorio porque no se cambia config/error plumbing ni superficie de seguridad; escalar solo si aparece leakage o modificación de BFF.

--- a/openspec/phase-16-5-verify-checklist.md
+++ b/openspec/phase-16-5-verify-checklist.md
@@ -1,0 +1,26 @@
+# Phase 16.5 verify checklist — Skills not-configured UX
+
+## Scope check
+- [x] Issue #46 leída desde GitHub.
+- [x] Superficie acotada a `/skills` UI/copy + docs.
+- [x] Decisión explícita: no dividir más; microfase única.
+- [x] Sin backend/API/runtime/dependencias nuevas.
+
+## Implementation check
+- [x] Panel raíz dominante para `not_configured`/error.
+- [x] Workspace no pide seleccionar skill cuando no hay catálogo.
+- [x] Catálogo/editor/preview reducen duplicación del mensaje raíz.
+- [x] Frontera de edición y estado de origen permanecen visibles como contexto secundario.
+- [x] Docs frontend actualizadas.
+
+## Verify commands
+- [x] `npm --prefix apps/web run typecheck`
+- [x] `npm --prefix apps/web run build`
+- [x] `npm run verify:visual-baseline`
+- [x] `git diff --check`
+
+## Review/closeout
+- [ ] PR con handoff a Usopp.
+- [ ] Issue #46 enlazada/cerrada tras merge.
+- [x] `.engram/phase-16-5-skills-not-configured-ux-closeout.md` actualizado.
+- [ ] Project Summary/vault actualizado si cambia el roadmap canónico.


### PR DESCRIPTION
## Resumen
- Cierra #46 con una microfase UI-only para `/skills` en estado `not_configured` / fuente raíz degradada.
- Añade un panel superior dominante de `Acción requerida` y relega workspace/catálogo/editor/preview a estados bloqueados secundarios.
- Actualiza documentación viva y artefactos OpenSpec/Engram de Phase 16.5.

## Decisión de corte
No divido más la issue: el alcance es homogéneo y acotado a una ruta frontend + copy/jerarquía + docs. No toca backend, BFF, runtime config, dependencias ni seguridad efectiva.

## Verificación
- ✅ `npm --prefix apps/web run typecheck`
- ✅ `npm --prefix apps/web run build`
- ✅ `npm run verify:visual-baseline`
- ✅ `git diff --check`
- ✅ Browser smoke local `/skills` en `not_configured`: panel raíz dominante, workspace bloqueado, sin overflow evidente; consola sin errores JS, con 503 esperados del BFF no configurado.

## Riesgo
Bajo. UI/copy only. Reviewer principal: Usopp por UX/copy/jerarquía visual.
