### PR TITLE
feat: add usage calendar UI

### DIFF
--- a/.engram/phase-17-3b-closeout.md
+++ b/.engram/phase-17-3b-closeout.md
@@ -1,0 +1,22 @@
+# Phase 17.3b closeout — Usage calendar UI
+
+## Resultado
+- `/usage` integra calendario por fecha natural usando `fetchUsageCalendar('current_cycle')` desde adapter server-only.
+- La UI renderiza cards responsive con fecha Europe/Madrid, delta diario del ciclo semanal Codex, ventanas 5h, pico diario y tramo parcial por inicio/reset.
+- Fallback local saneado añade fixture calendario y mantiene aviso no-tiempo-real.
+- 17.4 queda como siguiente bloque para actividad Hermes agregada y ventanas históricas dedicadas.
+
+## Verify
+- Red TDD: `npm run verify:usage-server-only` falló inicialmente por adapter/UI calendario inexistentes.
+- `npm run verify:usage-server-only` ✅
+- `npm --prefix apps/web run typecheck` ✅
+- `npm --prefix apps/web run build` ✅ (`/usage` sigue dinámica `ƒ`)
+- `npm run verify:visual-baseline` ✅
+- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` ✅
+- `git diff --check` ✅
+- Browser smoke local `/usage` en `127.0.0.1:3200`: 3 cards calendario, consola limpia, sin overflow horizontal desktop.
+
+## Riesgos / follow-ups
+- No hay selector de rango todavía; 17.3b consume `current_cycle` para mantener alcance pequeño.
+- El smoke visual real fue desktop disponible; Usopp debe revisar responsive/copy antes de merge.
+- Chopper debe revisar que el adapter sigue sin env pública, proxy genérico ni leakage.

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -140,6 +140,41 @@ button {
   white-space: nowrap;
 }
 
+.usage-calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
+  gap: 12px;
+}
+
+.usage-calendar-day {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.usage-calendar-day__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.usage-calendar-day__metrics dt {
+  color: #9aa7bd;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.usage-calendar-day__metrics dd {
+  margin: 2px 0 0;
+  font-weight: 800;
+}
+
 .responsive-code {
   overflow-x: auto;
   white-space: pre-wrap;
@@ -297,6 +332,10 @@ button {
 
   .surface-card {
     padding: 16px !important;
+  }
+
+  .usage-calendar-day__metrics {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/apps/web/src/app/usage/page.tsx
+++ b/apps/web/src/app/usage/page.tsx
@@ -1,7 +1,8 @@
 import type { ResourceStatus } from '@contracts/resource'
-import type { UsageCurrent, UsageWindowStatus } from '@contracts/read-models'
+import type { UsageCalendar, UsageCalendarDayStatus, UsageCurrent, UsageWindowStatus } from '@contracts/read-models'
 
-import { fetchUsageCurrent, UsageApiError } from '@/modules/usage/api/usage-http'
+import { fetchUsageCalendar, fetchUsageCurrent, UsageApiError } from '@/modules/usage/api/usage-http'
+import { usageCalendarFixture } from '@/modules/usage/view-models/usage-calendar.fixture'
 import { usageCurrentFixture } from '@/modules/usage/view-models/usage-current.fixture'
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
@@ -22,6 +23,7 @@ type UsageNotice = {
 
 type UsagePageData = {
   usage: UsageCurrent
+  calendar: UsageCalendar
   resourceStatus: ResourceStatus | 'fallback'
   notice: UsageNotice | null
   isSnapshotMode: boolean
@@ -44,23 +46,35 @@ const recommendationStatusMap: Record<UsageCurrent['recommendation']['state'], A
   sin_datos: 'sin-datos',
 }
 
+const calendarStatusMap: Record<UsageCalendarDayStatus, { appStatus: AppStatus; label: string; accent: 'sky' | 'success' | 'warning' | 'danger' }> = {
+  normal: { appStatus: 'operativo', label: 'Normal', accent: 'success' },
+  high: { appStatus: 'revision', label: 'Alto', accent: 'warning' },
+  critical: { appStatus: 'incidencia', label: 'Crítico', accent: 'danger' },
+  unknown: { appStatus: 'sin-datos', label: 'Sin datos', accent: 'sky' },
+}
+
 async function getInitialUsageData(): Promise<UsagePageData> {
   try {
-    const response = await fetchUsageCurrent()
-    const usage = response.data
+    const [currentResponse, calendarResponse] = await Promise.all([fetchUsageCurrent(), fetchUsageCalendar('current_cycle')])
+    const usage = currentResponse.data
+    const calendar = calendarResponse.data
 
-    if (response.status !== 'ready') {
+    const responseStatus = currentResponse.status !== 'ready' ? currentResponse.status : calendarResponse.status
+
+    if (responseStatus !== 'ready') {
       return {
         usage,
-        resourceStatus: response.status,
-        isSnapshotMode: response.status === 'stale',
-        notice: noticeFromResourceStatus(response.status),
+        calendar,
+        resourceStatus: responseStatus,
+        isSnapshotMode: responseStatus === 'stale',
+        notice: noticeFromResourceStatus(responseStatus),
       }
     }
 
     return {
       usage,
-      resourceStatus: response.status,
+      calendar,
+      resourceStatus: currentResponse.status,
       notice: null,
       isSnapshotMode: false,
     }
@@ -69,6 +83,7 @@ async function getInitialUsageData(): Promise<UsagePageData> {
 
     return {
       usage: usageCurrentFixture,
+      calendar: usageCalendarFixture,
       resourceStatus: 'fallback',
       isSnapshotMode: true,
       notice: {
@@ -152,6 +167,48 @@ function formatTimestamp(value: string | null) {
     dateStyle: 'medium',
     timeStyle: 'short',
   }).format(date)
+}
+
+function formatNaturalDate(value: string) {
+  const [year, month, day] = value.split('-').map(Number)
+  const date = new Date(Date.UTC(year, month - 1, day))
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return new Intl.DateTimeFormat('es-ES', {
+    weekday: 'short',
+    day: '2-digit',
+    month: 'short',
+  }).format(date)
+}
+
+function formatDeltaPercent(value: number | null) {
+  if (value === null) {
+    return '—'
+  }
+
+  return `+${Math.round(value)}%`
+}
+
+function calendarPartialCopy(reason: UsageCalendar['days'][number]['codex_segment']['reason']) {
+  if (reason === 'cycle_started_today') {
+    return 'Tramo parcial: inicio del ciclo semanal Codex'
+  }
+
+  if (reason === 'cycle_resets_today') {
+    return 'Tramo parcial: reset del ciclo semanal Codex'
+  }
+
+  return 'Día completo dentro del ciclo semanal Codex'
+}
+
+function formatPeakPrimary(value: number | null) {
+  if (value === null) {
+    return 'Sin pico 5h'
+  }
+
+  return `${Math.round(value)}% pico 5h`
 }
 
 function formatPercent(value: number | null) {
@@ -252,8 +309,71 @@ function WindowCard({
   )
 }
 
+function UsageCalendarPanel({ calendar, isSnapshotMode }: { calendar: UsageCalendar; isSnapshotMode: boolean }) {
+  const days = calendar.days.slice(-10)
+
+  return (
+    <SurfaceCard title="Calendario por fecha natural" eyebrow={`Ciclo semanal Codex · ${calendar.timezone}`} accent="gold" elevated>
+      <div style={{ display: 'grid', gap: '12px' }}>
+        <p style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
+          Primera lectura histórica saneada: agrupa por fecha natural Europe/Madrid, sin prompts, conversaciones, tokens ni actividad Hermes. El delta diario se calcula por segmentos continuos del ciclo semanal Codex para no contar resets como consumo.
+        </p>
+        {isSnapshotMode ? (
+          <p style={{ margin: 0, color: appTheme.colors.brandGold400, lineHeight: 1.5 }}>
+            Calendario mostrado desde snapshot/fallback saneado: útil para validar composición visual, no para decidir consumo real.
+          </p>
+        ) : null}
+        <div className="usage-calendar-grid" role="list" aria-label="Calendario Usage por fecha natural">
+          {days.length > 0 ? (
+            days.map((day) => {
+              const status = calendarStatusMap[day.status]
+              return (
+                <article className="usage-calendar-day" key={day.date} role="listitem" aria-label={`${formatNaturalDate(day.date)}: ${status.label}`}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', alignItems: 'flex-start' }}>
+                    <div>
+                      <p style={{ margin: 0, color: appTheme.colors.textMuted, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.08em' }}>{day.date}</p>
+                      <h3 style={{ margin: '4px 0 0', fontSize: '18px' }}>{formatNaturalDate(day.date)}</h3>
+                    </div>
+                    <StatusBadge status={status.appStatus} label={status.label} />
+                  </div>
+                  <dl className="usage-calendar-day__metrics">
+                    <div>
+                      <dt>Delta ciclo</dt>
+                      <dd>{formatDeltaPercent(day.secondary_delta_percent)}</dd>
+                    </div>
+                    <div>
+                      <dt>Ventanas 5h</dt>
+                      <dd>{day.primary_windows_count}</dd>
+                    </div>
+                    <div>
+                      <dt>Pico diario</dt>
+                      <dd>{formatPeakPrimary(day.peak_primary_used_percent)}</dd>
+                    </div>
+                  </dl>
+                  <p style={{ margin: 0, color: day.codex_segment.partial ? appTheme.colors.brandGold400 : appTheme.colors.textSecondary, lineHeight: 1.5 }}>
+                    {calendarPartialCopy(day.codex_segment.reason)}
+                  </p>
+                </article>
+              )
+            })
+          ) : (
+            <StatePanel
+              status="sin-datos"
+              title="Calendario sin datos"
+              description={calendar.empty_reason === 'not_configured' ? 'La fuente Usage calendar aún no está configurada.' : 'No hay días suficientes para componer el calendario saneado.'}
+              eyebrow="Usage calendar"
+              ariaRole="region"
+              ariaLabel="Calendario Usage sin datos"
+            />
+          )}
+        </div>
+      </div>
+    </SurfaceCard>
+  )
+}
+
 export default async function UsagePage() {
-  const { usage, notice, isSnapshotMode } = await getInitialUsageData()
+  const { usage, calendar, notice, isSnapshotMode } = await getInitialUsageData()
   const recommendationStatus = recommendationStatusMap[usage.recommendation.state]
 
   return (
@@ -320,13 +440,17 @@ export default async function UsagePage() {
         </SurfaceCard>
       </section>
 
+      <section className="section-block" aria-label="Calendario Usage">
+        <UsageCalendarPanel calendar={calendar} isSnapshotMode={isSnapshotMode} />
+      </section>
+
       <section className="section-block layout-grid layout-grid--content-aside">
-        <SurfaceCard title="Qué entra en esta vista" eyebrow="Alcance Phase 17.2" accent="gold">
+        <SurfaceCard title="Qué entra en esta vista" eyebrow="Alcance Phase 17.3b" accent="gold">
           <ul style={{ margin: 0, paddingLeft: '18px', color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
             <li>Snapshot actual saneado de Codex usage.</li>
             <li>Ventana 5h y ciclo semanal Codex con rangos calculados por reset.</li>
-            <li>Estado de fuente y recomendación operativa sin datos por conversación.</li>
-            <li>Calendario, ventanas históricas y actividad Hermes agregada quedan para 17.3/17.4.</li>
+            <li>Calendario por fecha natural Europe/Madrid con delta diario, ventanas 5h y pico diario saneados.</li>
+            <li>Actividad Hermes agregada y endpoint dedicado de ventanas históricas quedan para 17.4.</li>
           </ul>
         </SurfaceCard>
         <SurfaceCard title="Seguridad de datos" eyebrow="Deny by default" accent="sky">

--- a/apps/web/src/modules/AGENTS.md
+++ b/apps/web/src/modules/AGENTS.md
@@ -7,5 +7,5 @@ Features y módulos funcionales del frontend (dashboard, mugiwaras, skills, memo
 - Mantener una correspondencia clara entre módulo UI y módulo de producto.
 - Evitar dependencias cruzadas desordenadas.
 - **Vigilar `.gitignore`** y no subir mocks, capturas o outputs sensibles no saneados.
-- `usage`: Usage/Codex quota read-only frontend consuming server-only current snapshot adapter. Calendar and Hermes activity stay in later phases.
+- `usage`: Usage/Codex quota read-only frontend consuming server-only current snapshot and calendar adapters. Historical 5h windows and Hermes activity stay in later phases.
 - Si nace un módulo nuevo, documentarlo aquí y en docs.

--- a/apps/web/src/modules/usage/AGENTS.md
+++ b/apps/web/src/modules/usage/AGENTS.md
@@ -8,4 +8,4 @@ Módulo frontend para la superficie `/usage` de uso Codex/Hermes.
 - Mantener la página read-only.
 - Usar siempre `ciclo semanal Codex`; no presentar el ciclo como semana natural lunes-domingo.
 - No exponer prompts, raw conversations, tokens, user/account IDs, headers ni raw payload.
-- Calendario, ventanas históricas y actividad Hermes agregada pertenecen a fases posteriores separadas.
+- El calendario por fecha natural consume solo el endpoint backend allowlisted; ventanas históricas dedicadas y actividad Hermes agregada pertenecen a fases posteriores separadas.

--- a/apps/web/src/modules/usage/api/usage-http.ts
+++ b/apps/web/src/modules/usage/api/usage-http.ts
@@ -3,7 +3,7 @@ import 'server-only'
 import http from 'node:http'
 import https from 'node:https'
 
-import type { UsageCurrentResponse } from '@contracts/read-models'
+import type { UsageCalendarRange, UsageCalendarResponse, UsageCurrentResponse } from '@contracts/read-models'
 
 export const USAGE_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'
 
@@ -66,7 +66,7 @@ function parseJsonPayload<T>(body: string): T {
   }
 }
 
-async function requestUsageJson(url: string): Promise<UsageCurrentResponse> {
+async function requestUsageJson<T>(url: string): Promise<T> {
   const parsed = new URL(url)
   const transport = parsed.protocol === 'https:' ? https : http
 
@@ -97,7 +97,7 @@ async function requestUsageJson(url: string): Promise<UsageCurrentResponse> {
           }
 
           try {
-            resolve(parseJsonPayload<UsageCurrentResponse>(body))
+            resolve(parseJsonPayload<T>(body))
           } catch (error) {
             reject(error)
           }
@@ -122,5 +122,17 @@ export async function fetchUsageCurrent(): Promise<UsageCurrentResponse> {
     throw new UsageApiError('not_configured', { status: 0, code: 'not_configured' })
   }
 
-  return requestUsageJson(`${baseUrl}/api/v1/usage/current`)
+  return requestUsageJson<UsageCurrentResponse>(`${baseUrl}/api/v1/usage/current`)
+}
+
+export async function fetchUsageCalendar(range: UsageCalendarRange = 'current_cycle'): Promise<UsageCalendarResponse> {
+  const baseUrl = getUsageApiBaseUrl()
+
+  if (!baseUrl) {
+    throw new UsageApiError('not_configured', { status: 0, code: 'not_configured' })
+  }
+
+  const allowedRanges: UsageCalendarRange[] = ['current_cycle', 'previous_cycle', '7d', '30d']
+  const safeRange = allowedRanges.includes(range) ? range : 'current_cycle'
+  return requestUsageJson<UsageCalendarResponse>(`${baseUrl}/api/v1/usage/calendar?range=${encodeURIComponent(safeRange)}`)
 }

--- a/apps/web/src/modules/usage/view-models/usage-calendar.fixture.ts
+++ b/apps/web/src/modules/usage/view-models/usage-calendar.fixture.ts
@@ -1,0 +1,52 @@
+import type { UsageCalendar } from '@contracts/read-models'
+
+export const usageCalendarFixture: UsageCalendar = {
+  range: 'current_cycle',
+  timezone: 'Europe/Madrid',
+  current_cycle: {
+    label: 'Ciclo semanal Codex',
+    started_at: '2026-04-21T18:25:51+00:00',
+    reset_at: '2026-04-28T18:25:51+00:00',
+  },
+  days: [
+    {
+      date: '2026-04-24',
+      codex_segment: {
+        started_at: '2026-04-24T00:00:00+02:00',
+        ended_at: '2026-04-24T23:59:59+02:00',
+        partial: false,
+        reason: null,
+      },
+      secondary_delta_percent: 18,
+      primary_windows_count: 4,
+      peak_primary_used_percent: 58,
+      status: 'normal',
+    },
+    {
+      date: '2026-04-25',
+      codex_segment: {
+        started_at: '2026-04-25T00:00:00+02:00',
+        ended_at: '2026-04-25T23:59:59+02:00',
+        partial: false,
+        reason: null,
+      },
+      secondary_delta_percent: 27,
+      primary_windows_count: 5,
+      peak_primary_used_percent: 74,
+      status: 'high',
+    },
+    {
+      date: '2026-04-26',
+      codex_segment: {
+        started_at: '2026-04-26T00:00:00+02:00',
+        ended_at: '2026-04-26T17:04:43+02:00',
+        partial: true,
+        reason: 'cycle_resets_today',
+      },
+      secondary_delta_percent: 9,
+      primary_windows_count: 3,
+      peak_primary_used_percent: 26,
+      status: 'normal',
+    },
+  ],
+}

--- a/docs/frontend-ui-spec.md
+++ b/docs/frontend-ui-spec.md
@@ -83,7 +83,7 @@ Diseñar un shell de navegación estable y escaneable que:
 ├── /vault
 │   └── /vault/[...path]           # navegación documental si se implementa por ruta
 ├── /healthcheck
-└── /usage                         # Usage Codex/Hermes current-state; calendario en fases posteriores
+└── /usage                         # Usage Codex/Hermes current-state + calendario por fecha natural
 ```
 
 ## 2.3 IA del shell

