### PR TITLE
docs: reconcile phase roadmap

### DIFF
--- a/.engram/phase-18-roadmap-reconciliation-closeout.md
+++ b/.engram/phase-18-roadmap-reconciliation-closeout.md
@@ -1,0 +1,30 @@
+# Phase 18 roadmap reconciliation closeout
+
+## Qué se corrige
+Pablo detectó una discrepancia entre dos respuestas de Zoro:
+
+- Un plan verbal inicial asignaba Phase 17.x a productores Healthcheck (`vault-sync-status` y `backup-health-status`).
+- La ejecución real posterior consumió Phase 17.0/17.1 para Usage / GitHub #51 y fue mergeada por PR #69.
+
+## Decisión
+No se revierte PR #69: el cambio técnico es válido, revisado y ya está en `main`.
+
+La corrección canónica es:
+- Phase 17.x = Usage / #51.
+- Phase 18.x = productores Healthcheck pendientes.
+
+## Roadmap nuevo
+- 17.2: UI `/usage` current-state.
+- 17.3: calendario Usage por fecha natural.
+- 17.4: ventanas 5h + actividad Hermes agregada.
+- 17.5: closeout/canon Usage.
+- 18.0: planning/reconciliation Healthcheck producers.
+- 18.1: producer `vault-sync-status`.
+- 18.2: runner/timer `vault-sync-status`.
+- 18.3: producer `backup-health-status`.
+- 18.4: runner/timer `backup-health-status`.
+- 18.5: closeout/canon Healthcheck producers.
+
+## Continuidad
+Si Pablo dice “continúa Phase 17”, continuar Usage salvo aclaración explícita.
+Si Pablo pide productores `vault-sync`/`backup-health`, trabajar en Phase 18.x.

--- a/openspec/phase-17-0-usage-plan.md
+++ b/openspec/phase-17-0-usage-plan.md
@@ -4,7 +4,13 @@
 Abrir el bloque Usage para GitHub #51 sin mezclarlo con Git control (#40), header metrics (#36) ni productores Healthcheck pendientes. La feature debe exponer uso Codex/Hermes en modo read-only, con contratos saneados y progreso por microfases.
 
 ## Por qué ahora
-Pablo ha pedido comenzar Phase 17.0 y 17.1. El issue #51 ya contiene UX/product input de Usopp y existe una fuente operativa saneada producida por Franky: `codex-usage-snapshot.py` escribe snapshots cada 15 minutos en una SQLite fija bajo runtime privado. El estado real del repo no tiene todavía `openspec/phase-17*` ni módulo `usage`.
+Pablo pidió comenzar Phase 17.0 y 17.1 y PR #69 ya consumió esa numeración para Usage. El issue #51 contiene UX/product input de Usopp y existe una fuente operativa saneada producida por Franky: `codex-usage-snapshot.py` escribe snapshots cada 15 minutos en una SQLite fija bajo runtime privado.
+
+## Corrección de roadmap
+Antes de PR #69 existía un plan verbal que proponía usar Phase 17.x para productores Healthcheck pendientes (`vault-sync-status` y `backup-health-status`). Esa asignación quedó contradicha por la ejecución ya mergeada de Usage. Para evitar drift:
+- **Phase 17.x queda canónicamente reservada a Usage / GitHub #51**.
+- **Los productores Healthcheck pendientes pasan a Phase 18.x**.
+- Si se pide “continúa 17.x”, debe interpretarse como continuar Usage salvo que Pablo indique explícitamente lo contrario.
 
 ## Principios operativos
 - Backend como frontera de seguridad: ruta fija allowlisted, sin filesystem arbitrario, sin shell, sin raw payload.

