### PR TITLE
feat: add Usage current-state UI

### DIFF
--- a/.engram/phase-17-2-usage-current-ui-closeout.md
+++ b/.engram/phase-17-2-usage-current-ui-closeout.md
@@ -1,0 +1,30 @@
+# Phase 17.2 — Usage current-state UI closeout
+
+## Decisión de corte
+17.2 se mantiene como microfase única, sin subfases adicionales, porque el scope real es homogéneo: navegación `Uso`, ruta server-side `/usage`, adapter server-only al endpoint ya existente `GET /api/v1/usage/current`, UI current-state y guardrail estático.
+
+## Cerrado
+- Añadida ruta `/usage` como server page dinámica.
+- Añadida navegación `Uso`.
+- Añadido módulo frontend `apps/web/src/modules/usage` con adapter server-only usando `MUGIWARA_CONTROL_PANEL_API_URL` privada.
+- Añadido read model TS compartido para `UsageCurrentResponse` alineado con el backend 17.1.
+- Añadido guardrail `npm run verify:usage-server-only`.
+- Actualizadas docs frontend y baseline visual para incluir `/usage`.
+
+## Fuera de alcance preservado
+- Calendario por fecha natural: 17.3.
+- Ventanas 5h históricas y endpoints adicionales: 17.3/17.4 según corte final.
+- Actividad Hermes agregada: 17.4.
+- Proyecciones/analítica avanzada y cualquier escritura: fuera de 17.2.
+
+## Verify ejecutado
+- `npm run verify:usage-server-only`.
+- `npm --prefix apps/web run typecheck`.
+- `npm --prefix apps/web run build`.
+- `npm run verify:visual-baseline`.
+- `git diff --check`.
+- Smoke HTML dirigido de `http://127.0.0.1:3000/usage` comprobando título, navegación, wording `ciclo semanal Codex`, ausencia de env/URL backend pública y ausencia de secciones futuras de calendario/perfil dominante.
+- Browser smoke desktop de `/usage` con consola limpia y revisión visual sin overflow/layout roto evidente.
+
+## Review esperada
+PR visible frontend + server-only boundary: Usopp para UI/UX/copy/responsive y Chopper para privacidad/no leakage/server-only. Franky no es obligatorio salvo que aparezca objeción sobre semántica operativa del snapshot, porque 17.2 no cambia backend, productor, timer ni fuente SQLite.

