### PR TITLE
feat: add Usage calendar backend

### DIFF
--- a/.engram/phase-17-3a-usage-calendar-backend-closeout.md
+++ b/.engram/phase-17-3a-usage-calendar-backend-closeout.md
@@ -22,7 +22,7 @@
 - No se exponen paths runtime, raw payload, prompts, user/account IDs, tokens ni logs.
 
 ## Verify
-- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q`.
+- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` (6 tests; incluye regresión de reset/cambio de ciclo en la misma fecha natural).
 - `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py`.
 - `npm --prefix apps/web run typecheck`.
 - `git diff --check`.

--- a/.engram/phase-17-3a-usage-calendar-backend-closeout.md
+++ b/.engram/phase-17-3a-usage-calendar-backend-closeout.md
@@ -1,0 +1,29 @@
+# Phase 17.3a — Usage calendar backend closeout
+
+## Decisión
+17.3 se divide en 17.3a backend calendar read model y 17.3b UI calendario. Esta subfase cierra solo la frontera backend/contrato.
+
+## Cerrado
+- Endpoint `GET /api/v1/usage/calendar` con `range` allowlisted.
+- Agregación por fecha natural `Europe/Madrid`.
+- `days[]` con tramo Codex, delta diario del ciclo semanal Codex, conteo de ventanas 5h, pico diario 5h y estado diario saneado.
+- Tipos TS compartidos `UsageCalendar*`.
+- Docs `api-modules` y `read-models` actualizadas.
+
+## Fuera de alcance preservado
+- UI calendario en `/usage` queda para 17.3b.
+- Actividad Hermes agregada y perfil dominante siguen fuera hasta 17.4.
+- Endpoint dedicado de ventanas 5h históricas sigue separado.
+
+## Seguridad
+- No se añade escritura.
+- No hay path/url/method recibido como parámetro.
+- Rango inválido devuelve `validation_error` saneado por FastAPI handler.
+- No se exponen paths runtime, raw payload, prompts, user/account IDs, tokens ni logs.
+
+## Verify
+- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q`.
+- `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py`.
+- `npm --prefix apps/web run typecheck`.
+- `git diff --check`.
+- Smoke API real/TestClient de `/api/v1/usage/calendar?range=current_cycle` contra SQLite runtime saneada.

--- a/apps/api/src/modules/usage/router.py
+++ b/apps/api/src/modules/usage/router.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 
 from ...shared.contracts import resource_response
-from .service import USAGE_REFRESH_INTERVAL_MINUTES, UsageService
+from .service import USAGE_REFRESH_INTERVAL_MINUTES, UsageCalendarRange, UsageService
 
 router = APIRouter(prefix='/api/v1/usage', tags=['usage'])
 _service = UsageService()
@@ -25,5 +25,22 @@ def get_usage_current(service: UsageService = Depends(get_usage_service)) -> dic
             'sanitized': True,
             'source': 'codex-usage-snapshot-sqlite',
             'refresh_interval_minutes': USAGE_REFRESH_INTERVAL_MINUTES,
+        },
+    )
+
+
+@router.get('/calendar')
+def get_usage_calendar(range: UsageCalendarRange = 'current_cycle', service: UsageService = Depends(get_usage_service)) -> dict:
+    calendar = service.get_calendar(range)
+    return resource_response(
+        resource='usage.calendar',
+        status=service.calendar_status_for(calendar),
+        data=calendar,
+        meta={
+            'read_only': True,
+            'sanitized': True,
+            'source': 'codex-usage-snapshot-sqlite',
+            'range': range,
+            'timezone': 'Europe/Madrid',
         },
     )

--- a/apps/api/src/modules/usage/service.py
+++ b/apps/api/src/modules/usage/service.py
@@ -82,6 +82,18 @@ def _calendar_status(peak_primary: float | None, secondary_delta: float | None) 
     return 'normal'
 
 
+def _positive_delta(values: list[float]) -> float:
+    if len(values) < 2:
+        return 0.0 if len(values) == 1 else 0.0
+    total = 0.0
+    previous = values[0]
+    for value in values[1:]:
+        if value >= previous:
+            total += value - previous
+        previous = value
+    return round(total, 2)
+
+
 @dataclass(frozen=True)
 class UsageSnapshot:
     captured_at: str
@@ -326,9 +338,14 @@ class UsageService:
             elif cycle_reset is not None and cycle_reset.astimezone(USAGE_CALENDAR_TIMEZONE).date() == local_day:
                 reason = 'cycle_resets_today'
 
-            secondary_values = [value for value in (snapshot.secondary_used_percent for snapshot in day_snapshots) if value is not None]
+            secondary_values_by_cycle: dict[tuple[str | None, str | None], list[float]] = {}
+            for snapshot in day_snapshots:
+                if snapshot.secondary_used_percent is None:
+                    continue
+                cycle_key = (snapshot.secondary_cycle_start_at, snapshot.secondary_reset_at)
+                secondary_values_by_cycle.setdefault(cycle_key, []).append(snapshot.secondary_used_percent)
+            secondary_delta = round(sum(_positive_delta(values) for values in secondary_values_by_cycle.values()), 2) if secondary_values_by_cycle else None
             primary_values = [value for value in (snapshot.primary_used_percent for snapshot in day_snapshots) if value is not None]
-            secondary_delta = round(max(secondary_values) - min(secondary_values), 2) if len(secondary_values) >= 2 else 0.0 if len(secondary_values) == 1 else None
             peak_primary = round(max(primary_values), 2) if primary_values else None
             primary_windows = {
                 snapshot.primary_window_start_at

--- a/apps/api/src/modules/usage/service.py
+++ b/apps/api/src/modules/usage/service.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, time, timedelta, timezone
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Literal
+from zoneinfo import ZoneInfo
 import sqlite3
 
 CODEX_USAGE_DB_PATH = Path('/srv/crew-core/runtime/usage/codex-usage.sqlite')
 USAGE_REFRESH_INTERVAL_MINUTES = 15
 USAGE_STALE_AFTER_MINUTES = 45
+USAGE_CALENDAR_TIMEZONE = ZoneInfo('Europe/Madrid')
+UsageCalendarRange = Literal['current_cycle', 'previous_cycle', '7d', '30d']
 
 
 def _parse_datetime(value: str | None) -> datetime | None:
@@ -54,6 +57,27 @@ def _window_status(percent: float | None, *, limit_reached: bool | None = None) 
     if percent >= 95:
         return 'critical'
     if percent >= 80:
+        return 'high'
+    return 'normal'
+
+
+def _isoformat_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _local_midnight(value: datetime) -> datetime:
+    local = value.astimezone(USAGE_CALENDAR_TIMEZONE)
+    return datetime.combine(local.date(), time.min, tzinfo=USAGE_CALENDAR_TIMEZONE)
+
+
+def _calendar_status(peak_primary: float | None, secondary_delta: float | None) -> str:
+    if peak_primary is None and secondary_delta is None:
+        return 'unknown'
+    if peak_primary is not None and peak_primary >= 95:
+        return 'critical'
+    if peak_primary is not None and peak_primary >= 80:
+        return 'high'
+    if secondary_delta is not None and secondary_delta >= 25:
         return 'high'
     return 'normal'
 
@@ -148,6 +172,52 @@ class UsageService:
             },
         }
 
+    def get_calendar(self, range_name: UsageCalendarRange) -> dict[str, Any]:
+        latest = self._load_latest_snapshot()
+        if latest is None:
+            return {
+                'range': range_name,
+                'timezone': 'Europe/Madrid',
+                'current_cycle': None,
+                'days': [],
+                'empty_reason': 'not_configured',
+            }
+
+        latest_captured = _parse_datetime(latest.captured_at)
+        cycle_start = _parse_datetime(latest.secondary_cycle_start_at)
+        cycle_reset = _parse_datetime(latest.secondary_reset_at)
+        if latest_captured is None:
+            return {
+                'range': range_name,
+                'timezone': 'Europe/Madrid',
+                'current_cycle': None,
+                'days': [],
+                'empty_reason': 'unknown',
+            }
+
+        start_at, end_at = self._calendar_window(range_name, latest_captured, cycle_start, cycle_reset)
+        snapshots = self._load_snapshots_between(start_at, end_at)
+        return {
+            'range': range_name,
+            'timezone': 'Europe/Madrid',
+            'current_cycle': {
+                'started_at': latest.secondary_cycle_start_at,
+                'reset_at': latest.secondary_reset_at,
+                'label': 'Ciclo semanal Codex',
+            },
+            'days': self._calendar_days(snapshots, start_at=start_at, end_at=end_at, cycle_start=cycle_start, cycle_reset=cycle_reset),
+        }
+
+    @staticmethod
+    def calendar_status_for(payload: dict[str, Any]) -> str:
+        if payload.get('empty_reason') == 'not_configured':
+            return 'not_configured'
+        if payload.get('empty_reason') == 'unknown':
+            return 'unknown'
+        if len(payload.get('days', [])) == 0:
+            return 'not_configured'
+        return 'ready'
+
     def _empty_current(self) -> dict[str, Any]:
         return {
             'current_snapshot': {
@@ -208,6 +278,81 @@ class UsageService:
             return {'state': 'alto', 'label': 'Alto', 'message': 'Conviene vigilar. Prioriza tareas importantes y evita exploraciones largas.'}
         return {'state': 'normal', 'label': 'Normal', 'message': 'Uso dentro de rango. Ritmo sano.'}
 
+    def _calendar_window(
+        self,
+        range_name: UsageCalendarRange,
+        latest_captured: datetime,
+        cycle_start: datetime | None,
+        cycle_reset: datetime | None,
+    ) -> tuple[datetime, datetime]:
+        if range_name == 'current_cycle' and cycle_start is not None and cycle_reset is not None:
+            return cycle_start, min(latest_captured, cycle_reset)
+        if range_name == 'previous_cycle' and cycle_start is not None and cycle_reset is not None:
+            cycle_length = cycle_reset - cycle_start
+            return cycle_start - cycle_length, cycle_start
+        days = 30 if range_name == '30d' else 7
+        end_at = latest_captured
+        start_at = _local_midnight(latest_captured) - timedelta(days=days - 1)
+        return start_at.astimezone(timezone.utc), end_at
+
+    def _calendar_days(
+        self,
+        snapshots: list[UsageSnapshot],
+        *,
+        start_at: datetime,
+        end_at: datetime,
+        cycle_start: datetime | None,
+        cycle_reset: datetime | None,
+    ) -> list[dict[str, Any]]:
+        grouped: dict[str, list[UsageSnapshot]] = {}
+        for snapshot in snapshots:
+            captured = _parse_datetime(snapshot.captured_at)
+            if captured is None:
+                continue
+            date_key = captured.astimezone(USAGE_CALENDAR_TIMEZONE).date().isoformat()
+            grouped.setdefault(date_key, []).append(snapshot)
+
+        days: list[dict[str, Any]] = []
+        for date_key in sorted(grouped):
+            day_snapshots = sorted(grouped[date_key], key=lambda item: item.captured_at)
+            local_day = datetime.fromisoformat(date_key).date()
+            day_start = datetime.combine(local_day, time.min, tzinfo=USAGE_CALENDAR_TIMEZONE)
+            day_end = day_start + timedelta(days=1)
+            segment_start = max(day_start, start_at.astimezone(USAGE_CALENDAR_TIMEZONE))
+            segment_end = min(day_end, end_at.astimezone(USAGE_CALENDAR_TIMEZONE))
+            reason = None
+            if cycle_start is not None and cycle_start.astimezone(USAGE_CALENDAR_TIMEZONE).date() == local_day:
+                reason = 'cycle_started_today'
+            elif cycle_reset is not None and cycle_reset.astimezone(USAGE_CALENDAR_TIMEZONE).date() == local_day:
+                reason = 'cycle_resets_today'
+
+            secondary_values = [value for value in (snapshot.secondary_used_percent for snapshot in day_snapshots) if value is not None]
+            primary_values = [value for value in (snapshot.primary_used_percent for snapshot in day_snapshots) if value is not None]
+            secondary_delta = round(max(secondary_values) - min(secondary_values), 2) if len(secondary_values) >= 2 else 0.0 if len(secondary_values) == 1 else None
+            peak_primary = round(max(primary_values), 2) if primary_values else None
+            primary_windows = {
+                snapshot.primary_window_start_at
+                for snapshot in day_snapshots
+                if snapshot.primary_window_start_at is not None
+            }
+
+            days.append(
+                {
+                    'date': date_key,
+                    'codex_segment': {
+                        'started_at': _isoformat_utc(segment_start),
+                        'ended_at': _isoformat_utc(segment_end),
+                        'partial': reason is not None,
+                        'reason': reason,
+                    },
+                    'secondary_delta_percent': secondary_delta,
+                    'primary_windows_count': len(primary_windows),
+                    'peak_primary_used_percent': peak_primary,
+                    'status': _calendar_status(peak_primary, secondary_delta),
+                }
+            )
+        return days
+
     def _load_latest_snapshot(self) -> UsageSnapshot | None:
         if not self.db_path.exists() or not self.db_path.is_file():
             return None
@@ -247,6 +392,49 @@ class UsageService:
 
         if row is None:
             return None
+        return self._snapshot_from_row(row)
+
+    def _load_snapshots_between(self, start_at: datetime, end_at: datetime) -> list[UsageSnapshot]:
+        if not self.db_path.exists() or not self.db_path.is_file():
+            return []
+        try:
+            con = sqlite3.connect(f'file:{self.db_path}?mode=ro', uri=True)
+            con.row_factory = sqlite3.Row
+            rows = con.execute(
+                """
+                SELECT
+                    captured_at,
+                    plan_type,
+                    allowed,
+                    limit_reached,
+                    primary_used_percent,
+                    primary_window_seconds,
+                    primary_window_start_at,
+                    primary_reset_at,
+                    primary_reset_after_seconds,
+                    secondary_used_percent,
+                    secondary_window_seconds,
+                    secondary_cycle_start_at,
+                    secondary_reset_at,
+                    secondary_reset_after_seconds,
+                    additional_limits_count
+                FROM codex_usage_snapshots
+                WHERE captured_at_epoch >= ? AND captured_at_epoch <= ?
+                ORDER BY captured_at_epoch ASC, id ASC
+                """,
+                (int(start_at.timestamp()), int(end_at.timestamp())),
+            ).fetchall()
+        except sqlite3.Error:
+            return []
+        finally:
+            try:
+                con.close()
+            except UnboundLocalError:
+                pass
+        return [self._snapshot_from_row(row) for row in rows]
+
+    @staticmethod
+    def _snapshot_from_row(row: sqlite3.Row) -> UsageSnapshot:
         return UsageSnapshot(
             captured_at=str(row['captured_at']),
             plan_type=row['plan_type'],

--- a/apps/api/tests/test_usage_api.py
+++ b/apps/api/tests/test_usage_api.py
@@ -297,3 +297,63 @@ def test_usage_calendar_rejects_unknown_ranges_without_echoing_sensitive_values(
     payload = response.json()
     assert payload == {'detail': {'code': 'validation_error', 'message': 'Request validation failed.'}}
     assert '/srv/crew-core/runtime/usage' not in str(payload)
+
+
+def test_usage_calendar_does_not_count_cycle_reset_as_daily_delta(tmp_path):
+    db_path = tmp_path / 'codex-usage.sqlite'
+    con = sqlite3.connect(db_path)
+    _create_usage_schema(con)
+    # Same Europe/Madrid natural date, but two different Codex cycles around reset.
+    _insert_usage_snapshot(
+        con,
+        captured_at='2026-04-26T17:30:00+00:00',
+        primary_used_percent=40.0,
+        primary_window_start_at='2026-04-26T13:00:00+00:00',
+        primary_reset_at='2026-04-26T18:00:00+00:00',
+        secondary_used_percent=98.0,
+        secondary_cycle_start_at='2026-04-19T18:25:51+00:00',
+        secondary_reset_at='2026-04-26T18:25:51+00:00',
+    )
+    _insert_usage_snapshot(
+        con,
+        captured_at='2026-04-26T18:20:00+00:00',
+        primary_used_percent=50.0,
+        primary_window_start_at='2026-04-26T13:00:00+00:00',
+        primary_reset_at='2026-04-26T18:25:51+00:00',
+        secondary_used_percent=100.0,
+        secondary_cycle_start_at='2026-04-19T18:25:51+00:00',
+        secondary_reset_at='2026-04-26T18:25:51+00:00',
+    )
+    _insert_usage_snapshot(
+        con,
+        captured_at='2026-04-26T18:30:00+00:00',
+        plan_type='pro',
+        primary_used_percent=0.0,
+        primary_window_start_at='2026-04-26T18:25:51+00:00',
+        primary_reset_at='2026-04-26T23:25:51+00:00',
+        secondary_used_percent=0.0,
+        secondary_cycle_start_at='2026-04-26T18:25:51+00:00',
+        secondary_reset_at='2026-05-03T18:25:51+00:00',
+    )
+    _insert_usage_snapshot(
+        con,
+        captured_at='2026-04-26T19:30:00+00:00',
+        plan_type='pro',
+        primary_used_percent=1.0,
+        primary_window_start_at='2026-04-26T18:25:51+00:00',
+        primary_reset_at='2026-04-26T23:25:51+00:00',
+        secondary_used_percent=2.0,
+        secondary_cycle_start_at='2026-04-26T18:25:51+00:00',
+        secondary_reset_at='2026-05-03T18:25:51+00:00',
+    )
+    con.commit()
+    con.close()
+    _override_usage_service(UsageService(db_path=db_path, now=lambda: '2026-04-26T20:00:00+00:00'))
+
+    response = TestClient(app).get('/api/v1/usage/calendar?range=7d')
+
+    assert response.status_code == 200
+    rows = response.json()['data']['days']
+    reset_day = next(row for row in rows if row['date'] == '2026-04-26')
+    assert reset_day['secondary_delta_percent'] == 4.0
+    assert reset_day['status'] == 'normal'

--- a/apps/api/tests/test_usage_api.py
+++ b/apps/api/tests/test_usage_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+from datetime import datetime
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -12,6 +13,27 @@ from apps.api.src.modules.usage.service import UsageService
 
 def _create_usage_db(path: Path, *, captured_at: str = '2026-04-26T14:29:29+00:00') -> None:
     con = sqlite3.connect(path)
+    _create_usage_schema(con)
+    _insert_usage_snapshot(
+        con,
+        captured_at=captured_at,
+        plan_type='prolite',
+        allowed=1,
+        limit_reached=0,
+        primary_used_percent=26.0,
+        primary_window_start_at='2026-04-26T10:04:43+00:00',
+        primary_reset_at='2026-04-26T15:04:43+00:00',
+        primary_reset_after_seconds=2114,
+        secondary_used_percent=90.0,
+        secondary_cycle_start_at='2026-04-21T18:25:51+00:00',
+        secondary_reset_at='2026-04-28T18:25:51+00:00',
+        secondary_reset_after_seconds=186982,
+    )
+    con.commit()
+    con.close()
+
+
+def _create_usage_schema(con: sqlite3.Connection) -> None:
     con.execute(
         """
         CREATE TABLE codex_usage_snapshots (
@@ -37,6 +59,26 @@ def _create_usage_db(path: Path, *, captured_at: str = '2026-04-26T14:29:29+00:0
         )
         """
     )
+
+
+def _insert_usage_snapshot(
+    con: sqlite3.Connection,
+    *,
+    captured_at: str,
+    plan_type: str = 'prolite',
+    allowed: int = 1,
+    limit_reached: int = 0,
+    primary_used_percent: float = 0.0,
+    primary_window_start_at: str,
+    primary_reset_at: str,
+    primary_reset_after_seconds: int = 0,
+    secondary_used_percent: float,
+    secondary_cycle_start_at: str,
+    secondary_reset_at: str,
+    secondary_reset_after_seconds: int = 0,
+    additional_limits_count: int = 1,
+) -> None:
+    captured_epoch = int(datetime.fromisoformat(captured_at.replace('Z', '+00:00')).timestamp())
     con.execute(
         """
         INSERT INTO codex_usage_snapshots (
@@ -62,27 +104,25 @@ def _create_usage_db(path: Path, *, captured_at: str = '2026-04-26T14:29:29+00:0
         """,
         (
             captured_at,
-            1777213769,
-            'prolite',
-            1,
-            0,
-            26.0,
+            captured_epoch,
+            plan_type,
+            allowed,
+            limit_reached,
+            primary_used_percent,
             18000,
-            '2026-04-26T10:04:43+00:00',
-            '2026-04-26T15:04:43+00:00',
-            2114,
-            90.0,
+            primary_window_start_at,
+            primary_reset_at,
+            primary_reset_after_seconds,
+            secondary_used_percent,
             604800,
-            '2026-04-21T18:25:51+00:00',
-            '2026-04-28T18:25:51+00:00',
-            186982,
-            1,
+            secondary_cycle_start_at,
+            secondary_reset_at,
+            secondary_reset_after_seconds,
+            additional_limits_count,
             'franky',
             1,
         ),
     )
-    con.commit()
-    con.close()
 
 
 def _override_usage_service(service: UsageService):
@@ -168,3 +208,92 @@ def test_usage_current_marks_old_snapshots_as_stale(tmp_path):
     assert payload['status'] == 'stale'
     assert payload['data']['current_snapshot']['freshness']['state'] == 'stale'
     assert payload['data']['recommendation']['state'] == 'datos_antiguos'
+
+
+def test_usage_calendar_current_cycle_groups_by_natural_date_and_marks_partial_segments(tmp_path):
+    db_path = tmp_path / 'codex-usage.sqlite'
+    con = sqlite3.connect(db_path)
+    _create_usage_schema(con)
+    # Cycle starts at 20:25 CEST, so the first natural date is a partial segment.
+    _insert_usage_snapshot(
+        con,
+        captured_at='2026-04-21T18:30:00+00:00',
+        primary_used_percent=5.0,
+        primary_window_start_at='2026-04-21T18:25:51+00:00',
+        primary_reset_at='2026-04-21T23:25:51+00:00',
+        secondary_used_percent=1.0,
+        secondary_cycle_start_at='2026-04-21T18:25:51+00:00',
+        secondary_reset_at='2026-04-28T18:25:51+00:00',
+    )
+    _insert_usage_snapshot(
+        con,
+        captured_at='2026-04-21T21:00:00+00:00',
+        primary_used_percent=25.0,
+        primary_window_start_at='2026-04-21T18:25:51+00:00',
+        primary_reset_at='2026-04-21T23:25:51+00:00',
+        secondary_used_percent=4.0,
+        secondary_cycle_start_at='2026-04-21T18:25:51+00:00',
+        secondary_reset_at='2026-04-28T18:25:51+00:00',
+    )
+    _insert_usage_snapshot(
+        con,
+        captured_at='2026-04-22T10:00:00+00:00',
+        primary_used_percent=80.0,
+        primary_window_start_at='2026-04-22T08:00:00+00:00',
+        primary_reset_at='2026-04-22T13:00:00+00:00',
+        secondary_used_percent=12.5,
+        secondary_cycle_start_at='2026-04-21T18:25:51+00:00',
+        secondary_reset_at='2026-04-28T18:25:51+00:00',
+    )
+    _insert_usage_snapshot(
+        con,
+        captured_at='2026-04-22T16:00:00+00:00',
+        primary_used_percent=30.0,
+        primary_window_start_at='2026-04-22T13:00:00+00:00',
+        primary_reset_at='2026-04-22T18:00:00+00:00',
+        secondary_used_percent=15.0,
+        secondary_cycle_start_at='2026-04-21T18:25:51+00:00',
+        secondary_reset_at='2026-04-28T18:25:51+00:00',
+    )
+    con.commit()
+    con.close()
+    _override_usage_service(UsageService(db_path=db_path, now=lambda: '2026-04-22T16:30:00+00:00'))
+
+    response = TestClient(app).get('/api/v1/usage/calendar?range=current_cycle')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'usage.calendar'
+    assert payload['status'] == 'ready'
+    assert payload['meta'] == {
+        'read_only': True,
+        'sanitized': True,
+        'source': 'codex-usage-snapshot-sqlite',
+        'range': 'current_cycle',
+        'timezone': 'Europe/Madrid',
+    }
+    rows = payload['data']['days']
+    assert [row['date'] for row in rows] == ['2026-04-21', '2026-04-22']
+    assert rows[0]['codex_segment']['partial'] is True
+    assert rows[0]['codex_segment']['reason'] == 'cycle_started_today'
+    assert rows[0]['secondary_delta_percent'] == 3.0
+    assert rows[0]['primary_windows_count'] == 1
+    assert rows[0]['peak_primary_used_percent'] == 25.0
+    assert rows[1]['codex_segment']['partial'] is False
+    assert rows[1]['secondary_delta_percent'] == 2.5
+    assert rows[1]['primary_windows_count'] == 2
+    assert rows[1]['peak_primary_used_percent'] == 80.0
+    assert rows[1]['status'] == 'high'
+    assert '/srv/crew-core/runtime/usage' not in str(payload)
+    assert 'raw_payload_value' not in str(payload)
+
+
+def test_usage_calendar_rejects_unknown_ranges_without_echoing_sensitive_values(tmp_path):
+    _override_usage_service(UsageService(db_path=tmp_path / 'missing.sqlite', now=lambda: '2026-04-26T14:40:00+00:00'))
+
+    response = TestClient(app).get('/api/v1/usage/calendar?range=/srv/crew-core/runtime/usage/codex-usage.sqlite')
+
+    assert response.status_code == 422
+    payload = response.json()
+    assert payload == {'detail': {'code': 'validation_error', 'message': 'Request validation failed.'}}
+    assert '/srv/crew-core/runtime/usage' not in str(payload)

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -69,10 +69,12 @@
 
 ### `usage`
 - exponer `GET /api/v1/usage/current` como primera frontera read-only del bloque Usage (#51)
+- exponer `GET /api/v1/usage/calendar?range=current_cycle|previous_cycle|7d|30d` como primer read model histórico saneado del bloque Usage
 - consumir solo la SQLite saneada allowlisted de Codex usage producida fuera del backend
 - serializar snapshot actual, plan, ventana 5h, ciclo semanal Codex, frescura y recomendación sin paths runtime ni raw payload
+- serializar calendario por fecha natural en zona `Europe/Madrid`, deltas diarios del ciclo semanal Codex, tramos parciales por inicio/reset de ciclo, número de ventanas 5h y pico diario sin prompts, raw payload ni actividad Hermes
 - degradar DB ausente/ilegible/sin snapshots a `not_configured`/`unknown` visible, nunca a dato sano silencioso
-- mantener actividad Hermes local, calendario y ventanas históricas para subfases separadas y saneadas
+- mantener actividad Hermes local y ventanas históricas dedicadas para subfases separadas y saneadas
 
 ### `system`
 - estado general del servidor y señales operativas de alto nivel

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -72,7 +72,7 @@
 - exponer `GET /api/v1/usage/calendar?range=current_cycle|previous_cycle|7d|30d` como primer read model histórico saneado del bloque Usage
 - consumir solo la SQLite saneada allowlisted de Codex usage producida fuera del backend
 - serializar snapshot actual, plan, ventana 5h, ciclo semanal Codex, frescura y recomendación sin paths runtime ni raw payload
-- serializar calendario por fecha natural en zona `Europe/Madrid`, deltas diarios del ciclo semanal Codex, tramos parciales por inicio/reset de ciclo, número de ventanas 5h y pico diario sin prompts, raw payload ni actividad Hermes
+- serializar calendario por fecha natural en zona `Europe/Madrid`, deltas diarios del ciclo semanal Codex calculados por segmento continuo para no contar resets como consumo, tramos parciales por inicio/reset de ciclo, número de ventanas 5h y pico diario sin prompts, raw payload ni actividad Hermes
 - degradar DB ausente/ilegible/sin snapshots a `not_configured`/`unknown` visible, nunca a dato sano silencioso
 - mantener actividad Hermes local y ventanas históricas dedicadas para subfases separadas y saneadas
 

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -110,7 +110,7 @@ Campos esperados:
 - `range` (`current_cycle`, `previous_cycle`, `7d`, `30d`)
 - `timezone` fija `Europe/Madrid`
 - `current_cycle` con rango del ciclo semanal Codex de referencia
-- `days[]` con fecha natural, tramo Codex del día, delta diario del ciclo semanal Codex, número de ventanas 5h, pico 5h y estado diario saneado
+- `days[]` con fecha natural, tramo Codex del día, delta diario del ciclo semanal Codex calculado por segmento continuo de ciclo para no contar resets como consumo, número de ventanas 5h, pico 5h y estado diario saneado
 
 Uso:
 - exponer calendario por fecha natural como primera vista histórica de Usage

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -105,6 +105,19 @@ Uso:
 - exponer solo métricas saneadas desde la fuente SQLite allowlisted, sin email, user/account IDs, tokens, prompts, headers, logs ni raw payload
 - degradar fuente ausente/ilegible a `not_configured`/`unknown` sin path runtime
 
+### `usage.calendar`
+Campos esperados:
+- `range` (`current_cycle`, `previous_cycle`, `7d`, `30d`)
+- `timezone` fija `Europe/Madrid`
+- `current_cycle` con rango del ciclo semanal Codex de referencia
+- `days[]` con fecha natural, tramo Codex del día, delta diario del ciclo semanal Codex, número de ventanas 5h, pico 5h y estado diario saneado
+
+Uso:
+- exponer calendario por fecha natural como primera vista histórica de Usage
+- indicar `tramo parcial` solo cuando la fecha coincide con inicio/reset del ciclo semanal Codex
+- no incluir actividad Hermes, prompts, conversaciones, tokens, raw payload, rutas runtime ni causalidad por perfil
+- aceptar solo rangos allowlisted; valores desconocidos deben caer en error de validación saneado sin ecoar input
+
 ### `memory.agent_summary`
 Campos esperados:
 - `mugiwara_slug`

--- a/openspec/phase-17-3-usage-calendar-backend.md
+++ b/openspec/phase-17-3-usage-calendar-backend.md
@@ -1,0 +1,58 @@
+# Phase 17.3 — Usage calendar backend read model
+
+## Decisión de corte
+Sí divido 17.3.
+
+Motivo: el calendario por fecha natural introduce una frontera backend histórica nueva (`GET /api/v1/usage/calendar`) y una integración UI visible posterior. Mezclar backend aggregation, contrato TS, UI responsive, smoke visual y review Usopp+Chopper+Franky en una sola PR volvería a sobredimensionar la fase.
+
+Corte aplicado:
+- **17.3a** — backend calendar read model y contrato compartido.
+- **17.3b** — UI calendario en `/usage` + pulidos menores de Usopp de PR #71.
+
+## Objetivo de 17.3a
+Añadir el primer read model histórico saneado de Usage: calendario por fecha natural sobre la SQLite saneada de Codex usage, sin actividad Hermes, sin nuevas fuentes y sin UI todavía.
+
+## Alcance 17.3a
+- Endpoint `GET /api/v1/usage/calendar?range=current_cycle|previous_cycle|7d|30d`.
+- Agregación por fecha natural en `Europe/Madrid`.
+- Deltas diarios del `ciclo semanal Codex`.
+- Detección de tramo parcial cuando el día coincide con inicio/reset de ciclo.
+- Conteo de ventanas 5h del día y pico diario 5h.
+- Tipos TS compartidos `UsageCalendar*`.
+- Docs vivas `api-modules` y `read-models`.
+
+## Fuera de alcance
+- Renderizar calendario en `/usage`.
+- Actividad Hermes agregada, perfiles dominantes, mensajes, sesiones, tool calls o tokens.
+- Endpoint dedicado de ventanas 5h históricas.
+- Proyecciones agresivas o atribución causal por Mugiwara.
+- Escritura, export o acciones operativas.
+
+## Principios operativos
+- Fuente única: SQLite allowlisted producida por Franky fuera del backend.
+- Backend sigue read-only y no ejecuta shell, no lee filesystem arbitrario y no expone rutas runtime.
+- `range` es allowlist estricta; inputs desconocidos caen en validación saneada.
+- Usar siempre `ciclo semanal Codex`, no “semana” a secas.
+- El calendario usa fecha natural para UX, pero no afirma causalidad Hermes/Codex.
+
+## DoD 17.3a
+- Tests backend cubren agrupación por fecha natural, tramo parcial por inicio de ciclo, delta diario, ventanas 5h, pico 5h y rechazo saneado de rango inválido.
+- Respuesta usa `resource='usage.calendar'`, `read_only`, `sanitized`, source fija y timezone `Europe/Madrid`.
+- Payload no contiene paths runtime, raw payload ni datos prohibidos.
+- Contrato TS y docs vivos actualizados.
+
+## Verify esperado
+- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q`.
+- `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py`.
+- `npm --prefix apps/web run typecheck`.
+- `git diff --check`.
+
+## Review esperada
+- Franky: semántica operativa de SQLite/rangos/deltas.
+- Chopper: privacidad, allowlist de `range`, no leakage y no nueva superficie genérica.
+- Usopp no es obligatorio hasta 17.3b, salvo comentario opcional de producto.
+
+## 17.3b previsto
+- Integrar calendario en `/usage`.
+- Mobile como cards apiladas, desktop como tabla/card grid sin scroll horizontal obligatorio.
+- Aplicar followups menores de Usopp de PR #71 si encajan: copy de reset fallback, menor peso visual de metodología, fórmulas más legibles.