--- a/openspec/phase-18-healthcheck-producers-roadmap.md
+++ b/openspec/phase-18-healthcheck-producers-roadmap.md
@@ -1,0 +1,152 @@
+# Phase 18 — Healthcheck producers roadmap
+
+## Objetivo
+Reubicar y definir el bloque operativo pendiente de Healthcheck para crear productores/manifest writers seguros de `vault-sync-status.json` y `backup-health-status.json`, sin competir con la numeración ya consumida por Phase 17 Usage.
+
+## Decisión de numeración
+- Phase 17.x queda reservada a Usage / GitHub #51 porque PR #69 ya mergeó `phase-17-0-usage-plan` y `phase-17-1` backend foundation.
+- El plan verbal anterior que usaba Phase 17.x para productores Healthcheck queda corregido.
+- Los productores Healthcheck pendientes pasan a Phase 18.x.
+
+## Estado real actual
+Ya existen readers/adapters backend para:
+- `vault-sync` leyendo manifiesto fijo esperado en `/srv/crew-core/runtime/healthcheck/vault-sync-status.json`.
+- `backup-health` leyendo manifiesto fijo esperado en `/srv/crew-core/runtime/healthcheck/backup-health-status.json`.
+
+Siguen pendientes productores/runners para:
+- `vault-sync-status.json`.
+- `backup-health-status.json`.
+
+## Principios operativos
+- Productores fuera del backend; el backend sigue sin ejecutar shell/Git/systemd ni navegar filesystem.
+- JSON mínimo, saneado y estable.
+- Escritura atómica: temp file mismo directorio, fsync, `os.replace`, fsync del directorio padre.
+- Permisos no públicos: directorio 0750, fichero 0640 salvo decisión operativa distinta de Franky.
+- No serializar paths internos innecesarios, remotes, stdout/stderr, logs, diffs, tokens, `.env`, nombres de archivos de backup, checksums concretos ni raw errors.
+- Review Franky + Chopper en cada microfase con runtime/host boundary.
+
+## Roadmap canónico
+
+### Phase 18.0 — Planning/reconciliation del bloque operativo Healthcheck
+Objetivo: cerrar contrato exacto de producers antes de implementar.
+
+Incluye:
+- Confirmar estado actual de readers y rutas fijas esperadas.
+- Definir schema mínimo por manifiesto.
+- Definir reviewers y verify por subfase.
+- Crear checklist y closeout de continuidad.
+
+Verify:
+- `git diff --check`.
+- Revisión documental de docs/read-models/api-modules/healthcheck-source-policy.
+
+### Phase 18.1 — Producer `vault-sync-status`
+Objetivo: crear `scripts/write-vault-sync-status.py` y script npm `write:vault-sync-status`.
+
+JSON mínimo recomendado:
+- `status`
+- `result`
+- `updated_at`
+- `last_success_at` si está disponible de forma segura.
+
+No serializar:
+- branch, remotes, stdout/stderr, logs, rutas internas, tokens, diffs, errores crudos.
+
+Verify mínimo:
+- `python3 -m py_compile scripts/write-vault-sync-status.py ...tests...`
+- pytest dirigido del productor.
+- `npm run verify:healthcheck-source-policy`.
+- nuevo `npm run verify:vault-sync-status-runner` o guardrail equivalente.
+- `npm run write:vault-sync-status`.
+- validar shape/permisos del manifiesto real.
+- smoke API Healthcheck contra el manifiesto real.
+- `git diff --check`.
+
+Review: Franky + Chopper.
+
+### Phase 18.2 — Runner/timer `vault-sync-status`
+Objetivo: automatizar refresco periódico del manifiesto.
+
+Incluye:
+- `mugiwara-vault-sync-status.service`.
+- `mugiwara-vault-sync-status.timer`.
+- `scripts/install-vault-sync-status-user-timer.sh`.
+- Timer coherente con thresholds actuales `vault-sync`: warn 90m / fail 360m. Refresco inicial recomendado: 15–30 min salvo ajuste de Franky.
+- `TimeoutStartSec`, `NoNewPrivileges`, `PrivateTmp`, `ProtectSystem`, `ProtectHome` cuando encajen.
+- Unit llama script npm fijo, sin `--output` alternativo.
+
+Verify mínimo:
+- `systemd-analyze --user verify ...service ...timer`.
+- ejecutar installer.
+- `systemctl --user start mugiwara-vault-sync-status.service`.
+- `systemctl --user is-active mugiwara-vault-sync-status.timer`.
+- validar manifiesto real.
+- guardrail runner.
+- smoke API Healthcheck.
+
+Review: Franky + Chopper.
+
+### Phase 18.3 — Producer `backup-health-status`
+Objetivo: crear productor seguro de backup health.
+
+JSON mínimo recomendado:
+- `status`
+- `result`
+- `updated_at`
+- `last_success_at`
+- `checksum_present`
+- `retention_count`
+
+Semántica fail-closed:
+- `pass` solo si hay resultado positivo explícito.
+- `checksum_present is True`.
+- `retention_count >= 4` salvo cambio explícito de política.
+- Ausencia/parcialidad/desconocido degrada a `warn/stale/unknown`, nunca a verde silencioso.
+
+No serializar:
+- rutas de archivo, nombres de backups, destinos, tamaños, checksums concretos, stdout/stderr, logs, raw output, tokens o errores crudos.
+
+Verify mínimo:
+- py_compile + pytest dirigido.
+- guardrail runner específico.
+- ejecución real `npm run write:backup-health-status`.
+- validar shape/permisos del manifiesto real.
+- smoke API Healthcheck.
+- `git diff --check`.
+
+Review: Franky + Chopper.
+
+### Phase 18.4 — Runner/timer `backup-health-status`
+Objetivo: automatizar refresco periódico del manifiesto backup.
+
+Incluye:
+- `mugiwara-backup-health-status.service`.
+- `mugiwara-backup-health-status.timer`.
+- installer seguro.
+- Timer coherente con thresholds actuales `backup-health`: warn 1800m / fail 4320m; frecuencia no agresiva, ajustada a la cadencia real de backups.
+
+Verify mínimo:
+- systemd analyze + installer + start service + timer active.
+- validar manifiesto real y permisos.
+- smoke API Healthcheck.
+
+Review: Franky + Chopper.
+
+### Phase 18.5 — Closeout/canon Healthcheck producers
+Objetivo: cerrar el bloque productores pendientes.
+
+Incluye:
+- Actualizar docs vivas (`healthcheck-source-policy`, `api-modules`, `read-models`).
+- Actualizar Project Summary del vault.
+- Closeout Engram.
+- Confirmar que `vault-sync` y `backup-health` ya no degradan por falta de manifiesto si los productores están activos.
+
+Verify:
+- Guardrails Healthcheck relevantes.
+- Smoke API Healthcheck.
+- `git diff --check`.
+
+## Roadmap paralelo no mezclable
+- Phase 17.x Usage sigue abierta hasta UI `/usage`, calendario, ventanas 5h históricas y actividad Hermes agregada.
+- Phase 18.x Healthcheck producers puede ejecutarse antes o después de 17.2, pero no debe mezclarse en la misma PR.
+- #40 Git control y #36 header metrics quedan después, salvo decisión explícita de Pablo.