--- a/apps/web/src/app/usage/page.tsx
+++ b/apps/web/src/app/usage/page.tsx
@@ -1,0 +1,341 @@
+import type { ResourceStatus } from '@contracts/resource'
+import type { UsageCurrent, UsageWindowStatus } from '@contracts/read-models'
+
+import { fetchUsageCurrent, UsageApiError } from '@/modules/usage/api/usage-http'
+import { usageCurrentFixture } from '@/modules/usage/view-models/usage-current.fixture'
+import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
+import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
+import { StatePanel } from '@/shared/ui/state/StatePanel'
+import { SourceStatePills } from '@/shared/ui/status/SourceStatePills'
+import { StatusBadge } from '@/shared/ui/status/StatusBadge'
+import { appTheme, statusColorMap, type AppStatus } from '@/shared/theme/tokens'
+
+export const dynamic = 'force-dynamic'
+
+type UsageNotice = {
+  status: AppStatus
+  title: string
+  description: string
+  detail?: string
+  sourceStateItems: Array<{ label: string; tone: 'connected' | 'fallback' | 'snapshot' | 'not-realtime' | 'not-configured' | 'degraded' }>
+}
+
+type UsagePageData = {
+  usage: UsageCurrent
+  resourceStatus: ResourceStatus | 'fallback'
+  notice: UsageNotice | null
+  isSnapshotMode: boolean
+}
+
+const windowStatusMap: Record<UsageWindowStatus, { appStatus: AppStatus; label: string; accent: 'sky' | 'gold' | 'success' | 'warning' | 'danger' }> = {
+  normal: { appStatus: 'operativo', label: 'Normal', accent: 'success' },
+  high: { appStatus: 'revision', label: 'Alto', accent: 'warning' },
+  critical: { appStatus: 'incidencia', label: 'Crítico', accent: 'danger' },
+  limit_reached: { appStatus: 'incidencia', label: 'Límite alcanzado', accent: 'danger' },
+  unknown: { appStatus: 'sin-datos', label: 'Sin datos', accent: 'sky' },
+}
+
+const recommendationStatusMap: Record<UsageCurrent['recommendation']['state'], AppStatus> = {
+  normal: 'operativo',
+  alto: 'revision',
+  critico: 'incidencia',
+  limite_alcanzado: 'incidencia',
+  datos_antiguos: 'stale',
+  sin_datos: 'sin-datos',
+}
+
+async function getInitialUsageData(): Promise<UsagePageData> {
+  try {
+    const response = await fetchUsageCurrent()
+    const usage = response.data
+
+    if (response.status !== 'ready') {
+      return {
+        usage,
+        resourceStatus: response.status,
+        isSnapshotMode: response.status === 'stale',
+        notice: noticeFromResourceStatus(response.status),
+      }
+    }
+
+    return {
+      usage,
+      resourceStatus: response.status,
+      notice: null,
+      isSnapshotMode: false,
+    }
+  } catch (error) {
+    const apiError = error instanceof UsageApiError ? error : null
+
+    return {
+      usage: usageCurrentFixture,
+      resourceStatus: 'fallback',
+      isSnapshotMode: true,
+      notice: {
+        status: apiError?.code === 'not_configured' ? 'revision' : 'incidencia',
+        title:
+          apiError?.code === 'not_configured'
+            ? 'Usage en modo fallback local'
+            : apiError?.code === 'invalid_config'
+              ? 'Configuración server-only de Usage inválida'
+              : 'API Usage no disponible',
+        description:
+          apiError?.code === 'not_configured'
+            ? 'Mostrando snapshot local saneado. Estos datos sostienen la navegación, pero no representan lectura real ni tiempo real.'
+            : 'La página mantiene fallback saneado local. No se muestran detalles internos del backend ni salidas operativas crudas.',
+        detail: apiError?.code ? `Estado técnico: ${apiError.code}` : undefined,
+        sourceStateItems: [
+          { label: 'Modo fallback local', tone: 'fallback' },
+          { label: 'Snapshot saneado', tone: 'snapshot' },
+          { label: 'No tiempo real', tone: 'not-realtime' },
+        ],
+      },
+    }
+  }
+}
+
+function noticeFromResourceStatus(status: ResourceStatus): UsageNotice | null {
+  if (status === 'ready') {
+    return null
+  }
+
+  if (status === 'stale') {
+    return {
+      status: 'stale',
+      title: 'Usage con datos antiguos',
+      description: 'El snapshot existe, pero no es reciente. La lectura sigue siendo saneada y read-only; revisa el timer si el estado persiste.',
+      detail: 'Estado técnico: stale',
+      sourceStateItems: [
+        { label: 'API real conectada', tone: 'connected' },
+        { label: 'Snapshot saneado', tone: 'snapshot' },
+        { label: 'Datos antiguos', tone: 'not-realtime' },
+      ],
+    }
+  }
+
+  if (status === 'not_configured') {
+    return {
+      status: 'revision',
+      title: 'Usage sin fuente configurada',
+      description: 'Aún no hay snapshot disponible para Usage. La página se mantiene en modo solo lectura y sin detalles internos del host.',
+      detail: 'Estado técnico: not_configured',
+      sourceStateItems: [
+        { label: 'Fuente no configurada', tone: 'not-configured' },
+        { label: 'No tiempo real', tone: 'not-realtime' },
+      ],
+    }
+  }
+
+  return {
+    status: 'revision',
+    title: 'Usage degradado',
+    description: 'La API respondió sin lectura lista. Se muestra el estado degradado sin filtrar detalles internos.',
+    detail: `Estado técnico: ${status}`,
+    sourceStateItems: [
+      { label: 'Error/degradado', tone: 'degraded' },
+      { label: 'No tiempo real', tone: 'not-realtime' },
+    ],
+  }
+}
+
+function formatTimestamp(value: string | null) {
+  if (!value) {
+    return 'Fecha no disponible'
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return 'Fecha no disponible'
+  }
+
+  return new Intl.DateTimeFormat('es-ES', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date)
+}
+
+function formatPercent(value: number | null) {
+  if (value === null) {
+    return '—'
+  }
+
+  return `${Math.round(value)}%`
+}
+
+function formatResetAfter(seconds: number | null) {
+  if (seconds === null) {
+    return 'Tiempo restante no disponible'
+  }
+
+  if (seconds <= 0) {
+    return 'Reset pendiente de refresco'
+  }
+
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+
+  if (hours > 0) {
+    return `${hours} h ${minutes} min restantes`
+  }
+
+  return `${minutes} min restantes`
+}
+
+function formatBoolean(value: boolean | null) {
+  if (value === null) {
+    return 'No disponible'
+  }
+
+  return value ? 'Sí' : 'No'
+}
+
+function windowStatusToBadge(status: UsageWindowStatus) {
+  return windowStatusMap[status]
+}
+
+function UsageProgressBar({ value, status }: { value: number | null; status: UsageWindowStatus }) {
+  const width = value === null ? 0 : Math.max(0, Math.min(100, value))
+  const badge = windowStatusToBadge(status)
+  const color = statusColorMap[badge.appStatus]
+
+  return (
+    <div
+      aria-label={`Uso actual ${formatPercent(value)}`}
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={value ?? undefined}
+      style={{
+        width: '100%',
+        height: '10px',
+        borderRadius: '999px',
+        background: 'rgba(255,255,255,0.10)',
+        overflow: 'hidden',
+        margin: '12px 0',
+      }}
+    >
+      <div
+        style={{
+          width: `${width}%`,
+          height: '100%',
+          borderRadius: '999px',
+          background: color,
+        }}
+      />
+    </div>
+  )
+}
+
+function WindowCard({
+  title,
+  window,
+  emphasis = false,
+}: {
+  title: string
+  window: UsageCurrent['primary_window'] | UsageCurrent['secondary_cycle']
+  emphasis?: boolean
+}) {
+  const status = windowStatusToBadge(window.status)
+
+  return (
+    <SurfaceCard title={title} eyebrow={window.label} accent={emphasis ? 'gold' : status.accent} elevated={emphasis}>
+      <p style={{ margin: '0 0 8px', fontSize: emphasis ? '34px' : '30px', fontWeight: 800 }}>{formatPercent(window.used_percent)}</p>
+      <UsageProgressBar value={window.used_percent} status={window.status} />
+      <div style={{ display: 'grid', gap: '8px', color: appTheme.colors.textSecondary }}>
+        <p style={{ margin: 0 }}>Rango: {formatTimestamp(window.started_at)} → {formatTimestamp(window.reset_at)}</p>
+        <p style={{ margin: 0 }}>Reset: {formatResetAfter(window.reset_after_seconds)}</p>
+      </div>
+      <div style={{ marginTop: '12px' }}>
+        <StatusBadge status={status.appStatus} label={status.label} />
+      </div>
+    </SurfaceCard>
+  )
+}
+
+export default async function UsagePage() {
+  const { usage, notice, isSnapshotMode } = await getInitialUsageData()
+  const recommendationStatus = recommendationStatusMap[usage.recommendation.state]
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="Uso"
+        title="Uso Codex/Hermes"
+        subtitle="Cuota Codex, ciclos de reset y actividad local saneada. Primera vista read-only centrada en el snapshot actual."
+        mugiwaraSlug="franky"
+        detailPills={[
+          `Plan: ${usage.plan.type}`,
+          `${isSnapshotMode ? 'Corte del snapshot' : 'Última actualización'}: ${formatTimestamp(usage.current_snapshot.captured_at)}`,
+          usage.current_snapshot.source_label,
+          'Solo lectura',
+        ]}
+      />
+
+      {notice ? (
+        <StatePanel
+          status={notice.status}
+          title={notice.title}
+          description={notice.description}
+          detail={notice.detail}
+          eyebrow="Estado de fuente"
+          ariaRole={notice.status === 'incidencia' ? 'alert' : 'region'}
+          ariaLabel="Estado de fuente Usage"
+        >
+          <SourceStatePills items={notice.sourceStateItems} />
+        </StatePanel>
+      ) : null}
+
+      <StatePanel
+        status="revision"
+        title="El ciclo semanal Codex no es calendario lunes-domingo"
+        description={usage.methodology.cycle_copy}
+        eyebrow="Metodología"
+      />
+
+      <section className="layout-grid layout-grid--dashboard-metrics section-block" aria-label="Estado actual de Usage">
+        <WindowCard title="Ventana 5h" window={usage.primary_window} />
+        <WindowCard title="Ciclo semanal Codex" window={usage.secondary_cycle} emphasis />
+        <SurfaceCard title="Plan" eyebrow="Cuenta Codex" accent="sky">
+          <dl style={{ margin: 0, display: 'grid', gap: '10px' }}>
+            <div>
+              <dt style={{ color: appTheme.colors.textMuted, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Tipo</dt>
+              <dd style={{ margin: 0, fontSize: '26px', fontWeight: 800 }}>{usage.plan.type}</dd>
+            </div>
+            <div>
+              <dt style={{ color: appTheme.colors.textMuted, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Permitido</dt>
+              <dd style={{ margin: 0 }}>{formatBoolean(usage.plan.allowed)}</dd>
+            </div>
+            <div>
+              <dt style={{ color: appTheme.colors.textMuted, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Límite alcanzado</dt>
+              <dd style={{ margin: 0 }}>{formatBoolean(usage.plan.limit_reached)}</dd>
+            </div>
+          </dl>
+        </SurfaceCard>
+        <SurfaceCard title="Recomendación actual" eyebrow="Prioridad" accent={recommendationStatus === 'incidencia' ? 'danger' : recommendationStatus === 'revision' ? 'warning' : 'success'} elevated>
+          <p style={{ margin: '0 0 10px', fontSize: '24px', fontWeight: 800 }}>{usage.recommendation.label}</p>
+          <p style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.5 }}>{usage.recommendation.message}</p>
+          <div style={{ marginTop: '12px' }}>
+            <StatusBadge status={recommendationStatus} />
+          </div>
+        </SurfaceCard>
+      </section>
+
+      <section className="section-block layout-grid layout-grid--content-aside">
+        <SurfaceCard title="Qué entra en esta vista" eyebrow="Alcance Phase 17.2" accent="gold">
+          <ul style={{ margin: 0, paddingLeft: '18px', color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
+            <li>Snapshot actual saneado de Codex usage.</li>
+            <li>Ventana 5h y ciclo semanal Codex con rangos calculados por reset.</li>
+            <li>Estado de fuente y recomendación operativa sin datos por conversación.</li>
+            <li>Calendario, ventanas históricas y actividad Hermes agregada quedan para 17.3/17.4.</li>
+          </ul>
+        </SurfaceCard>
+        <SurfaceCard title="Seguridad de datos" eyebrow="Deny by default" accent="sky">
+          <p style={{ marginTop: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>{usage.methodology.privacy}</p>
+          <p style={{ marginBottom: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
+            Fórmulas: {usage.methodology.primary_window_formula}; {usage.methodology.secondary_cycle_formula}.
+          </p>
+        </SurfaceCard>
+      </section>
+    </>
+  )
+}

--- a/apps/web/src/modules/AGENTS.md
+++ b/apps/web/src/modules/AGENTS.md
@@ -7,4 +7,5 @@ Features y módulos funcionales del frontend (dashboard, mugiwaras, skills, memo
 - Mantener una correspondencia clara entre módulo UI y módulo de producto.
 - Evitar dependencias cruzadas desordenadas.
 - **Vigilar `.gitignore`** y no subir mocks, capturas o outputs sensibles no saneados.
+- `usage`: Usage/Codex quota read-only frontend consuming server-only current snapshot adapter. Calendar and Hermes activity stay in later phases.
 - Si nace un módulo nuevo, documentarlo aquí y en docs.

--- a/apps/web/src/modules/usage/AGENTS.md
+++ b/apps/web/src/modules/usage/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md — apps/web/src/modules/usage
+
+## Rol
+Módulo frontend para la superficie `/usage` de uso Codex/Hermes.
+
+## Reglas
+- Consumir Usage desde adapters server-only; no usar `NEXT_PUBLIC_*` ni URL backend en cliente.
+- Mantener la página read-only.
+- Usar siempre `ciclo semanal Codex`; no presentar el ciclo como semana natural lunes-domingo.
+- No exponer prompts, raw conversations, tokens, user/account IDs, headers ni raw payload.
+- Calendario, ventanas históricas y actividad Hermes agregada pertenecen a fases posteriores separadas.

--- a/apps/web/src/modules/usage/api/usage-http.ts
+++ b/apps/web/src/modules/usage/api/usage-http.ts
@@ -1,0 +1,126 @@
+import 'server-only'
+
+import http from 'node:http'
+import https from 'node:https'
+
+import type { UsageCurrentResponse } from '@contracts/read-models'
+
+export const USAGE_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'
+
+export class UsageApiError extends Error {
+  status: number
+  code: string
+
+  constructor(message: string, options: { status: number; code: string }) {
+    super(message)
+    this.name = 'UsageApiError'
+    this.status = options.status
+    this.code = options.code
+  }
+}
+
+type ApiErrorPayload = {
+  detail?: {
+    code?: string
+    message?: string
+  }
+}
+
+function trimTrailingSlash(value: string) {
+  return value.replace(/\/$/, '')
+}
+
+function parseUsageApiBaseUrl(value: string) {
+  let parsed: URL
+
+  try {
+    parsed = new URL(value)
+  } catch {
+    throw new UsageApiError('invalid_config', { status: 0, code: 'invalid_config' })
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new UsageApiError('invalid_config', { status: 0, code: 'invalid_config' })
+  }
+
+  return trimTrailingSlash(value)
+}
+
+export function getUsageApiBaseUrl() {
+  const value = process.env[USAGE_API_BASE_URL_ENV]
+  return value ? parseUsageApiBaseUrl(value) : null
+}
+
+function apiErrorFromPayload(payload: ApiErrorPayload | null, status: number) {
+  return new UsageApiError(payload?.detail?.message ?? `http_${status}`, {
+    status,
+    code: payload?.detail?.code ?? `http_${status}`,
+  })
+}
+
+function parseJsonPayload<T>(body: string): T {
+  try {
+    return JSON.parse(body) as T
+  } catch {
+    throw new UsageApiError('invalid_json', { status: 0, code: 'invalid_json' })
+  }
+}
+
+async function requestUsageJson(url: string): Promise<UsageCurrentResponse> {
+  const parsed = new URL(url)
+  const transport = parsed.protocol === 'https:' ? https : http
+
+  return new Promise((resolve, reject) => {
+    const request = transport.request(
+      parsed,
+      {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        timeout: 5000,
+      },
+      (response) => {
+        const chunks: Buffer[] = []
+        response.on('data', (chunk: Buffer) => chunks.push(chunk))
+        response.on('end', () => {
+          const body = Buffer.concat(chunks).toString('utf8')
+          const status = response.statusCode ?? 0
+
+          if (status < 200 || status >= 300) {
+            let payload: ApiErrorPayload | null = null
+            try {
+              payload = JSON.parse(body) as ApiErrorPayload
+            } catch {
+              payload = null
+            }
+            reject(apiErrorFromPayload(payload, status))
+            return
+          }
+
+          try {
+            resolve(parseJsonPayload<UsageCurrentResponse>(body))
+          } catch (error) {
+            reject(error)
+          }
+        })
+      },
+    )
+
+    request.on('timeout', () => {
+      request.destroy(new UsageApiError('timeout', { status: 0, code: 'timeout' }))
+    })
+    request.on('error', (error) => {
+      reject(error instanceof UsageApiError ? error : new UsageApiError('fetch_failed', { status: 0, code: 'fetch_failed' }))
+    })
+    request.end()
+  })
+}
+
+export async function fetchUsageCurrent(): Promise<UsageCurrentResponse> {
+  const baseUrl = getUsageApiBaseUrl()
+
+  if (!baseUrl) {
+    throw new UsageApiError('not_configured', { status: 0, code: 'not_configured' })
+  }
+
+  return requestUsageJson(`${baseUrl}/api/v1/usage/current`)
+}

--- a/apps/web/src/modules/usage/view-models/usage-current.fixture.ts
+++ b/apps/web/src/modules/usage/view-models/usage-current.fixture.ts
@@ -1,0 +1,48 @@
+import type { UsageCurrent } from '@contracts/read-models'
+
+export const usageCurrentFixture: UsageCurrent = {
+  current_snapshot: {
+    captured_at: '2026-04-26T14:29:29+00:00',
+    source_label: 'snapshot cada 15 min',
+    freshness: {
+      state: 'stale',
+      age_minutes: null,
+      label: 'Snapshot local saneado',
+    },
+  },
+  plan: {
+    type: 'prolite',
+    allowed: true,
+    limit_reached: false,
+    additional_limits_count: 1,
+  },
+  primary_window: {
+    label: 'Ventana 5h',
+    used_percent: 26,
+    window_seconds: 18000,
+    started_at: '2026-04-26T10:04:43+00:00',
+    reset_at: '2026-04-26T15:04:43+00:00',
+    reset_after_seconds: null,
+    status: 'normal',
+  },
+  secondary_cycle: {
+    label: 'Ciclo semanal Codex',
+    used_percent: 90,
+    window_seconds: 604800,
+    started_at: '2026-04-21T18:25:51+00:00',
+    reset_at: '2026-04-28T18:25:51+00:00',
+    reset_after_seconds: null,
+    status: 'high',
+  },
+  recommendation: {
+    state: 'alto',
+    label: 'Alto',
+    message: 'Conviene vigilar. Prioriza tareas importantes y evita exploraciones largas.',
+  },
+  methodology: {
+    cycle_copy: 'Codex no usa el calendario lunes-domingo: el ciclo semanal Codex va desde el reset anterior hasta el próximo reset.',
+    primary_window_formula: 'primary_reset_at - 18000s → primary_reset_at',
+    secondary_cycle_formula: 'secondary_reset_at - 604800s → secondary_reset_at',
+    privacy: 'Lectura agregada y saneada: sin email, user_id, account_id, tokens, headers, prompts ni raw payload.',
+  },
+}

--- a/apps/web/src/shared/ui/navigation/SidebarNav.tsx
+++ b/apps/web/src/shared/ui/navigation/SidebarNav.tsx
@@ -14,6 +14,7 @@ const routes = [
   { href: '/memory', label: 'Memory', icon: '◎' },
   { href: '/vault', label: 'Vault', icon: '◈' },
   { href: '/healthcheck', label: 'Healthcheck', icon: '✓' },
+  { href: '/usage', label: 'Uso', icon: '◌' },
 ] as const
 
 type SidebarNavProps = {

--- a/docs/frontend-implementation-handoff.md
+++ b/docs/frontend-implementation-handoff.md
@@ -44,6 +44,7 @@ Después:
 - `memory`
 - `vault`
 - `healthcheck`
+- `usage` current-state
 
 ## Fase 3 — pantalla productiva
 Después:
@@ -86,6 +87,7 @@ apps/web/src/app/
   vault/page.tsx
   vault/[...path]/page.tsx          # opcional si la navegación es por ruta
   healthcheck/page.tsx
+  usage/page.tsx                    # Usage Codex/Hermes current-state
 ```
 
 ## 3.2 Módulos funcionales
@@ -113,6 +115,10 @@ apps/web/src/modules/
     index.ts
   healthcheck/
     components/
+    view-models/
+    index.ts
+  usage/
+    api/
     view-models/
     index.ts
 ```

--- a/docs/frontend-ui-spec.md
+++ b/docs/frontend-ui-spec.md
@@ -66,6 +66,7 @@ Diseñar un shell de navegación estable y escaneable que:
 4. `memory`
 5. `vault`
 6. `healthcheck`
+7. `usage`
 
 ## 2.2 Jerarquía de rutas sugerida
 ```text
@@ -81,7 +82,8 @@ Diseñar un shell de navegación estable y escaneable que:
 │   └── /memory/[slug]             # opcional o resuelto por selector/tab
 ├── /vault
 │   └── /vault/[...path]           # navegación documental si se implementa por ruta
-└── /healthcheck
+├── /healthcheck
+└── /usage                         # Usage Codex/Hermes current-state; calendario en fases posteriores
 ```
 
 ## 2.3 IA del shell
@@ -92,6 +94,7 @@ Diseñar un shell de navegación estable y escaneable que:
 - Memory
 - Vault
 - Healthcheck
+- Uso
 
 ### Topbar
 - identidad del producto

--- a/openspec/phase-17-2-usage-current-ui.md
+++ b/openspec/phase-17-2-usage-current-ui.md
@@ -1,0 +1,63 @@
+# Phase 17.2 — Usage current-state UI
+
+## Decisión de corte
+No divido 17.2 en subfases adicionales.
+
+Motivo: tras inspeccionar el estado real, 17.2 es homogénea y pequeña si se mantiene estrictamente como **UI current-state**:
+- navegación `Uso`;
+- ruta `/usage`;
+- adapter server-only a `GET /api/v1/usage/current`;
+- header, cuatro cards superiores, callout de metodología y estados degradados visibles.
+
+Sí quedan fuera, y ya están separadas en 17.3/17.4:
+- calendario por fecha natural;
+- endpoints nuevos de calendar/five-hour-windows/hermes-activity;
+- actividad Hermes agregada;
+- proyecciones o analítica avanzada.
+
+Si durante implementación aparece necesidad de crear nuevos endpoints backend o leer nuevas fuentes, se corta la fase y pasa a 17.3+.
+
+## Objetivo
+Materializar la primera página visible `/usage` usando solo el read model ya cerrado en 17.1, sin ampliar la superficie backend ni mezclar calendarios o actividad Hermes.
+
+## Alcance
+- Añadir navegación principal `Uso`.
+- Añadir ruta server-side `/usage`.
+- Crear módulo frontend `usage` con adapter server-only.
+- Usar `MUGIWARA_CONTROL_PANEL_API_URL` privada, no `NEXT_PUBLIC_*`.
+- Renderizar:
+  - título `Uso Codex/Hermes`;
+  - subtítulo `Cuota Codex, ciclos de reset y actividad local saneada.`;
+  - pills: plan, última actualización, fuente snapshot cada 15 min, solo lectura;
+  - cuatro cards: Ventana 5h, Ciclo semanal Codex, Plan, Recomendación actual;
+  - callout de que Codex no usa semanas lunes-domingo;
+  - metodología mínima de fórmulas `primary_reset_at - 18000s` y `secondary_reset_at - 604800s`;
+  - estado de fuente/fallback/stale/not_configured visible.
+
+## Fuera de alcance
+- `GET /api/v1/usage/calendar`.
+- `GET /api/v1/usage/five-hour-windows`.
+- `GET /api/v1/usage/hermes-activity`.
+- Actividad Hermes local, tokens, sesiones, mensajes o tool calls.
+- Modificar `/uso` de Telegram.
+- Acciones de escritura o export.
+
+## DoD
+- `/usage` compila y aparece en navegación.
+- La página no usa browser-side backend URL ni `NEXT_PUBLIC_*`.
+- La UI nunca llama “semana” a secas al ciclo; usa `ciclo semanal Codex`.
+- Stale/not_configured/error se muestran como estado degradado, no como sano.
+- En mobile las cards pasan a una columna mediante utilidades responsive existentes.
+- Docs/Engram quedan actualizados.
+
+## Verify esperado
+- `npm --prefix apps/web run typecheck`.
+- `npm --prefix apps/web run build`.
+- `npm run verify:visual-baseline`.
+- `git diff --check`.
+- Smoke HTML o browser dirigido para comprobar `/usage`, navegación `Uso` y ausencia de `NEXT_PUBLIC`/backend URL en el render.
+
+## Review esperada
+- Usopp: UI/UX/responsive/copy visible.
+- Chopper: copy de privacidad/no leakage y server-only boundary.
+- Franky: opcional si no cambia fuente/runtime; pedirlo si detectamos riesgo operativo nuevo.

--- a/openspec/phase-17-2-verify-checklist.md
+++ b/openspec/phase-17-2-verify-checklist.md
@@ -1,0 +1,23 @@
+# Phase 17.2 verify checklist
+
+## Scope decision
+- [x] 17.2 no se divide más: microfase única UI current-state.
+- [x] Calendario, ventanas históricas y Hermes activity quedan fuera en 17.3/17.4.
+- [x] No se crean endpoints backend nuevos.
+
+## Implementation checklist
+- [x] Navegación incluye `Uso` → `/usage`.
+- [x] `/usage` usa server-only adapter contra `GET /api/v1/usage/current`.
+- [x] No hay `NEXT_PUBLIC_*` ni backend URL browser-side.
+- [x] Header muestra título, subtítulo, plan, última actualización, fuente y solo lectura.
+- [x] Cards muestran ventana 5h, ciclo semanal Codex, plan y recomendación.
+- [x] Copy explica que Codex no cuenta semanas lunes-domingo.
+- [x] Estados `stale`, `not_configured` y error degradan visibles sin detalles internos.
+
+## Verify evidence
+- [x] `npm run verify:usage-server-only`.
+- [x] `npm --prefix apps/web run typecheck`.
+- [x] `npm --prefix apps/web run build`.
+- [x] `npm run verify:visual-baseline`.
+- [x] `git diff --check`.
+- [x] Smoke dirigido `/usage`: HTML smoke + browser smoke desktop con consola limpia.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "verify:gateway-status-runner": "node scripts/check-gateway-status-runner.mjs",
     "verify:cronjobs-status-runner": "node scripts/check-cronjobs-status-runner.mjs",
     "verify:statepanel-aria": "node scripts/check-statepanel-aria.mjs",
+    "verify:usage-server-only": "node scripts/check-usage-server-only.mjs",
     "write:project-health-status": "python3 scripts/write-project-health-status.py",
     "write:gateway-status": "python3 scripts/write-gateway-status.py",
     "write:cronjobs-status": "python3 scripts/write-cronjobs-status.py",

--- a/packages/contracts/src/read-models.ts
+++ b/packages/contracts/src/read-models.ts
@@ -166,6 +166,57 @@ export type SystemSignal = {
   freshness: Freshness
 }
 
+export type UsageFreshness = {
+  state: 'fresh' | 'stale' | 'unknown'
+  age_minutes: number | null
+  label: string
+}
+
+export type UsageWindowStatus = 'normal' | 'high' | 'critical' | 'limit_reached' | 'unknown'
+
+export type UsageCurrent = {
+  current_snapshot: {
+    captured_at: string | null
+    source_label: string
+    freshness: UsageFreshness
+  }
+  plan: {
+    type: string
+    allowed: boolean | null
+    limit_reached: boolean | null
+    additional_limits_count: number
+  }
+  primary_window: {
+    label: 'Ventana 5h'
+    used_percent: number | null
+    window_seconds: number | null
+    started_at: string | null
+    reset_at: string | null
+    reset_after_seconds: number | null
+    status: UsageWindowStatus
+  }
+  secondary_cycle: {
+    label: 'Ciclo semanal Codex'
+    used_percent: number | null
+    window_seconds: number | null
+    started_at: string | null
+    reset_at: string | null
+    reset_after_seconds: number | null
+    status: UsageWindowStatus
+  }
+  recommendation: {
+    state: 'normal' | 'alto' | 'critico' | 'limite_alcanzado' | 'datos_antiguos' | 'sin_datos'
+    label: string
+    message: string
+  }
+  methodology: {
+    cycle_copy: string
+    primary_window_formula: string
+    secondary_cycle_formula: string
+    privacy: string
+  }
+}
+
 export type DashboardSummaryResponse = ResourceEnvelope<DashboardSummary, { links_count: number }>
 export type MugiwarasCatalogResponse = ResourceEnvelope<{ items: MugiwaraCard[]; crew_rules_document: CrewRulesDocument }, { count: number; crew_rules_document: string; read_only: true }>
 export type MugiwaraProfileResponse = ResourceEnvelope<MugiwaraProfile, { slug: string; read_only: true }>
@@ -175,4 +226,5 @@ export type VaultIndexResponse = ResourceEnvelope<VaultIndex, { safe_root: strin
 export type VaultDocumentResponse = ResourceEnvelope<VaultDocument, { path: string; markdown_only: true }>
 export type HealthcheckWorkspaceResponse = ResourceEnvelope<HealthcheckWorkspace, { count: number; read_only: true; sanitized: true; source: string }>
 export type HealthcheckSummaryResponse = ResourceEnvelope<{ items: HealthcheckSummary[] }, { count: number }>
+export type UsageCurrentResponse = ResourceEnvelope<UsageCurrent, { read_only: true; sanitized: true; source: string; refresh_interval_minutes: number }>
 export type SystemSignalsResponse = ResourceEnvelope<{ items: SystemSignal[] }, { count: number }>

--- a/scripts/check-usage-server-only.mjs
+++ b/scripts/check-usage-server-only.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/** Static safety check for Phase 17.2 Usage server-only integration. */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = process.cwd()
+const httpPath = join(repoRoot, 'apps/web/src/modules/usage/api/usage-http.ts')
+const pagePath = join(repoRoot, 'apps/web/src/app/usage/page.tsx')
+const navPath = join(repoRoot, 'apps/web/src/shared/ui/navigation/SidebarNav.tsx')
+const failures = []
+
+const http = readFileSync(httpPath, 'utf8')
+const page = readFileSync(pagePath, 'utf8')
+const nav = readFileSync(navPath, 'utf8')
+
+if (!http.includes("import 'server-only'")) {
+  failures.push('usage http adapter must be server-only guarded')
+}
+if (!http.includes("USAGE_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'")) {
+  failures.push('usage http adapter must use MUGIWARA_CONTROL_PANEL_API_URL')
+}
+if (http.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL') || page.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL')) {
+  failures.push('usage must not use public backend env')
+}
+if (!http.includes('/api/v1/usage/current')) {
+  failures.push('usage adapter must call the fixed current endpoint')
+}
+if (http.includes('path=') || http.includes('target=') || http.includes('method=')) {
+  failures.push('usage adapter must not grow generic proxy parameters')
+}
+if (!http.includes("parsed.protocol !== 'http:'") || !http.includes("parsed.protocol !== 'https:'")) {
+  failures.push('usage http adapter must reject non-http(s) API base URLs')
+}
+if (http.includes('fetch(')) {
+  failures.push('usage http adapter must avoid Next.js instrumented fetch metadata for backend URL secrecy')
+}
+if (!page.includes("export const dynamic = 'force-dynamic'")) {
+  failures.push('usage page must force dynamic rendering')
+}
+if (page.includes("'use client'")) {
+  failures.push('usage page must remain a server page')
+}
+if (page.includes('process.env')) {
+  failures.push('usage page must not read backend env directly')
+}
+if (!page.includes('Ciclo semanal Codex') || !page.includes('ciclo semanal Codex')) {
+  failures.push('usage page must render ciclo semanal Codex wording')
+}
+if (!nav.includes("href: '/usage'") || !nav.includes("label: 'Uso'")) {
+  failures.push('sidebar navigation must expose Uso /usage')
+}
+
+if (failures.length > 0) {
+  console.error('Usage server-only integration check failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log('Usage server-only integration check passed')

--- a/scripts/visual-verify-baseline.mjs
+++ b/scripts/visual-verify-baseline.mjs
@@ -97,6 +97,17 @@ const routes = [
       'ninguna card crítica rompe el grid en tablet',
     ],
   },
+  {
+    path: '/usage',
+    title: 'Uso Codex/Hermes',
+    checks: [
+      'las cards de ventana 5h, ciclo semanal Codex, plan y recomendación apilan sin overflow',
+      'el ciclo se etiqueta como ciclo semanal Codex y no como calendario lunes-domingo',
+      'stale, not_configured o fallback quedan visibles como fuente degradada/no tiempo real',
+      'fórmulas y privacidad hacen wrap sin filtrar detalles internos del host',
+      'no aparecen calendario, ventanas históricas ni actividad Hermes antes de sus fases',
+    ],
+  },
 ]
 
 function renderMarkdown() {


### PR DESCRIPTION
## Summary
- Decide Phase 17.2 does not need further subphases: current-state UI is homogeneous and bounded.
- Add read-only `/usage` server page, sidebar navigation `Uso`, server-only Usage adapter and fallback snapshot.
- Add shared TS read model, Usage server-only guardrail, frontend docs/OpenSpec/Engram closeout and visual baseline entry.

## Scope boundaries
- No new backend endpoints.
- No calendar, historical 5h windows, Hermes activity aggregation or projections.
- No write actions.

## Verification
- `npm run verify:usage-server-only`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build`
- `npm run verify:visual-baseline`
- `git diff --check`
- HTML smoke for `/usage` checking title/nav/ciclo semanal Codex wording/no public env/no backend URL/no future calendar sections
- Browser smoke desktop for `/usage`: console clean, no obvious overflow/layout break

## Review routing
- Usopp: UI/UX/copy/responsive for the new visible `/usage` page.
- Chopper: privacy/no leakage/server-only boundary.