--- a/openspec/phase-17-3-usage-calendar-backend.md
+++ b/openspec/phase-17-3-usage-calendar-backend.md
@@ -15,7 +15,7 @@ Añadir el primer read model histórico saneado de Usage: calendario por fecha n
 ## Alcance 17.3a
 - Endpoint `GET /api/v1/usage/calendar?range=current_cycle|previous_cycle|7d|30d`.
 - Agregación por fecha natural en `Europe/Madrid`.
-- Deltas diarios del `ciclo semanal Codex`.
+- Deltas diarios del `ciclo semanal Codex`, calculados por segmentos continuos de ciclo para no contar resets como consumo.
 - Detección de tramo parcial cuando el día coincide con inicio/reset de ciclo.
 - Conteo de ventanas 5h del día y pico diario 5h.
 - Tipos TS compartidos `UsageCalendar*`.
@@ -36,7 +36,7 @@ Añadir el primer read model histórico saneado de Usage: calendario por fecha n
 - El calendario usa fecha natural para UX, pero no afirma causalidad Hermes/Codex.
 
 ## DoD 17.3a
-- Tests backend cubren agrupación por fecha natural, tramo parcial por inicio de ciclo, delta diario, ventanas 5h, pico 5h y rechazo saneado de rango inválido.
+- Tests backend cubren agrupación por fecha natural, tramo parcial por inicio de ciclo, delta diario sin contar resets como consumo, ventanas 5h, pico 5h y rechazo saneado de rango inválido.
 - Respuesta usa `resource='usage.calendar'`, `read_only`, `sanitized`, source fija y timezone `Europe/Madrid`.
 - Payload no contiene paths runtime, raw payload ni datos prohibidos.
 - Contrato TS y docs vivos actualizados.