--- a/openspec/phase-17-3b-usage-calendar-ui.md
+++ b/openspec/phase-17-3b-usage-calendar-ui.md
@@ -1,0 +1,46 @@
+# Phase 17.3b — Usage calendar UI
+
+## Objetivo
+Integrar en `/usage` el calendario por fecha natural cerrado en 17.3a, manteniendo la página read-only, server-only y sin ampliar fuentes ni actividad Hermes.
+
+## Por qué ahora
+17.3a ya expone `GET /api/v1/usage/calendar?range=current_cycle|previous_cycle|7d|30d` y los contratos TS. El siguiente corte seguro es una UI visible que consuma solo `current_cycle` y deje ventanas históricas dedicadas/Hermes activity para 17.4.
+
+## Alcance
+- Adapter server-only `fetchUsageCalendar('current_cycle')` con rango allowlisted.
+- Fixture local saneada para fallback/snapshot visual.
+- Panel responsive en `/usage` con:
+  - fecha natural Europe/Madrid;
+  - delta diario del ciclo semanal Codex;
+  - número de ventanas 5h;
+  - pico diario 5h;
+  - marca de tramo parcial por inicio/reset de ciclo.
+- Pulido menor del copy de alcance para reflejar que calendario ya entra en 17.3b.
+- Guardrail `verify:usage-server-only` actualizado para fijar adapter calendario y grid responsive.
+- Baseline visual actualizado para que `/usage` espere calendario y siga excluyendo actividad Hermes/ventanas históricas dedicadas.
+
+## Fuera de alcance
+- Cambiar backend Usage o endpoint 17.3a.
+- Selector interactivo de rangos (`previous_cycle`, `7d`, `30d`).
+- Endpoint dedicado de ventanas 5h históricas.
+- Actividad Hermes agregada, perfiles dominantes, sesiones, mensajes, tool calls o tokens.
+- Escritura, export o acciones operativas.
+
+## Principios operativos
+- `ciclo semanal Codex`, nunca “semana” a secas.
+- El calendario usa fecha natural para orientación humana, no para afirmar causalidad ni consumo por Mugiwara.
+- La UI no lee env ni backend URL directamente; todo pasa por adapter server-only.
+- Fallback/snapshot queda visible como no tiempo real.
+- Sin scroll horizontal obligatorio: cards/grid responsive.
+
+## DoD
+- `/usage` renderiza calendario por fecha natural en desktop/tablet/mobile.
+- No aparecen prompts, raw conversations, tokens, headers, account/user IDs, rutas runtime ni backend URL.
+- `verify:usage-server-only` fija endpoint calendario y no permite proxy genérico.
+- `typecheck`, `build`, `verify:visual-baseline`, `verify:usage-server-only` y `git diff --check` pasan.
+- Smoke browser confirma `/usage` sin errores de consola ni overflow horizontal obvio.
+
+## Review esperada
+- Usopp: UI/UX/responsive/copy visual de calendario.
+- Chopper: no leakage, server-only, no env pública ni proxy genérico.
+- Franky no es obligatorio si no cambia backend/runtime/fuentes.

