### PR TITLE
feat: add Usage five-hour windows backend

### DIFF
--- a/.engram/phase-17-4a-usage-five-hour-windows-backend-closeout.md
+++ b/.engram/phase-17-4a-usage-five-hour-windows-backend-closeout.md
@@ -1,0 +1,28 @@
+# Phase 17.4a closeout — Usage five-hour windows backend
+
+## Scope
+17.4 was split before implementation. 17.4a adds only the backend read model for dedicated Codex five-hour windows.
+
+## Implemented
+- `GET /api/v1/usage/five-hour-windows?limit=8`.
+- SQLite read-only source remains the allowlisted Codex usage DB.
+- Windows are grouped by `primary_window_start_at`/`primary_reset_at`.
+- Public payload exposes only start/end, peak %, positive delta %, sample count and status.
+- Missing/unreadable/no usable snapshots degrade to `not_configured` without paths.
+- Shared TS contracts and docs updated.
+
+## Deferred
+- 17.4b: `/usage` UI for windows.
+- 17.4c: Hermes activity aggregation, with separate source/security review.
+- 17.4d: UI Hermes activity + final #51 closeout/canon.
+
+## Verify
+- Red inicial: tests nuevos fallaron con 404 antes de implementar el endpoint.
+- `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py`.
+- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` → 8 passed.
+- `npm --prefix apps/web run typecheck`.
+- `git diff --check`.
+- Smoke TestClient contra SQLite real: `GET /api/v1/usage/five-hour-windows?limit=3` → 200 `ready`, 3 ventanas, sin path runtime.
+
+## Discovery
+Real SQLite snapshots showed 1-second jitter in `primary_window_start_at`/`primary_reset_at`; the endpoint normalizes window start/end to UTC minute buckets so one physical Codex window is not split into duplicate rows.

--- a/apps/api/src/modules/usage/AGENTS.md
+++ b/apps/api/src/modules/usage/AGENTS.md
@@ -8,4 +8,5 @@ Módulo backend read-only para snapshots saneados de uso Codex/Hermes.
 - No exponer email, user_id, account_id, tokens, headers, prompts, logs brutos ni raw payload.
 - No convertir Usage en filesystem browser ni consola host.
 - Mantener la semántica `ciclo semanal Codex`, no “semana” de calendario.
+- Las ventanas 5h históricas deben salir solo de la SQLite allowlisted en modo lectura, agrupadas por inicio/reset normalizado a minuto UTC y sin paths runtime.
 - La actividad Hermes local debe permanecer agregada y saneada cuando se añada en fases posteriores.

--- a/apps/api/src/modules/usage/router.py
+++ b/apps/api/src/modules/usage/router.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from ...shared.contracts import resource_response
-from .service import USAGE_REFRESH_INTERVAL_MINUTES, UsageCalendarRange, UsageService
+from .service import DEFAULT_USAGE_WINDOWS_LIMIT, MAX_USAGE_WINDOWS_LIMIT, USAGE_REFRESH_INTERVAL_MINUTES, UsageCalendarRange, UsageService
 
 router = APIRouter(prefix='/api/v1/usage', tags=['usage'])
 _service = UsageService()
@@ -42,5 +42,24 @@ def get_usage_calendar(range: UsageCalendarRange = 'current_cycle', service: Usa
             'source': 'codex-usage-snapshot-sqlite',
             'range': range,
             'timezone': 'Europe/Madrid',
+        },
+    )
+
+
+@router.get('/five-hour-windows')
+def get_usage_five_hour_windows(
+    limit: int = Query(DEFAULT_USAGE_WINDOWS_LIMIT, ge=1, le=MAX_USAGE_WINDOWS_LIMIT),
+    service: UsageService = Depends(get_usage_service),
+) -> dict:
+    windows = service.get_five_hour_windows(limit)
+    return resource_response(
+        resource='usage.five_hour_windows',
+        status=service.five_hour_windows_status_for(windows),
+        data=windows,
+        meta={
+            'read_only': True,
+            'sanitized': True,
+            'source': 'codex-usage-snapshot-sqlite',
+            'limit': limit,
         },
     )

--- a/apps/api/src/modules/usage/service.py
+++ b/apps/api/src/modules/usage/service.py
@@ -12,6 +12,8 @@ USAGE_REFRESH_INTERVAL_MINUTES = 15
 USAGE_STALE_AFTER_MINUTES = 45
 USAGE_CALENDAR_TIMEZONE = ZoneInfo('Europe/Madrid')
 UsageCalendarRange = Literal['current_cycle', 'previous_cycle', '7d', '30d']
+MAX_USAGE_WINDOWS_LIMIT = 24
+DEFAULT_USAGE_WINDOWS_LIMIT = 8
 
 
 def _parse_datetime(value: str | None) -> datetime | None:
@@ -63,6 +65,14 @@ def _window_status(percent: float | None, *, limit_reached: bool | None = None) 
 
 def _isoformat_utc(value: datetime) -> str:
     return value.astimezone(timezone.utc).isoformat()
+
+
+def _window_bucket_timestamp(value: str) -> str:
+    parsed = _parse_datetime(value)
+    if parsed is None:
+        return value
+    normalized = parsed.astimezone(timezone.utc).replace(second=0, microsecond=0)
+    return normalized.isoformat()
 
 
 def _local_midnight(value: datetime) -> datetime:
@@ -219,6 +229,49 @@ class UsageService:
             },
             'days': self._calendar_days(snapshots, start_at=start_at, end_at=end_at, cycle_start=cycle_start, cycle_reset=cycle_reset),
         }
+
+    def get_five_hour_windows(self, limit: int = DEFAULT_USAGE_WINDOWS_LIMIT) -> dict[str, Any]:
+        safe_limit = max(1, min(MAX_USAGE_WINDOWS_LIMIT, limit))
+        snapshots = self._load_latest_snapshots(limit=safe_limit * 96)
+        if not snapshots:
+            return {'windows': [], 'empty_reason': 'not_configured'}
+
+        grouped: dict[tuple[str, str], list[UsageSnapshot]] = {}
+        for snapshot in snapshots:
+            if snapshot.primary_window_start_at is None or snapshot.primary_reset_at is None:
+                continue
+            started_at = _window_bucket_timestamp(snapshot.primary_window_start_at)
+            ended_at = _window_bucket_timestamp(snapshot.primary_reset_at)
+            grouped.setdefault((started_at, ended_at), []).append(snapshot)
+
+        windows: list[dict[str, Any]] = []
+        for (started_at, ended_at), window_snapshots in grouped.items():
+            ordered = sorted(window_snapshots, key=lambda item: item.captured_at)
+            values = [value for value in (item.primary_used_percent for item in ordered) if value is not None]
+            peak = round(max(values), 2) if values else None
+            delta = _positive_delta(values) if values else None
+            windows.append(
+                {
+                    'started_at': started_at,
+                    'ended_at': ended_at,
+                    'peak_used_percent': peak,
+                    'delta_percent': delta,
+                    'samples_count': len(ordered),
+                    'status': _window_status(peak),
+                }
+            )
+
+        windows.sort(key=lambda item: item['started_at'], reverse=True)
+        windows = windows[:safe_limit]
+        return {'windows': windows, 'empty_reason': None if windows else 'not_configured'}
+
+    @staticmethod
+    def five_hour_windows_status_for(payload: dict[str, Any]) -> str:
+        if payload.get('empty_reason') == 'not_configured':
+            return 'not_configured'
+        if not payload.get('windows'):
+            return 'not_configured'
+        return 'ready'
 
     @staticmethod
     def calendar_status_for(payload: dict[str, Any]) -> str:
@@ -410,6 +463,46 @@ class UsageService:
         if row is None:
             return None
         return self._snapshot_from_row(row)
+
+    def _load_latest_snapshots(self, *, limit: int) -> list[UsageSnapshot]:
+        if not self.db_path.exists() or not self.db_path.is_file():
+            return []
+        try:
+            con = sqlite3.connect(f'file:{self.db_path}?mode=ro', uri=True)
+            con.row_factory = sqlite3.Row
+            rows = con.execute(
+                """
+                SELECT
+                    captured_at,
+                    plan_type,
+                    allowed,
+                    limit_reached,
+                    primary_used_percent,
+                    primary_window_seconds,
+                    primary_window_start_at,
+                    primary_reset_at,
+                    primary_reset_after_seconds,
+                    secondary_used_percent,
+                    secondary_window_seconds,
+                    secondary_cycle_start_at,
+                    secondary_reset_at,
+                    secondary_reset_after_seconds,
+                    additional_limits_count
+                FROM codex_usage_snapshots
+                ORDER BY captured_at_epoch DESC, id DESC
+                LIMIT ?
+                """,
+                (max(1, min(MAX_USAGE_WINDOWS_LIMIT * 96, limit)),),
+            ).fetchall()
+        except sqlite3.Error:
+            return []
+        finally:
+            try:
+                con.close()
+            except UnboundLocalError:
+                pass
+        snapshots = [self._snapshot_from_row(row) for row in rows]
+        return sorted(snapshots, key=lambda item: item.captured_at)
 
     def _load_snapshots_between(self, start_at: datetime, end_at: datetime) -> list[UsageSnapshot]:
         if not self.db_path.exists() or not self.db_path.is_file():

--- a/apps/api/tests/test_usage_api.py
+++ b/apps/api/tests/test_usage_api.py
@@ -299,6 +299,105 @@ def test_usage_calendar_rejects_unknown_ranges_without_echoing_sensitive_values(
     assert '/srv/crew-core/runtime/usage' not in str(payload)
 
 
+def test_usage_five_hour_windows_groups_latest_windows_without_leaking_runtime_path(tmp_path):
+    db_path = tmp_path / 'codex-usage.sqlite'
+    con = sqlite3.connect(db_path)
+    _create_usage_schema(con)
+    _insert_usage_snapshot(
+        con,
+        captured_at='2026-04-26T10:10:00+00:00',
+        primary_used_percent=5.0,
+        primary_window_start_at='2026-04-26T10:00:00+00:00',
+        primary_reset_at='2026-04-26T15:00:00+00:00',
+        secondary_used_percent=80.0,
+        secondary_cycle_start_at='2026-04-21T18:25:51+00:00',
+        secondary_reset_at='2026-04-28T18:25:51+00:00',
+    )
+    _insert_usage_snapshot(
+        con,
+        captured_at='2026-04-26T12:00:00+00:00',
+        primary_used_percent=35.0,
+        primary_window_start_at='2026-04-26T10:00:00+00:00',
+        primary_reset_at='2026-04-26T15:00:00+00:00',
+        secondary_used_percent=82.0,
+        secondary_cycle_start_at='2026-04-21T18:25:51+00:00',
+        secondary_reset_at='2026-04-28T18:25:51+00:00',
+    )
+    _insert_usage_snapshot(
+        con,
+        captured_at='2026-04-26T15:05:00+00:00',
+        primary_used_percent=2.0,
+        primary_window_start_at='2026-04-26T15:00:00+00:00',
+        primary_reset_at='2026-04-26T20:00:00+00:00',
+        secondary_used_percent=83.0,
+        secondary_cycle_start_at='2026-04-21T18:25:51+00:00',
+        secondary_reset_at='2026-04-28T18:25:51+00:00',
+    )
+    _insert_usage_snapshot(
+        con,
+        captured_at='2026-04-26T19:00:00+00:00',
+        primary_used_percent=97.0,
+        primary_window_start_at='2026-04-26T15:00:00+00:00',
+        primary_reset_at='2026-04-26T20:00:00+00:00',
+        secondary_used_percent=90.0,
+        secondary_cycle_start_at='2026-04-21T18:25:51+00:00',
+        secondary_reset_at='2026-04-28T18:25:51+00:00',
+    )
+    _insert_usage_snapshot(
+        con,
+        captured_at='2026-04-26T19:15:00+00:00',
+        primary_used_percent=98.0,
+        primary_window_start_at='2026-04-26T15:00:01+00:00',
+        primary_reset_at='2026-04-26T20:00:01+00:00',
+        secondary_used_percent=91.0,
+        secondary_cycle_start_at='2026-04-21T18:25:51+00:00',
+        secondary_reset_at='2026-04-28T18:25:51+00:00',
+    )
+    con.commit()
+    con.close()
+    _override_usage_service(UsageService(db_path=db_path, now=lambda: '2026-04-26T20:00:00+00:00'))
+
+    response = TestClient(app).get('/api/v1/usage/five-hour-windows?limit=2')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'usage.five_hour_windows'
+    assert payload['status'] == 'ready'
+    assert payload['meta'] == {
+        'read_only': True,
+        'sanitized': True,
+        'source': 'codex-usage-snapshot-sqlite',
+        'limit': 2,
+    }
+    assert payload['data']['empty_reason'] is None
+    windows = payload['data']['windows']
+    assert [window['started_at'] for window in windows] == ['2026-04-26T15:00:00+00:00', '2026-04-26T10:00:00+00:00']
+    assert windows[0] == {
+        'started_at': '2026-04-26T15:00:00+00:00',
+        'ended_at': '2026-04-26T20:00:00+00:00',
+        'peak_used_percent': 98.0,
+        'delta_percent': 96.0,
+        'samples_count': 3,
+        'status': 'critical',
+    }
+    assert windows[1]['peak_used_percent'] == 35.0
+    assert windows[1]['delta_percent'] == 30.0
+    assert '/srv/crew-core/runtime/usage' not in str(payload)
+    assert 'raw_payload_value' not in str(payload)
+
+
+def test_usage_five_hour_windows_degrades_when_snapshot_db_is_absent(tmp_path):
+    _override_usage_service(UsageService(db_path=tmp_path / 'missing.sqlite', now=lambda: '2026-04-26T14:40:00+00:00'))
+
+    response = TestClient(app).get('/api/v1/usage/five-hour-windows')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['status'] == 'not_configured'
+    assert payload['data'] == {'windows': [], 'empty_reason': 'not_configured'}
+    assert 'missing.sqlite' not in str(payload)
+
+
 def test_usage_calendar_does_not_count_cycle_reset_as_daily_delta(tmp_path):
     db_path = tmp_path / 'codex-usage.sqlite'
     con = sqlite3.connect(db_path)

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -73,8 +73,10 @@
 - consumir solo la SQLite saneada allowlisted de Codex usage producida fuera del backend
 - serializar snapshot actual, plan, ventana 5h, ciclo semanal Codex, frescura y recomendación sin paths runtime ni raw payload
 - serializar calendario por fecha natural en zona `Europe/Madrid`, deltas diarios del ciclo semanal Codex calculados por segmento continuo para no contar resets como consumo, tramos parciales por inicio/reset de ciclo, número de ventanas 5h y pico diario sin prompts, raw payload ni actividad Hermes
+- exponer `GET /api/v1/usage/five-hour-windows?limit=8` como read model dedicado de últimas ventanas 5h, agrupado por inicio/reset de ventana normalizado a minuto UTC y limitado a `1..24`
+- serializar ventanas 5h solo con inicio, fin, pico %, delta positivo intra-ventana, muestras y estado; sin paths runtime, prompts, raw payload ni actividad Hermes
 - degradar DB ausente/ilegible/sin snapshots a `not_configured`/`unknown` visible, nunca a dato sano silencioso
-- mantener actividad Hermes local y ventanas históricas dedicadas para subfases separadas y saneadas
+- mantener actividad Hermes local para subfase separada y saneada
 
 ### `system`
 - estado general del servidor y señales operativas de alto nivel

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -118,6 +118,18 @@ Uso:
 - no incluir actividad Hermes, prompts, conversaciones, tokens, raw payload, rutas runtime ni causalidad por perfil
 - aceptar solo rangos allowlisted; valores desconocidos deben caer en error de validación saneado sin ecoar input
 
+### `usage.five_hour_windows`
+Campos esperados:
+- `windows[]` con `started_at`, `ended_at`, `peak_used_percent`, `delta_percent`, `samples_count` y `status`
+- `empty_reason` (`not_configured` o `null`)
+
+Uso:
+- exponer las últimas ventanas 5h dedicadas de Codex como read model histórico saneado
+- agrupar únicamente por `primary_window_start_at`/`primary_reset_at` normalizados a minuto UTC desde la SQLite allowlisted en modo lectura
+- calcular delta como suma de incrementos positivos dentro de la misma ventana 5h, evitando convertir resets o descensos en consumo negativo
+- no incluir actividad Hermes, prompts, conversaciones, tokens, raw payload, rutas runtime ni causalidad por perfil
+- limitar la respuesta con `limit` validado (`1..24`) y degradar fuente ausente/ilegible a `not_configured` sin path runtime
+
 ### `memory.agent_summary`
 Campos esperados:
 - `mugiwara_slug`

--- a/openspec/phase-17-4-usage-final-split.md
+++ b/openspec/phase-17-4-usage-final-split.md
@@ -1,0 +1,44 @@
+# Phase 17.4 — Usage final split for #51
+
+## Decisión de división
+17.4 **sí se divide** antes de implementar. Cerrar #51 de una vez mezclaría tres fronteras distintas:
+
+1. read model backend de ventanas 5h históricas sobre SQLite Codex;
+2. UI visible en `/usage` para esas ventanas;
+3. actividad Hermes local agregada leyendo `state.db` de perfiles allowlisted.
+
+La tercera frontera introduce una fuente distinta a la SQLite de Franky y requiere saneado específico para no exponer prompts, mensajes, rutas, IDs o datos por conversación. Meterlo en la misma PR que ventanas 5h aumentaría riesgo y dificultaría review.
+
+## Microfases
+
+### 17.4a — backend five-hour windows
+- Añadir `GET /api/v1/usage/five-hour-windows?limit=8`.
+- Fuente única: SQLite allowlisted `codex-usage-snapshot-sqlite` en `mode=ro`.
+- Agrupar por `primary_window_start_at`/`primary_reset_at`.
+- Serializar solo inicio, fin, pico %, delta positivo dentro de ventana, número de muestras y estado saneado.
+- Fuera de alcance: UI, actividad Hermes, nueva fuente `state.db`, escritura.
+- Review: Franky + Chopper.
+
+### 17.4b — UI windows
+- Extender adapter server-only y `/usage` para mostrar últimas ventanas 5h.
+- Fixture fallback saneada.
+- Guardrail `verify:usage-server-only` actualizado.
+- Fuera de alcance: actividad Hermes.
+- Review: Usopp + Chopper.
+
+### 17.4c — backend Hermes activity aggregation
+- Diseñar y añadir read model agregado/read-only sobre perfiles Hermes allowlisted.
+- Exponer solo perfiles, sesiones/mensajes/tool calls agregados y rangos redondeados/saneados.
+- Prohibido: prompts, contenidos, raw conversations, user IDs, chat IDs, tool payloads, rutas DB, costes detallados por conversación, tokens crudos por sesión.
+- Review: Franky + Chopper.
+
+### 17.4d — UI Hermes activity + closeout #51
+- Mostrar actividad Hermes como correlación orientativa, no causalidad exacta.
+- Actualizar docs, Project Summary/vault, issue #51 y closeout Engram.
+- Review: Usopp + Chopper; Franky solo si cambia fuente/backend.
+
+## Definition of Done de 17.4 completo
+- #51 cumple navegación, current-state, calendario, ventanas 5h y actividad Hermes agregada saneada.
+- No hay escritura ni exposición de secretos/PII/raw payloads/prompts/logs.
+- Verify backend/frontend/guardrails pasado por microfase.
+- Project Summary y issue #51 reflejan cierre real.

--- a/openspec/phase-17-4a-usage-five-hour-windows-backend.md
+++ b/openspec/phase-17-4a-usage-five-hour-windows-backend.md
@@ -1,0 +1,41 @@
+# Phase 17.4a — Usage five-hour windows backend
+
+## Objetivo
+Añadir un read model backend dedicado para últimas ventanas 5h de Codex dentro del bloque Usage/#51.
+
+## Decisión de scope
+17.4 queda dividida. Esta microfase cierra solo la frontera backend de ventanas 5h y deja fuera UI y actividad Hermes.
+
+## Alcance
+- `GET /api/v1/usage/five-hour-windows?limit=8`.
+- `limit` validado `1..24`.
+- Lectura read-only de la SQLite allowlisted `codex-usage-snapshot-sqlite` en `mode=ro`.
+- Agrupación por `primary_window_start_at`/`primary_reset_at` normalizados a minuto UTC
+- Salida saneada: `started_at`, `ended_at`, `peak_used_percent`, `delta_percent`, `samples_count`, `status`.
+- Contrato TS compartido `UsageFiveHourWindowsResponse`.
+- Tests de camino feliz y degradación `not_configured`.
+- Docs vivas actualizadas.
+
+## Fuera de alcance
+- UI `/usage` para mostrar ventanas.
+- Actividad Hermes local agregada.
+- Lectura de `state.db` Hermes.
+- Escritura, export, acciones operativas, prompts, conversaciones, tokens, raw payload o rutas runtime.
+
+## Semántica
+- `peak_used_percent`: máximo de `primary_used_percent` dentro de la ventana.
+- `delta_percent`: suma de incrementos positivos dentro de la misma ventana, no resta global que pueda convertir descensos/resets en señal falsa.
+- Inicio/reset se normalizan a minuto UTC para absorber jitter de segundos observado en snapshots reales.
+- `status`: reutiliza semántica de ventana (`normal`, `high`, `critical`, `limit_reached`, `unknown`) basada en pico.
+- Sin snapshots/fuente ausente: `not_configured` visible y content-free.
+
+## Verify esperado
+- Red inicial de tests nuevos.
+- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q`.
+- `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py`.
+- `npm --prefix apps/web run typecheck` para contratos compartidos.
+- `git diff --check`.
+- Smoke TestClient del endpoint real contra la SQLite allowlisted si existe.
+
+## Review
+Franky + Chopper: frontera backend/fuente operativa SQLite y no leakage.