--- a/openspec/phase-17-3a-verify-checklist.md
+++ b/openspec/phase-17-3a-verify-checklist.md
@@ -10,6 +10,7 @@
 - [x] Calendario agrupa por fecha natural en `Europe/Madrid`.
 - [x] Tramo parcial se marca para inicio/reset del ciclo semanal Codex.
 - [x] Deltas diarios, conteo de ventanas 5h y pico 5h calculados desde snapshots saneados.
+- [x] Regresión cubierta: un reset/cambio de ciclo en la misma fecha natural no infla `secondary_delta_percent` como falso consumo.
 - [x] Rechazo de rangos inválidos no ecoa input sensible.
 - [x] Contrato TS `UsageCalendarResponse` añadido.
 - [x] Docs vivas actualizadas.

--- a/openspec/phase-17-3a-verify-checklist.md
+++ b/openspec/phase-17-3a-verify-checklist.md
@@ -1,0 +1,23 @@
+# Phase 17.3a verify checklist
+
+## Scope decision
+- [x] 17.3 se divide en 17.3a backend read model y 17.3b UI calendario.
+- [x] 17.3a no añade UI, Hermes activity, endpoint de ventanas históricas ni escritura.
+- [x] `range` queda allowlisted (`current_cycle`, `previous_cycle`, `7d`, `30d`).
+
+## Implementation checklist
+- [x] `GET /api/v1/usage/calendar` añadido.
+- [x] Calendario agrupa por fecha natural en `Europe/Madrid`.
+- [x] Tramo parcial se marca para inicio/reset del ciclo semanal Codex.
+- [x] Deltas diarios, conteo de ventanas 5h y pico 5h calculados desde snapshots saneados.
+- [x] Rechazo de rangos inválidos no ecoa input sensible.
+- [x] Contrato TS `UsageCalendarResponse` añadido.
+- [x] Docs vivas actualizadas.
+
+## Verify evidence
+- [x] Red TDD inicial: `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` falló por endpoint `/calendar` inexistente.
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q`.
+- [x] `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py`.
+- [x] `npm --prefix apps/web run typecheck`.
+- [x] `git diff --check`.
+- [x] Smoke API real/TestClient dirigido de `/api/v1/usage/calendar?range=current_cycle` contra la SQLite runtime saneada.

--- a/packages/contracts/src/read-models.ts
+++ b/packages/contracts/src/read-models.ts
@@ -217,6 +217,33 @@ export type UsageCurrent = {
   }
 }
 
+export type UsageCalendarRange = 'current_cycle' | 'previous_cycle' | '7d' | '30d'
+export type UsageCalendarDayStatus = 'normal' | 'high' | 'critical' | 'unknown'
+
+export type UsageCalendar = {
+  range: UsageCalendarRange
+  timezone: 'Europe/Madrid'
+  current_cycle: {
+    started_at: string | null
+    reset_at: string | null
+    label: 'Ciclo semanal Codex'
+  } | null
+  days: Array<{
+    date: string
+    codex_segment: {
+      started_at: string
+      ended_at: string
+      partial: boolean
+      reason: 'cycle_started_today' | 'cycle_resets_today' | null
+    }
+    secondary_delta_percent: number | null
+    primary_windows_count: number
+    peak_primary_used_percent: number | null
+    status: UsageCalendarDayStatus
+  }>
+  empty_reason?: 'not_configured' | 'unknown'
+}
+
 export type DashboardSummaryResponse = ResourceEnvelope<DashboardSummary, { links_count: number }>
 export type MugiwarasCatalogResponse = ResourceEnvelope<{ items: MugiwaraCard[]; crew_rules_document: CrewRulesDocument }, { count: number; crew_rules_document: string; read_only: true }>
 export type MugiwaraProfileResponse = ResourceEnvelope<MugiwaraProfile, { slug: string; read_only: true }>
@@ -227,4 +254,5 @@ export type VaultDocumentResponse = ResourceEnvelope<VaultDocument, { path: stri
 export type HealthcheckWorkspaceResponse = ResourceEnvelope<HealthcheckWorkspace, { count: number; read_only: true; sanitized: true; source: string }>
 export type HealthcheckSummaryResponse = ResourceEnvelope<{ items: HealthcheckSummary[] }, { count: number }>
 export type UsageCurrentResponse = ResourceEnvelope<UsageCurrent, { read_only: true; sanitized: true; source: string; refresh_interval_minutes: number }>
+export type UsageCalendarResponse = ResourceEnvelope<UsageCalendar, { read_only: true; sanitized: true; source: string; range: UsageCalendarRange; timezone: 'Europe/Madrid' }>
 export type SystemSignalsResponse = ResourceEnvelope<{ items: SystemSignal[] }, { count: number }>


### PR DESCRIPTION
## Summary
- Decide Phase 17.3 must be split: 17.3a backend calendar read model, 17.3b UI calendar.
- Add `GET /api/v1/usage/calendar?range=current_cycle|previous_cycle|7d|30d`.
- Aggregate sanitized Codex usage snapshots by natural date in `Europe/Madrid` with daily Codex cycle delta, partial cycle segment markers, 5h window count and daily 5h peak.
- Add shared TS `UsageCalendar*` contracts, OpenSpec/checklist/Engram closeout and docs updates.

## Scope boundaries
- No `/usage` UI calendar yet; that is 17.3b.
- No Hermes activity, prompts, conversations, tokens, profile dominance or causality.
- No dedicated 5h windows endpoint and no write/export actions.

## Verification
- Red TDD first: usage tests failed because `/calendar` did not exist.
- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q`
- `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py`
- `npm --prefix apps/web run typecheck`
- `git diff --check`
- TestClient smoke against runtime SQLite for `/api/v1/usage/calendar?range=current_cycle`

## Review routing
- Franky: operational semantics of SQLite snapshot aggregation, ranges and calendar/window metrics.
- Chopper: security/privacy/no leakage, strict range allowlist and no generic host/browser surface.