--- a/openspec/phase-17-3b-verify-checklist.md
+++ b/openspec/phase-17-3b-verify-checklist.md
@@ -1,0 +1,29 @@
+# Phase 17.3b verify checklist
+
+## Scope decision
+- [x] 17.3b se limita a UI calendario en `/usage`.
+- [x] No añade backend, fuentes nuevas, escritura, Hermes activity ni ventanas históricas dedicadas.
+- [x] Consume solo `current_cycle` desde el endpoint allowlisted ya cerrado en 17.3a.
+
+## TDD / guardrail
+- [x] Red inicial: `npm run verify:usage-server-only` falló al exigir adapter calendario, contratos compartidos y grid responsive todavía inexistentes.
+- [x] Adapter server-only actualizado con `UsageCalendarRange`/`UsageCalendarResponse`.
+- [x] Página `/usage` renderiza calendario por fecha natural Europe/Madrid.
+- [x] Fallback local saneado incluye fixture calendario sin datos sensibles.
+- [x] `verify:usage-server-only` fija ausencia de proxy genérico, env pública y lectura directa de env en página.
+
+## UI / UX
+- [x] Cards calendario apilables sin tabla ni scroll horizontal obligatorio.
+- [x] Día muestra delta de ciclo, ventanas 5h, pico 5h y estado.
+- [x] Tramos parciales explican inicio/reset del ciclo semanal Codex.
+- [x] Copy mantiene fuera de alcance actividad Hermes y ventanas históricas dedicadas.
+- [x] Visual baseline actualizada.
+
+## Verify evidence
+- [x] `npm run verify:usage-server-only`.
+- [x] `npm --prefix apps/web run typecheck`.
+- [x] `npm --prefix apps/web run build`.
+- [x] `npm run verify:visual-baseline`.
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q`.
+- [x] `git diff --check`.
+- [x] Smoke browser `/usage` sin consola roja ni overflow horizontal obvio en viewport desktop disponible.

--- a/scripts/check-usage-server-only.mjs
+++ b/scripts/check-usage-server-only.mjs
@@ -25,6 +25,18 @@ if (http.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL') || page.includes
 if (!http.includes('/api/v1/usage/current')) {
   failures.push('usage adapter must call the fixed current endpoint')
 }
+if (!http.includes('/api/v1/usage/calendar?range=')) {
+  failures.push('usage adapter must call the fixed calendar endpoint with allowlisted range')
+}
+if (!http.includes('UsageCalendarRange') || !http.includes('UsageCalendarResponse')) {
+  failures.push('usage adapter must type calendar ranges and responses via shared contracts')
+}
+if (!page.includes('Calendario por fecha natural') || !page.includes('Europe/Madrid')) {
+  failures.push('usage page must render the natural-date calendar with timezone context')
+}
+if (!page.includes('usage-calendar-grid') || !page.includes('primary_windows_count')) {
+  failures.push('usage page must render a responsive calendar grid without generic table overflow')
+}
 if (http.includes('path=') || http.includes('target=') || http.includes('method=')) {
   failures.push('usage adapter must not grow generic proxy parameters')
 }

--- a/scripts/visual-verify-baseline.mjs
+++ b/scripts/visual-verify-baseline.mjs
@@ -105,7 +105,8 @@ const routes = [
       'el ciclo se etiqueta como ciclo semanal Codex y no como calendario lunes-domingo',
       'stale, not_configured o fallback quedan visibles como fuente degradada/no tiempo real',
       'fórmulas y privacidad hacen wrap sin filtrar detalles internos del host',
-      'no aparecen calendario, ventanas históricas ni actividad Hermes antes de sus fases',
+      'el calendario por fecha natural aparece como grid/cards responsive sin scroll horizontal obligatorio',
+      'actividad Hermes agregada y endpoint dedicado de ventanas históricas siguen fuera de esta fase',
     ],
   },
 ]


### PR DESCRIPTION
## Qué cambia
- Añade la UI de calendario por fecha natural en `/usage` sobre `GET /api/v1/usage/calendar`.
- Extiende el adapter server-only de Usage con `fetchUsageCalendar('current_cycle')` y tipos compartidos `UsageCalendar*`.
- Añade fixture local saneada para fallback/snapshot y cards responsive sin tabla ni scroll horizontal obligatorio.
- Actualiza guardrail `verify:usage-server-only`, visual baseline, OpenSpec, closeout Engram y docs vivas.

## Alcance cerrado
- Read-only, server-side y sin nuevas fuentes.
- Sin actividad Hermes agregada, sin selector de rangos, sin endpoint dedicado de ventanas históricas y sin escritura.
- Mantiene semántica `ciclo semanal Codex`; fecha natural Europe/Madrid solo como orientación UX.

## Verificación de Zoro
- Red TDD inicial: `npm run verify:usage-server-only` falló al exigir adapter/UI calendario inexistentes.
- `npm run verify:usage-server-only`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build` (`/usage` sigue dinámica `ƒ`)
- `npm run verify:visual-baseline`
- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q`
- `git diff --check`
- Smoke browser local `/usage` en `127.0.0.1:3200`: 3 cards calendario, consola limpia, sin overflow horizontal desktop.

## Riesgos / review solicitada
- Usopp: revisar jerarquía visual, responsive, copy y claridad del calendario.
- Chopper: revisar server-only/no leakage/no env pública/no proxy genérico.
- Franky no solicitado por defecto: no cambia backend, runtime, timers ni fuentes.

## Siguiente paso si se mergea
- Actualizar Project Summary del vault y issue #51 indicando 17.3b cerrada.
- Continuar con 17.4: ventanas históricas dedicadas + actividad Hermes agregada, o pausar Usage y pasar a Phase 18.x Healthcheck producers.