--- a/openspec/phase-17-4a-verify-checklist.md
+++ b/openspec/phase-17-4a-verify-checklist.md
@@ -1,0 +1,23 @@
+# Phase 17.4a verify checklist
+
+## Scope decision
+- [x] 17.4 se divide antes de implementar.
+- [x] 17.4a se limita a backend five-hour windows.
+- [x] UI `/usage` y Hermes activity quedan fuera.
+
+## Backend contract
+- [x] Endpoint fijo `GET /api/v1/usage/five-hour-windows`.
+- [x] `limit` validado entre 1 y 24.
+- [x] Fuente única SQLite allowlisted en `mode=ro`.
+- [x] Ventanas agrupadas por `primary_window_start_at`/`primary_reset_at`.
+- [x] Salida saneada sin path runtime, raw payload, prompts ni actividad Hermes.
+- [x] DB ausente degrada a `not_configured` content-free.
+- [x] Contrato TS compartido actualizado.
+
+## Verify evidence
+- [x] Red inicial: tests nuevos fallaban con `404` antes de implementar el endpoint.
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` → 8 passed.
+- [x] `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py`.
+- [x] `npm --prefix apps/web run typecheck`.
+- [x] `git diff --check`.
+- [x] Smoke TestClient contra SQLite real: `GET /api/v1/usage/five-hour-windows?limit=3` → 200 `ready`, 3 ventanas, sin path runtime.

--- a/packages/contracts/src/read-models.ts
+++ b/packages/contracts/src/read-models.ts
@@ -244,6 +244,18 @@ export type UsageCalendar = {
   empty_reason?: 'not_configured' | 'unknown'
 }
 
+export type UsageFiveHourWindows = {
+  windows: Array<{
+    started_at: string
+    ended_at: string
+    peak_used_percent: number | null
+    delta_percent: number | null
+    samples_count: number
+    status: UsageWindowStatus
+  }>
+  empty_reason: 'not_configured' | null
+}
+
 export type DashboardSummaryResponse = ResourceEnvelope<DashboardSummary, { links_count: number }>
 export type MugiwarasCatalogResponse = ResourceEnvelope<{ items: MugiwaraCard[]; crew_rules_document: CrewRulesDocument }, { count: number; crew_rules_document: string; read_only: true }>
 export type MugiwaraProfileResponse = ResourceEnvelope<MugiwaraProfile, { slug: string; read_only: true }>
@@ -255,4 +267,5 @@ export type HealthcheckWorkspaceResponse = ResourceEnvelope<HealthcheckWorkspace
 export type HealthcheckSummaryResponse = ResourceEnvelope<{ items: HealthcheckSummary[] }, { count: number }>
 export type UsageCurrentResponse = ResourceEnvelope<UsageCurrent, { read_only: true; sanitized: true; source: string; refresh_interval_minutes: number }>
 export type UsageCalendarResponse = ResourceEnvelope<UsageCalendar, { read_only: true; sanitized: true; source: string; range: UsageCalendarRange; timezone: 'Europe/Madrid' }>
+export type UsageFiveHourWindowsResponse = ResourceEnvelope<UsageFiveHourWindows, { read_only: true; sanitized: true; source: string; limit: number }>
 export type SystemSignalsResponse = ResourceEnvelope<{ items: SystemSignal[] }, { count: number }>


### PR DESCRIPTION
## Resumen
- Divide Phase 17.4 antes de cerrar #51 para no mezclar ventanas 5h, UI y actividad Hermes.
- Añade `GET /api/v1/usage/five-hour-windows?limit=8` como read model backend read-only sobre la SQLite saneada de Codex usage.
- Agrupa ventanas por `primary_window_start_at`/`primary_reset_at` normalizados a minuto UTC para absorber jitter de segundos observado en snapshots reales.
- Expone solo inicio, fin, pico %, delta positivo intra-ventana, muestras y estado; sin paths runtime, prompts, raw payload ni actividad Hermes.
- Actualiza contratos TS, docs, OpenSpec y closeout Engram.

## Verify Zoro
- Red inicial: tests nuevos fallaban con `404` antes de implementar el endpoint.
- `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py`
- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` → 8 passed
- `npm --prefix apps/web run typecheck`
- `git diff --check`
- Smoke TestClient contra SQLite real: `GET /api/v1/usage/five-hour-windows?limit=3` → 200 `ready`, 3 ventanas, sin path runtime.

## Riesgo y reviewers
- Franky: semántica operativa de ventanas 5h, agrupación/normalización y viabilidad del read model.
- Chopper: frontera read-only/no leakage, validación de `limit`, ausencia de prompts/raw/path runtime.

## Fuera de alcance
- UI de ventanas 5h en `/usage` → 17.4b.
- Actividad Hermes agregada desde `state.db` → 17.4c/17.4d.
- Cierre final de #51 y Project Summary/vault → después de 17.4d.
