### PR TITLE
feat: start usage current backend

### DIFF
--- a/.engram/phase-17-1-usage-current-backend-closeout.md
+++ b/.engram/phase-17-1-usage-current-backend-closeout.md
@@ -1,0 +1,28 @@
+# Phase 17.1 closeout — Usage backend current snapshot foundation
+
+## Resultado
+Phase 17.1 arranca el bloque Usage (#51) por la parte más segura: backend read-only de snapshot actual.
+
+## Cambios técnicos
+- Añadido módulo `apps/api/src/modules/usage` con `UsageService` y router.
+- Registrado `GET /api/v1/usage/current` en FastAPI.
+- Añadidos tests `apps/api/tests/test_usage_api.py`.
+- Añadido `AGENTS.md` del módulo Usage con frontera de seguridad.
+- Añadidos OpenSpec de Phase 17.0 y Phase 17.1.
+- Actualizadas docs vivas `docs/api-modules.md` y `docs/read-models.md`.
+
+## Decisiones relevantes
+- Primera entrega limitada a snapshot actual; no mezcla UI, calendario ni actividad Hermes local.
+- Fuente runtime fija y read-only; no discovery, shell ni escritura.
+- `stale` para snapshots mayores de 45 minutos.
+- La respuesta contiene copy de privacidad pero no valores sensibles ni path runtime.
+- Tras revisión operativa de Franky, el router calcula el payload una sola vez por request y deriva el status del mismo payload para evitar doble lectura SQLite.
+
+## Verify
+- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py apps/api/tests/test_shared_contracts.py -q` → 5 passed.
+- `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py apps/api/tests/test_vault_api.py apps/api/tests/test_healthcheck_dashboard_api.py apps/api/tests/test_usage_api.py -q` → 72 passed.
+- `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py` → OK.
+- `git diff --check` → OK.
+
+## Continuidad
+Siguiente microfase recomendada: 17.2, ruta `/usage` y UI current-state con loader server-only, fallback visible, navegación `Uso` y review Usopp + Chopper/Franky si se mantiene la fuente real.

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -8,6 +8,7 @@ from .modules.memory.router import router as memory_router
 from .modules.vault.router import router as vault_router
 from .modules.healthcheck.router import router as healthcheck_router
 from .modules.dashboard.router import router as dashboard_router
+from .modules.usage.router import router as usage_router
 
 SECURITY_HEADERS = {
     'X-Content-Type-Options': 'nosniff',
@@ -63,6 +64,7 @@ app.include_router(memory_router)
 app.include_router(vault_router)
 app.include_router(healthcheck_router)
 app.include_router(dashboard_router)
+app.include_router(usage_router)
 
 
 @app.get('/health')

--- a/apps/api/src/modules/usage/AGENTS.md
+++ b/apps/api/src/modules/usage/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md — apps/api/src/modules/usage
+
+## Rol
+Módulo backend read-only para snapshots saneados de uso Codex/Hermes.
+
+## Reglas
+- Leer solo la fuente SQLite allowlisted de uso saneado.
+- No exponer email, user_id, account_id, tokens, headers, prompts, logs brutos ni raw payload.
+- No convertir Usage en filesystem browser ni consola host.
+- Mantener la semántica `ciclo semanal Codex`, no “semana” de calendario.
+- La actividad Hermes local debe permanecer agregada y saneada cuando se añada en fases posteriores.

--- a/apps/api/src/modules/usage/__init__.py
+++ b/apps/api/src/modules/usage/__init__.py
@@ -1,0 +1,1 @@
+"""Read-only usage module for sanitized Codex/Hermes usage snapshots."""

--- a/apps/api/src/modules/usage/router.py
+++ b/apps/api/src/modules/usage/router.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from ...shared.contracts import resource_response
+from .service import USAGE_REFRESH_INTERVAL_MINUTES, UsageService
+
+router = APIRouter(prefix='/api/v1/usage', tags=['usage'])
+_service = UsageService()
+
+
+def get_usage_service() -> UsageService:
+    return _service
+
+
+@router.get('/current')
+def get_usage_current(service: UsageService = Depends(get_usage_service)) -> dict:
+    current_usage = service.get_current()
+    return resource_response(
+        resource='usage.current',
+        status=service.status_for(current_usage),
+        data=current_usage,
+        meta={
+            'read_only': True,
+            'sanitized': True,
+            'source': 'codex-usage-snapshot-sqlite',
+            'refresh_interval_minutes': USAGE_REFRESH_INTERVAL_MINUTES,
+        },
+    )

--- a/apps/api/src/modules/usage/service.py
+++ b/apps/api/src/modules/usage/service.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+import sqlite3
+
+CODEX_USAGE_DB_PATH = Path('/srv/crew-core/runtime/usage/codex-usage.sqlite')
+USAGE_REFRESH_INTERVAL_MINUTES = 15
+USAGE_STALE_AFTER_MINUTES = 45
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        normalized = value.replace('Z', '+00:00')
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _bool_or_none(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if value in (0, 1, False, True):
+        return bool(value)
+    return None
+
+
+def _percent_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        percent = float(value)
+    except (TypeError, ValueError):
+        return None
+    return max(0.0, min(100.0, round(percent, 2)))
+
+
+def _window_status(percent: float | None, *, limit_reached: bool | None = None) -> str:
+    if limit_reached:
+        return 'limit_reached'
+    if percent is None:
+        return 'unknown'
+    if percent >= 95:
+        return 'critical'
+    if percent >= 80:
+        return 'high'
+    return 'normal'
+
+
+@dataclass(frozen=True)
+class UsageSnapshot:
+    captured_at: str
+    plan_type: str | None
+    allowed: bool | None
+    limit_reached: bool | None
+    primary_used_percent: float | None
+    primary_window_seconds: int | None
+    primary_window_start_at: str | None
+    primary_reset_at: str | None
+    primary_reset_after_seconds: int | None
+    secondary_used_percent: float | None
+    secondary_window_seconds: int | None
+    secondary_cycle_start_at: str | None
+    secondary_reset_at: str | None
+    secondary_reset_after_seconds: int | None
+    additional_limits_count: int
+
+
+class UsageService:
+    def __init__(self, *, db_path: Path = CODEX_USAGE_DB_PATH, now: Callable[[], str] = _iso_now):
+        self.db_path = db_path
+        self._now = now
+
+    def current_status(self) -> str:
+        return self.status_for(self.get_current())
+
+    @staticmethod
+    def status_for(payload: dict[str, Any]) -> str:
+        freshness_state = payload['current_snapshot']['freshness']['state']
+        if payload['current_snapshot']['captured_at'] is None:
+            return 'not_configured'
+        if freshness_state == 'stale':
+            return 'stale'
+        return 'ready'
+
+    def get_current(self) -> dict[str, Any]:
+        snapshot = self._load_latest_snapshot()
+        if snapshot is None:
+            return self._empty_current()
+
+        freshness = self._freshness(snapshot.captured_at)
+        primary_status = _window_status(snapshot.primary_used_percent, limit_reached=snapshot.limit_reached)
+        secondary_status = _window_status(snapshot.secondary_used_percent, limit_reached=snapshot.limit_reached)
+        recommendation = self._recommendation(
+            freshness_state=freshness['state'],
+            limit_reached=snapshot.limit_reached,
+            primary_status=primary_status,
+            secondary_status=secondary_status,
+        )
+
+        return {
+            'current_snapshot': {
+                'captured_at': snapshot.captured_at,
+                'source_label': 'snapshot cada 15 min',
+                'freshness': freshness,
+            },
+            'plan': {
+                'type': snapshot.plan_type or 'desconocido',
+                'allowed': snapshot.allowed,
+                'limit_reached': snapshot.limit_reached,
+                'additional_limits_count': snapshot.additional_limits_count,
+            },
+            'primary_window': {
+                'label': 'Ventana 5h',
+                'used_percent': snapshot.primary_used_percent,
+                'window_seconds': snapshot.primary_window_seconds,
+                'started_at': snapshot.primary_window_start_at,
+                'reset_at': snapshot.primary_reset_at,
+                'reset_after_seconds': snapshot.primary_reset_after_seconds,
+                'status': primary_status,
+            },
+            'secondary_cycle': {
+                'label': 'Ciclo semanal Codex',
+                'used_percent': snapshot.secondary_used_percent,
+                'window_seconds': snapshot.secondary_window_seconds,
+                'started_at': snapshot.secondary_cycle_start_at,
+                'reset_at': snapshot.secondary_reset_at,
+                'reset_after_seconds': snapshot.secondary_reset_after_seconds,
+                'status': secondary_status,
+            },
+            'recommendation': recommendation,
+            'methodology': {
+                'cycle_copy': 'Codex no cuenta semanas de lunes a domingo: el ciclo semanal Codex va desde el reset anterior hasta el próximo reset.',
+                'primary_window_formula': 'primary_reset_at - 18000s → primary_reset_at',
+                'secondary_cycle_formula': 'secondary_reset_at - 604800s → secondary_reset_at',
+                'privacy': 'Lectura agregada y saneada: sin email, user_id, account_id, tokens, headers, prompts ni raw payload.',
+            },
+        }
+
+    def _empty_current(self) -> dict[str, Any]:
+        return {
+            'current_snapshot': {
+                'captured_at': None,
+                'source_label': 'snapshot cada 15 min',
+                'freshness': {'state': 'unknown', 'age_minutes': None, 'label': 'Sin snapshot disponible'},
+            },
+            'plan': {'type': 'desconocido', 'allowed': None, 'limit_reached': None, 'additional_limits_count': 0},
+            'primary_window': {
+                'label': 'Ventana 5h',
+                'used_percent': None,
+                'window_seconds': 18000,
+                'started_at': None,
+                'reset_at': None,
+                'reset_after_seconds': None,
+                'status': 'unknown',
+            },
+            'secondary_cycle': {
+                'label': 'Ciclo semanal Codex',
+                'used_percent': None,
+                'window_seconds': 604800,
+                'started_at': None,
+                'reset_at': None,
+                'reset_after_seconds': None,
+                'status': 'unknown',
+            },
+            'recommendation': {
+                'state': 'sin_datos',
+                'label': 'Sin datos',
+                'message': 'Aún no hay snapshot saneado suficiente para mostrar tendencia de uso.',
+            },
+            'methodology': {
+                'cycle_copy': 'Codex no cuenta semanas de lunes a domingo: el ciclo semanal Codex va desde el reset anterior hasta el próximo reset.',
+                'primary_window_formula': 'primary_reset_at - 18000s → primary_reset_at',
+                'secondary_cycle_formula': 'secondary_reset_at - 604800s → secondary_reset_at',
+                'privacy': 'Lectura agregada y saneada: sin email, user_id, account_id, tokens, headers, prompts ni raw payload.',
+            },
+        }
+
+    def _freshness(self, captured_at: str) -> dict[str, Any]:
+        captured = _parse_datetime(captured_at)
+        now = _parse_datetime(self._now())
+        if captured is None or now is None:
+            return {'state': 'unknown', 'age_minutes': None, 'label': 'Frescura desconocida'}
+        age_minutes = max(0, int((now - captured).total_seconds() // 60))
+        if age_minutes > USAGE_STALE_AFTER_MINUTES:
+            return {'state': 'stale', 'age_minutes': age_minutes, 'label': 'Datos antiguos'}
+        return {'state': 'fresh', 'age_minutes': age_minutes, 'label': 'Snapshot reciente'}
+
+    def _recommendation(self, *, freshness_state: str, limit_reached: bool | None, primary_status: str, secondary_status: str) -> dict[str, str]:
+        if freshness_state == 'stale':
+            return {'state': 'datos_antiguos', 'label': 'Datos antiguos', 'message': 'El snapshot no es reciente. Revisa el timer o espera al próximo refresco.'}
+        if limit_reached:
+            return {'state': 'limite_alcanzado', 'label': 'Límite alcanzado', 'message': 'Espera al reset y evita reintentos automáticos.'}
+        if 'critical' in (primary_status, secondary_status):
+            return {'state': 'critico', 'label': 'Crítico', 'message': 'Margen reducido. Reserva Codex para tareas críticas o espera al reset.'}
+        if 'high' in (primary_status, secondary_status):
+            return {'state': 'alto', 'label': 'Alto', 'message': 'Conviene vigilar. Prioriza tareas importantes y evita exploraciones largas.'}
+        return {'state': 'normal', 'label': 'Normal', 'message': 'Uso dentro de rango. Ritmo sano.'}
+
+    def _load_latest_snapshot(self) -> UsageSnapshot | None:
+        if not self.db_path.exists() or not self.db_path.is_file():
+            return None
+        try:
+            con = sqlite3.connect(f'file:{self.db_path}?mode=ro', uri=True)
+            con.row_factory = sqlite3.Row
+            row = con.execute(
+                """
+                SELECT
+                    captured_at,
+                    plan_type,
+                    allowed,
+                    limit_reached,
+                    primary_used_percent,
+                    primary_window_seconds,
+                    primary_window_start_at,
+                    primary_reset_at,
+                    primary_reset_after_seconds,
+                    secondary_used_percent,
+                    secondary_window_seconds,
+                    secondary_cycle_start_at,
+                    secondary_reset_at,
+                    secondary_reset_after_seconds,
+                    additional_limits_count
+                FROM codex_usage_snapshots
+                ORDER BY captured_at_epoch DESC, id DESC
+                LIMIT 1
+                """
+            ).fetchone()
+        except sqlite3.Error:
+            return None
+        finally:
+            try:
+                con.close()
+            except UnboundLocalError:
+                pass
+
+        if row is None:
+            return None
+        return UsageSnapshot(
+            captured_at=str(row['captured_at']),
+            plan_type=row['plan_type'],
+            allowed=_bool_or_none(row['allowed']),
+            limit_reached=_bool_or_none(row['limit_reached']),
+            primary_used_percent=_percent_or_none(row['primary_used_percent']),
+            primary_window_seconds=row['primary_window_seconds'],
+            primary_window_start_at=row['primary_window_start_at'],
+            primary_reset_at=row['primary_reset_at'],
+            primary_reset_after_seconds=row['primary_reset_after_seconds'],
+            secondary_used_percent=_percent_or_none(row['secondary_used_percent']),
+            secondary_window_seconds=row['secondary_window_seconds'],
+            secondary_cycle_start_at=row['secondary_cycle_start_at'],
+            secondary_reset_at=row['secondary_reset_at'],
+            secondary_reset_after_seconds=row['secondary_reset_after_seconds'],
+            additional_limits_count=int(row['additional_limits_count'] or 0),
+        )

--- a/apps/api/tests/test_usage_api.py
+++ b/apps/api/tests/test_usage_api.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from apps.api.src.main import app
+from apps.api.src.modules.usage.router import get_usage_service
+from apps.api.src.modules.usage.service import UsageService
+
+
+def _create_usage_db(path: Path, *, captured_at: str = '2026-04-26T14:29:29+00:00') -> None:
+    con = sqlite3.connect(path)
+    con.execute(
+        """
+        CREATE TABLE codex_usage_snapshots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            captured_at TEXT NOT NULL,
+            captured_at_epoch INTEGER NOT NULL,
+            plan_type TEXT,
+            allowed INTEGER,
+            limit_reached INTEGER,
+            primary_used_percent REAL,
+            primary_window_seconds INTEGER,
+            primary_window_start_at TEXT,
+            primary_reset_at TEXT,
+            primary_reset_after_seconds INTEGER,
+            secondary_used_percent REAL,
+            secondary_window_seconds INTEGER,
+            secondary_cycle_start_at TEXT,
+            secondary_reset_at TEXT,
+            secondary_reset_after_seconds INTEGER,
+            additional_limits_count INTEGER NOT NULL DEFAULT 0,
+            created_by TEXT NOT NULL DEFAULT 'franky',
+            schema_version INTEGER NOT NULL DEFAULT 1
+        )
+        """
+    )
+    con.execute(
+        """
+        INSERT INTO codex_usage_snapshots (
+            captured_at,
+            captured_at_epoch,
+            plan_type,
+            allowed,
+            limit_reached,
+            primary_used_percent,
+            primary_window_seconds,
+            primary_window_start_at,
+            primary_reset_at,
+            primary_reset_after_seconds,
+            secondary_used_percent,
+            secondary_window_seconds,
+            secondary_cycle_start_at,
+            secondary_reset_at,
+            secondary_reset_after_seconds,
+            additional_limits_count,
+            created_by,
+            schema_version
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            captured_at,
+            1777213769,
+            'prolite',
+            1,
+            0,
+            26.0,
+            18000,
+            '2026-04-26T10:04:43+00:00',
+            '2026-04-26T15:04:43+00:00',
+            2114,
+            90.0,
+            604800,
+            '2026-04-21T18:25:51+00:00',
+            '2026-04-28T18:25:51+00:00',
+            186982,
+            1,
+            'franky',
+            1,
+        ),
+    )
+    con.commit()
+    con.close()
+
+
+def _override_usage_service(service: UsageService):
+    app.dependency_overrides[get_usage_service] = lambda: service
+
+
+def teardown_function():
+    app.dependency_overrides.clear()
+
+
+def test_usage_current_returns_sanitized_codex_snapshot(tmp_path):
+    db_path = tmp_path / 'codex-usage.sqlite'
+    _create_usage_db(db_path)
+    _override_usage_service(UsageService(db_path=db_path, now=lambda: '2026-04-26T14:40:00+00:00'))
+
+    response = TestClient(app).get('/api/v1/usage/current')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'usage.current'
+    assert payload['status'] == 'ready'
+    assert payload['meta'] == {
+        'read_only': True,
+        'sanitized': True,
+        'source': 'codex-usage-snapshot-sqlite',
+        'refresh_interval_minutes': 15,
+    }
+
+    data = payload['data']
+    assert data['plan']['type'] == 'prolite'
+    assert data['plan']['allowed'] is True
+    assert data['plan']['limit_reached'] is False
+    assert data['current_snapshot']['captured_at'] == '2026-04-26T14:29:29+00:00'
+    assert data['current_snapshot']['source_label'] == 'snapshot cada 15 min'
+    assert data['current_snapshot']['freshness']['state'] == 'fresh'
+    assert data['primary_window'] == {
+        'label': 'Ventana 5h',
+        'used_percent': 26.0,
+        'window_seconds': 18000,
+        'started_at': '2026-04-26T10:04:43+00:00',
+        'reset_at': '2026-04-26T15:04:43+00:00',
+        'reset_after_seconds': 2114,
+        'status': 'normal',
+    }
+    assert data['secondary_cycle'] == {
+        'label': 'Ciclo semanal Codex',
+        'used_percent': 90.0,
+        'window_seconds': 604800,
+        'started_at': '2026-04-21T18:25:51+00:00',
+        'reset_at': '2026-04-28T18:25:51+00:00',
+        'reset_after_seconds': 186982,
+        'status': 'high',
+    }
+    assert data['recommendation']['state'] == 'alto'
+    assert 'semana' not in data['secondary_cycle']['label'].lower().replace('semanal', '')
+    assert '/srv/crew-core/runtime/usage' not in str(payload)
+    assert 'synthetic-token' not in str(payload).lower()
+    assert 'raw_payload_value' not in str(payload).lower()
+
+
+def test_usage_current_degrades_when_snapshot_db_is_absent(tmp_path):
+    _override_usage_service(UsageService(db_path=tmp_path / 'missing.sqlite', now=lambda: '2026-04-26T14:40:00+00:00'))
+
+    response = TestClient(app).get('/api/v1/usage/current')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['status'] == 'not_configured'
+    assert payload['data']['current_snapshot']['freshness']['state'] == 'unknown'
+    assert payload['data']['recommendation']['state'] == 'sin_datos'
+    assert 'missing.sqlite' not in str(payload)
+
+
+def test_usage_current_marks_old_snapshots_as_stale(tmp_path):
+    db_path = tmp_path / 'codex-usage.sqlite'
+    _create_usage_db(db_path, captured_at='2026-04-26T10:00:00+00:00')
+    _override_usage_service(UsageService(db_path=db_path, now=lambda: '2026-04-26T14:40:00+00:00'))
+
+    response = TestClient(app).get('/api/v1/usage/current')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['status'] == 'stale'
+    assert payload['data']['current_snapshot']['freshness']['state'] == 'stale'
+    assert payload['data']['recommendation']['state'] == 'datos_antiguos'

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -6,6 +6,8 @@
 - `memory`
 - `vault`
 - `healthcheck`
+- `dashboard`
+- `usage`
 - `system`
 
 ## Responsabilidad por módulo
@@ -64,6 +66,13 @@
 - exponer `GET /api/v1/dashboard` como agregación read-only para la home operativa
 - componer solo resúmenes seguros y links allowlisted
 - degradar Healthcheck no configurado a warning/stale visible, nunca a sano silencioso
+
+### `usage`
+- exponer `GET /api/v1/usage/current` como primera frontera read-only del bloque Usage (#51)
+- consumir solo la SQLite saneada allowlisted de Codex usage producida fuera del backend
+- serializar snapshot actual, plan, ventana 5h, ciclo semanal Codex, frescura y recomendación sin paths runtime ni raw payload
+- degradar DB ausente/ilegible/sin snapshots a `not_configured`/`unknown` visible, nunca a dato sano silencioso
+- mantener actividad Hermes local, calendario y ventanas históricas para subfases separadas y saneadas
 
 ### `system`
 - estado general del servidor y señales operativas de alto nivel

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -90,6 +90,21 @@ Issue #43 automates the project-health producer with the user-level `mugiwara-pr
 
 Phase 15.8 closes the Healthcheck real-source block through 15.7b. Canonical state: readers exist for `vault-sync`, `backup-health`, `project-health`, `gateway-status` and `cronjobs`; producers/runners exist for `project-health`, `gateway-status` and `cronjobs-status`; `vault-sync-status` and `backup-health-status` producers remain explicit follow-ups rather than blockers. Healthcheck still degrades missing/unreadable fixed manifests visibly and must not expose host internals.
 
+### `usage.current`
+Campos esperados:
+- `current_snapshot` con `captured_at`, `source_label` y `freshness`
+- `plan` con tipo de plan, `allowed`, `limit_reached` y límites adicionales
+- `primary_window` para la `Ventana 5h`: porcentaje usado, rango, reset y estado
+- `secondary_cycle` para el `Ciclo semanal Codex`: porcentaje usado, rango, reset y estado
+- `recommendation` con estado/copy operativo
+- `methodology` con fórmulas de reset y privacidad
+
+Uso:
+- responder rápido si la ventana 5h o el ciclo semanal Codex están en zona normal/alta/crítica
+- mantener explícito que el ciclo semanal Codex no equivale a semana natural lunes-domingo
+- exponer solo métricas saneadas desde la fuente SQLite allowlisted, sin email, user/account IDs, tokens, prompts, headers, logs ni raw payload
+- degradar fuente ausente/ilegible a `not_configured`/`unknown` sin path runtime
+
 ### `memory.agent_summary`
 Campos esperados:
 - `mugiwara_slug`

--- a/openspec/phase-17-0-usage-plan.md
+++ b/openspec/phase-17-0-usage-plan.md
@@ -1,0 +1,90 @@
+# Phase 17.0 — Usage page block plan
+
+## Objetivo
+Abrir el bloque Usage para GitHub #51 sin mezclarlo con Git control (#40), header metrics (#36) ni productores Healthcheck pendientes. La feature debe exponer uso Codex/Hermes en modo read-only, con contratos saneados y progreso por microfases.
+
+## Por qué ahora
+Pablo ha pedido comenzar Phase 17.0 y 17.1. El issue #51 ya contiene UX/product input de Usopp y existe una fuente operativa saneada producida por Franky: `codex-usage-snapshot.py` escribe snapshots cada 15 minutos en una SQLite fija bajo runtime privado. El estado real del repo no tiene todavía `openspec/phase-17*` ni módulo `usage`.
+
+## Principios operativos
+- Backend como frontera de seguridad: ruta fija allowlisted, sin filesystem arbitrario, sin shell, sin raw payload.
+- Etiqueta obligatoria: `ciclo semanal Codex`, no “semana” a secas.
+- La página es read-only; no añade acciones ni duplicación de `/healthcheck`.
+- Actividad Hermes local queda para subfase separada y solo como agregado saneado.
+- UI responsive: calendario por fecha natural, mobile sin scroll horizontal obligatorio.
+
+## Fuera de alcance del bloque inicial
+- Modificar `/uso` de Telegram.
+- Escrituras, export CSV o predicción agresiva tipo “quedan X prompts”.
+- Atribución exacta de consumo Codex por Mugiwara o conversación.
+- Exponer prompts, raw conversations, logs, email, user/account IDs, tokens u OAuth.
+- #40 Git control y #36 header metrics.
+
+## Subfases
+
+### 17.1 — Backend current snapshot foundation
+Alcance:
+- Crear módulo backend `usage`.
+- Exponer `GET /api/v1/usage/current`.
+- Leer solo la SQLite saneada allowlisted de Codex usage.
+- Publicar plan, ventana 5h, ciclo semanal Codex, frescura y recomendación actual.
+- Degradar DB ausente/ilegible a `not_configured`/`unknown` sin rutas internas.
+
+DoD:
+- Tests backend para snapshot listo, DB ausente y snapshot stale.
+- Respuesta `resource_response` con `read_only`, `sanitized`, `source` y frecuencia.
+- No serializa path runtime, raw payload ni identificadores prohibidos.
+- Docs vivas actualizadas.
+
+Verify esperado:
+- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py`
+- `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py`
+- `git diff --check`
+
+### 17.2 — Usage page shell and current state UI
+Alcance:
+- Añadir navegación `Uso` y ruta `/usage`.
+- Server loader/BFF frontend server-only contra `/api/v1/usage/current`.
+- Render header, cuatro cards superiores y metodología mínima.
+- Estados loading/fallback/error/stale visibles.
+
+Verify esperado:
+- Typecheck/build web.
+- `verify:visual-baseline`.
+- Browser smoke responsive dirigido.
+- Review Usopp + Chopper si se toca copy de privacidad y frontend visible.
+
+### 17.3 — Calendar read model
+Alcance:
+- `GET /api/v1/usage/calendar?range=current_cycle|previous_cycle|7d|30d`.
+- Agregación por fecha natural, deltas de ciclo, tramos parciales y pico 5h.
+- Sin actividad Hermes por conversación; solo agregados si existe fuente saneada.
+
+Verify esperado:
+- Tests de partición por ciclo/reset y no scroll horizontal en mobile cuando llegue la UI.
+
+### 17.4 — Five-hour windows and Hermes aggregated activity
+Alcance:
+- `GET /api/v1/usage/five-hour-windows?limit=8`.
+- `GET /api/v1/usage/hermes-activity?range=...` solo si hay fuente agregada segura.
+- Copy de correlación orientativa, sin causalidad exacta.
+
+Verify esperado:
+- Tests de límites, saneado y no leakage.
+- Review Chopper + Franky.
+
+### 17.5 — UI closeout and canon refresh
+Alcance:
+- Completar responsive, docs, OpenSpec closeout, Project Summary/vault y issue #51.
+- PR review con Usopp + Chopper + Franky si backend/runtime sigue tocado.
+
+## Riesgos
+- La fuente SQLite es operativa real; no debe versionarse ni copiarse al repo.
+- La primera UI puede sobredimensionarse si se intenta meter calendario completo y Hermes activity en la misma PR.
+- La semántica `allowed`/`limit_reached` puede fluctuar en snapshots; la UI debe mostrarlos como estado de snapshot, no verdad absoluta.
+- La actividad Hermes local necesita un diseño aparte para no filtrar prompts o conversaciones.
+
+## Política de rama/cierre
+- Rama: `zoro/phase-17-usage-foundation`.
+- Commits semánticos con trailers Mugiwara.
+- PR relevante requiere Franky/Chopper para backend/fuente runtime; Usopp cuando entre UI visible.

--- a/openspec/phase-17-1-planning-verify-checklist.md
+++ b/openspec/phase-17-1-planning-verify-checklist.md
@@ -1,0 +1,19 @@
+# Phase 17.1 planning/verify checklist
+
+## Planning evidence
+- [x] Repo real inspeccionado: `main` limpio antes de rama y issues abiertos #51/#40/#36 revisados.
+- [x] Project Summary leído: features nuevas estaban pendientes y #51 es el primer bloque escogido por petición explícita de Pablo.
+- [x] Fuente real inspeccionada: SQLite `/srv/crew-core/runtime/usage/codex-usage.sqlite` existe con tabla `codex_usage_snapshots` y campos saneados.
+- [x] Scope dividido: 17.1 solo backend current snapshot; UI/calendario/Hermes activity quedan fuera.
+
+## Verify evidence
+- [x] Red TDD inicial: `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` falló por módulo `usage` inexistente.
+- [x] Green dirigido: `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q`.
+- [x] Compile dirigido.
+- [x] Guardrails/docs diff check.
+- [x] Smoke API vía FastAPI TestClient cubierto por `test_usage_api.py`.
+
+## Review routing esperado
+- Franky: fuente SQLite/runtime snapshot y semántica operativa.
+- Chopper: no leakage de PII/raw payload y frontera host.
+- Usopp: no obligatorio en 17.1 si no hay UI visible; sí desde 17.2.

--- a/openspec/phase-17-1-usage-current-backend.md
+++ b/openspec/phase-17-1-usage-current-backend.md
@@ -1,0 +1,36 @@
+# Phase 17.1 — Usage backend current snapshot foundation
+
+## Alcance cerrado
+Phase 17.1 crea la primera frontera backend del bloque Usage:
+
+- nuevo módulo `apps/api/src/modules/usage`;
+- endpoint read-only `GET /api/v1/usage/current`;
+- lectura de la SQLite saneada de Franky en ruta fija allowlisted;
+- respuesta con snapshot actual, plan, ventana 5h, ciclo semanal Codex, frescura, recomendación y metodología/privacidad;
+- degradación segura ante DB ausente/ilegible o snapshots antiguos.
+
+## Decisiones
+- La DB runtime no se versiona ni se copia; el backend solo lee `codex_usage_snapshots` en modo SQLite read-only.
+- La respuesta no expone rutas runtime ni detalles internos del host.
+- `ciclo semanal Codex` queda como etiqueta de producto para evitar confundirlo con una semana natural lunes-domingo.
+- `stale` se declara si el snapshot supera 45 minutos, coherente con productor cada 15 minutos y margen de retraso operativo.
+- `not_configured` representa DB ausente/ilegible/sin snapshots sin filtrar path local.
+
+## DoD
+- [x] Tests backend para snapshot ready, DB ausente y snapshot stale.
+- [x] Endpoint registrado en FastAPI.
+- [x] Módulo documentado con `AGENTS.md` local.
+- [x] Docs `api-modules` y `read-models` actualizadas.
+- [x] No se añaden acciones de escritura.
+
+## Verify
+- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py`
+- `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py`
+- `git diff --check`
+
+## Fuera de alcance pendiente
+- Página `/usage` en frontend.
+- Calendario de consumo por fecha natural.
+- Ventanas 5h agregadas por día/rango.
+- Actividad Hermes local agregada.
+- Gráficas o proyecciones avanzadas.


### PR DESCRIPTION
## Objetivo

Comenzar Phase 17.0/17.1 del `mugiwara-control-panel` para GitHub #51 (`Usage page`) con un primer corte seguro: planificación del bloque y backend read-only del snapshot actual de uso Codex.

## Alcance

- Añade `openspec/phase-17-0-usage-plan.md` con el corte en microfases.
- Añade `openspec/phase-17-1-usage-current-backend.md` y checklist de verify.
- Crea `apps/api/src/modules/usage`.
- Expone `GET /api/v1/usage/current`.
- Lee solo la SQLite saneada allowlisted de Codex usage.
- Devuelve snapshot actual, plan, ventana 5h, ciclo semanal Codex, frescura, recomendación y metodología/privacidad.
- Degrada DB ausente/ilegible a `not_configured`/`unknown` sin filtrar path runtime.
- Actualiza `docs/api-modules.md`, `docs/read-models.md` y closeout Engram.

## Fuera de alcance

- UI `/usage`.
- Calendario de consumo.
- Ventanas históricas 5h.
- Actividad Hermes local agregada.
- Git control #40 y header metrics #36.

## Verificación Zoro

- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py apps/api/tests/test_shared_contracts.py -q` → 5 passed.
- `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py apps/api/tests/test_skills_api.py apps/api/tests/test_vault_api.py apps/api/tests/test_healthcheck_dashboard_api.py apps/api/tests/test_usage_api.py -q` → 72 passed.
- `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py` → OK.
- `git diff --check` → OK.

## Riesgo y reviewers

- **Franky**: validar fuente operativa SQLite/runtime snapshot, threshold `stale` y mantenibilidad del endpoint.
- **Chopper**: validar frontera host/PII/raw payload, no leakage de path runtime y degradación segura.
- **Usopp**: no solicitado en esta ronda porque no hay UI visible; entrará en 17.2.

No auto-mergear hasta recibir revisión de Franky + Chopper o declaración explícita de bloqueo por permisos.