--- a/openspec/phase-18-roadmap-reconciliation-checklist.md
+++ b/openspec/phase-18-roadmap-reconciliation-checklist.md
@@ -1,0 +1,20 @@
+# Phase 18 roadmap reconciliation checklist
+
+## Contexto corregido
+- [x] PR #69 ya mergeó Phase 17.0/17.1 como Usage.
+- [x] Existía un plan verbal previo que asignaba 17.x a productores Healthcheck.
+- [x] Se decide no revertir PR #69 ni renumerar artefactos mergeados.
+- [x] Phase 17.x queda canónicamente como Usage / #51.
+- [x] Productores Healthcheck pendientes pasan a Phase 18.x.
+
+## Artefactos actualizados
+- [x] `openspec/phase-17-0-usage-plan.md` incluye nota de corrección.
+- [x] `openspec/phase-18-healthcheck-producers-roadmap.md` define roadmap nuevo.
+- [x] `.engram/phase-18-roadmap-reconciliation-closeout.md` deja continuidad.
+- [x] Project Summary del vault actualizado.
+- [x] Skill `zoro-project-phase-planning` corregida.
+
+## Verify
+- [x] `git diff --check` en repo proyecto.
+- [x] `git diff --check` en vault.
+- [ ] commits/push realizados.


### PR DESCRIPTION
## Objetivo

Corregir el drift de roadmap detectado por Pablo: hubo un plan verbal donde Phase 17.x era para productores Healthcheck, pero PR #69 ya mergeó Phase 17.0/17.1 como Usage.

## Corrección canónica

- **Phase 17.x = Usage / GitHub #51**.
- **Phase 18.x = productores Healthcheck pendientes** (`vault-sync-status` y `backup-health-status`).
- No se revierte PR #69: el cambio técnico es válido y ya está en `main`.

## Cambios

- Añade nota de corrección en `openspec/phase-17-0-usage-plan.md`.
- Añade `openspec/phase-18-healthcheck-producers-roadmap.md` con roadmap completo:
  - 18.0 planning/reconciliation.
  - 18.1 producer `vault-sync-status`.
  - 18.2 runner/timer `vault-sync-status`.
  - 18.3 producer `backup-health-status`.
  - 18.4 runner/timer `backup-health-status`.
  - 18.5 closeout/canon.
- Añade checklist y closeout Engram.
- Project Summary del vault ya quedó corregido por sync automático (`32fb64a`).
- Skill `zoro-project-phase-planning` corregida para no repetir el drift.

## Verify

- `git diff --check` en repo proyecto → OK.
- `git diff --check` en vault → OK.

## Riesgo

Docs/canon-only: no toca runtime, backend behavior, frontend, dependencias, seguridad efectiva ni UI.

## Review

Excepción de bajo riesgo: revisión manual de Zoro, sin handoff externo. La corrección nace de una instrucción explícita de Pablo y no cambia código productivo.
