### PR TITLE
feat: add Usage five-hour windows UI

### DIFF
--- a/.engram/phase-17-4b-usage-five-hour-windows-ui-closeout.md
+++ b/.engram/phase-17-4b-usage-five-hour-windows-ui-closeout.md
@@ -1,0 +1,24 @@
+# Phase 17.4b closeout — Usage five-hour windows UI
+
+## Scope
+17.4b integrates the Phase 17.4a five-hour windows backend into `/usage` UI. It remains server-only/read-only and does not add Hermes activity.
+
+## Implemented
+- `fetchUsageFiveHourWindows(8)` in the server-only Usage adapter.
+- Fallback fixture for five-hour windows.
+- `/usage` panel `Ventanas 5h históricas` with start/end, peak, intra-window delta, samples, status and peak progress bar.
+- Responsive CSS for the windows list.
+- `verify:usage-server-only` now fixes the five-hour windows endpoint and UI strings.
+- Backend regression test for invalid `limit` values, covering Chopper's PR #74 nonblocking follow-up.
+
+## Deferred
+- Hermes activity backend aggregation and UI, still separated for 17.4c/17.4d.
+
+## Verify
+- `npm run verify:usage-server-only`.
+- `npm --prefix apps/web run typecheck`.
+- `npm --prefix apps/web run build` confirmed `/usage` remains dynamic (`ƒ`).
+- `npm run verify:visual-baseline`.
+- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` → 9 passed.
+- `git diff --check`.
+- Browser smoke `/usage` against local branch API (`127.0.0.1:8010`) and web (`127.0.0.1:3011`): real API mode, windows panel visible, console clean, no horizontal overflow.

--- a/apps/api/tests/test_usage_api.py
+++ b/apps/api/tests/test_usage_api.py
@@ -398,6 +398,18 @@ def test_usage_five_hour_windows_degrades_when_snapshot_db_is_absent(tmp_path):
     assert 'missing.sqlite' not in str(payload)
 
 
+def test_usage_five_hour_windows_rejects_invalid_limits_without_echoing_sensitive_values(tmp_path):
+    _override_usage_service(UsageService(db_path=tmp_path / 'missing.sqlite', now=lambda: '2026-04-26T14:40:00+00:00'))
+
+    for value in ('0', '25', '/srv/crew-core/runtime/usage/codex-usage.sqlite'):
+        response = TestClient(app).get(f'/api/v1/usage/five-hour-windows?limit={value}')
+
+        assert response.status_code == 422
+        payload = response.json()
+        assert payload == {'detail': {'code': 'validation_error', 'message': 'Request validation failed.'}}
+        assert '/srv/crew-core/runtime/usage' not in str(payload)
+
+
 def test_usage_calendar_does_not_count_cycle_reset_as_daily_delta(tmp_path):
     db_path = tmp_path / 'codex-usage.sqlite'
     con = sqlite3.connect(db_path)

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -175,6 +175,48 @@ button {
   font-weight: 800;
 }
 
+.usage-windows-list {
+  display: grid;
+  gap: 12px;
+}
+
+.usage-window-row {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 18px;
+  background: rgba(90, 157, 219, 0.08);
+}
+
+.usage-window-row__main {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
+.usage-window-row__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.usage-window-row__metrics dt {
+  color: #9aa7bd;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.usage-window-row__metrics dd {
+  margin: 2px 0 0;
+  font-weight: 800;
+}
+
 .responsive-code {
   overflow-x: auto;
   white-space: pre-wrap;
@@ -334,8 +376,13 @@ button {
     padding: 16px !important;
   }
 
-  .usage-calendar-day__metrics {
+  .usage-calendar-day__metrics,
+  .usage-window-row__metrics {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .usage-window-row__main {
+    flex-direction: column;
   }
 }
 

--- a/apps/web/src/app/usage/page.tsx
+++ b/apps/web/src/app/usage/page.tsx
@@ -1,9 +1,10 @@
 import type { ResourceStatus } from '@contracts/resource'
-import type { UsageCalendar, UsageCalendarDayStatus, UsageCurrent, UsageWindowStatus } from '@contracts/read-models'
+import type { UsageCalendar, UsageCalendarDayStatus, UsageCurrent, UsageFiveHourWindows, UsageWindowStatus } from '@contracts/read-models'
 
-import { fetchUsageCalendar, fetchUsageCurrent, UsageApiError } from '@/modules/usage/api/usage-http'
+import { fetchUsageCalendar, fetchUsageCurrent, fetchUsageFiveHourWindows, UsageApiError } from '@/modules/usage/api/usage-http'
 import { usageCalendarFixture } from '@/modules/usage/view-models/usage-calendar.fixture'
 import { usageCurrentFixture } from '@/modules/usage/view-models/usage-current.fixture'
+import { usageFiveHourWindowsFixture } from '@/modules/usage/view-models/usage-five-hour-windows.fixture'
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
 import { StatePanel } from '@/shared/ui/state/StatePanel'
@@ -24,6 +25,7 @@ type UsageNotice = {
 type UsagePageData = {
   usage: UsageCurrent
   calendar: UsageCalendar
+  fiveHourWindows: UsageFiveHourWindows
   resourceStatus: ResourceStatus | 'fallback'
   notice: UsageNotice | null
   isSnapshotMode: boolean
@@ -55,16 +57,22 @@ const calendarStatusMap: Record<UsageCalendarDayStatus, { appStatus: AppStatus; 
 
 async function getInitialUsageData(): Promise<UsagePageData> {
   try {
-    const [currentResponse, calendarResponse] = await Promise.all([fetchUsageCurrent(), fetchUsageCalendar('current_cycle')])
+    const [currentResponse, calendarResponse, fiveHourWindowsResponse] = await Promise.all([
+      fetchUsageCurrent(),
+      fetchUsageCalendar('current_cycle'),
+      fetchUsageFiveHourWindows(8),
+    ])
     const usage = currentResponse.data
     const calendar = calendarResponse.data
+    const fiveHourWindows = fiveHourWindowsResponse.data
 
-    const responseStatus = currentResponse.status !== 'ready' ? currentResponse.status : calendarResponse.status
+    const responseStatus = currentResponse.status !== 'ready' ? currentResponse.status : calendarResponse.status !== 'ready' ? calendarResponse.status : fiveHourWindowsResponse.status
 
     if (responseStatus !== 'ready') {
       return {
         usage,
         calendar,
+        fiveHourWindows,
         resourceStatus: responseStatus,
         isSnapshotMode: responseStatus === 'stale',
         notice: noticeFromResourceStatus(responseStatus),
@@ -74,6 +82,7 @@ async function getInitialUsageData(): Promise<UsagePageData> {
     return {
       usage,
       calendar,
+      fiveHourWindows,
       resourceStatus: currentResponse.status,
       notice: null,
       isSnapshotMode: false,
@@ -84,6 +93,7 @@ async function getInitialUsageData(): Promise<UsagePageData> {
     return {
       usage: usageCurrentFixture,
       calendar: usageCalendarFixture,
+      fiveHourWindows: usageFiveHourWindowsFixture,
       resourceStatus: 'fallback',
       isSnapshotMode: true,
       notice: {
@@ -203,6 +213,14 @@ function calendarPartialCopy(reason: UsageCalendar['days'][number]['codex_segmen
   return 'Día completo dentro del ciclo semanal Codex'
 }
 
+function formatSamples(value: number) {
+  if (value === 1) {
+    return '1 muestra'
+  }
+
+  return `${value} muestras`
+}
+
 function formatPeakPrimary(value: number | null) {
   if (value === null) {
     return 'Sin pico 5h'
@@ -309,6 +327,67 @@ function WindowCard({
   )
 }
 
+function UsageWindowsPanel({ windows, isSnapshotMode }: { windows: UsageFiveHourWindows; isSnapshotMode: boolean }) {
+  const items = windows.windows.slice(0, 8)
+
+  return (
+    <SurfaceCard title="Ventanas 5h históricas" eyebrow="Últimas ventanas Codex · saneado" accent="sky" elevated>
+      <div style={{ display: 'grid', gap: '12px' }}>
+        <p style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
+          Lectura dedicada de ventanas 5h: pico, delta positivo intra-ventana y muestras agregadas desde la SQLite saneada. No incluye actividad Hermes ni atribución causal por perfil.
+        </p>
+        {isSnapshotMode ? (
+          <p style={{ margin: 0, color: appTheme.colors.brandGold400, lineHeight: 1.5 }}>
+            Ventanas mostradas desde snapshot/fallback saneado: sirven para validar composición visual, no para decidir consumo real.
+          </p>
+        ) : null}
+        <div className="usage-windows-list" role="list" aria-label="Últimas ventanas 5h de Usage">
+          {items.length > 0 ? (
+            items.map((window) => {
+              const status = windowStatusToBadge(window.status)
+              return (
+                <article className="usage-window-row" key={`${window.started_at}-${window.ended_at}`} role="listitem" aria-label={`Ventana 5h ${formatTimestamp(window.started_at)}: ${status.label}`}>
+                  <div className="usage-window-row__main">
+                    <div>
+                      <p style={{ margin: 0, color: appTheme.colors.textMuted, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Ventana 5h</p>
+                      <h3 style={{ margin: '4px 0 0', fontSize: '18px' }}>{formatTimestamp(window.started_at)} → {formatTimestamp(window.ended_at)}</h3>
+                    </div>
+                    <StatusBadge status={status.appStatus} label={status.label} />
+                  </div>
+                  <dl className="usage-window-row__metrics">
+                    <div>
+                      <dt>Pico</dt>
+                      <dd>{formatPercent(window.peak_used_percent)}</dd>
+                    </div>
+                    <div>
+                      <dt>Delta intra-ventana</dt>
+                      <dd>{formatDeltaPercent(window.delta_percent)}</dd>
+                    </div>
+                    <div>
+                      <dt>Muestras</dt>
+                      <dd>{formatSamples(window.samples_count)}</dd>
+                    </div>
+                  </dl>
+                  <UsageProgressBar value={window.peak_used_percent} status={window.status} />
+                </article>
+              )
+            })
+          ) : (
+            <StatePanel
+              status="sin-datos"
+              title="Ventanas 5h sin datos"
+              description={windows.empty_reason === 'not_configured' ? 'La fuente de ventanas Usage aún no está configurada.' : 'No hay ventanas suficientes para componer el historial saneado.'}
+              eyebrow="Usage windows"
+              ariaRole="region"
+              ariaLabel="Ventanas 5h Usage sin datos"
+            />
+          )}
+        </div>
+      </div>
+    </SurfaceCard>
+  )
+}
+
 function UsageCalendarPanel({ calendar, isSnapshotMode }: { calendar: UsageCalendar; isSnapshotMode: boolean }) {
   const days = calendar.days.slice(-10)
 
@@ -373,7 +452,7 @@ function UsageCalendarPanel({ calendar, isSnapshotMode }: { calendar: UsageCalen
 }
 
 export default async function UsagePage() {
-  const { usage, calendar, notice, isSnapshotMode } = await getInitialUsageData()
+  const { usage, calendar, fiveHourWindows, notice, isSnapshotMode } = await getInitialUsageData()
   const recommendationStatus = recommendationStatusMap[usage.recommendation.state]
 
   return (
@@ -444,13 +523,18 @@ export default async function UsagePage() {
         <UsageCalendarPanel calendar={calendar} isSnapshotMode={isSnapshotMode} />
       </section>
 
+      <section className="section-block" aria-label="Ventanas 5h Usage">
+        <UsageWindowsPanel windows={fiveHourWindows} isSnapshotMode={isSnapshotMode} />
+      </section>
+
       <section className="section-block layout-grid layout-grid--content-aside">
-        <SurfaceCard title="Qué entra en esta vista" eyebrow="Alcance Phase 17.3b" accent="gold">
+        <SurfaceCard title="Qué entra en esta vista" eyebrow="Alcance Phase 17.4b" accent="gold">
           <ul style={{ margin: 0, paddingLeft: '18px', color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
             <li>Snapshot actual saneado de Codex usage.</li>
             <li>Ventana 5h y ciclo semanal Codex con rangos calculados por reset.</li>
             <li>Calendario por fecha natural Europe/Madrid con delta diario, ventanas 5h y pico diario saneados.</li>
-            <li>Actividad Hermes agregada y endpoint dedicado de ventanas históricas quedan para 17.4.</li>
+            <li>Ventanas 5h históricas dedicadas con pico, delta intra-ventana y muestras.</li>
+            <li>Actividad Hermes agregada queda para 17.4c/17.4d.</li>
           </ul>
         </SurfaceCard>
         <SurfaceCard title="Seguridad de datos" eyebrow="Deny by default" accent="sky">

--- a/apps/web/src/modules/AGENTS.md
+++ b/apps/web/src/modules/AGENTS.md
@@ -7,5 +7,5 @@ Features y módulos funcionales del frontend (dashboard, mugiwaras, skills, memo
 - Mantener una correspondencia clara entre módulo UI y módulo de producto.
 - Evitar dependencias cruzadas desordenadas.
 - **Vigilar `.gitignore`** y no subir mocks, capturas o outputs sensibles no saneados.
-- `usage`: Usage/Codex quota read-only frontend consuming server-only current snapshot and calendar adapters. Historical 5h windows and Hermes activity stay in later phases.
+- `usage`: Usage/Codex quota read-only frontend consuming server-only current snapshot, calendar and dedicated five-hour windows adapters. Hermes activity stays in a later phase.
 - Si nace un módulo nuevo, documentarlo aquí y en docs.

--- a/apps/web/src/modules/usage/AGENTS.md
+++ b/apps/web/src/modules/usage/AGENTS.md
@@ -8,4 +8,4 @@ Módulo frontend para la superficie `/usage` de uso Codex/Hermes.
 - Mantener la página read-only.
 - Usar siempre `ciclo semanal Codex`; no presentar el ciclo como semana natural lunes-domingo.
 - No exponer prompts, raw conversations, tokens, user/account IDs, headers ni raw payload.
-- El calendario por fecha natural consume solo el endpoint backend allowlisted; ventanas históricas dedicadas y actividad Hermes agregada pertenecen a fases posteriores separadas.
+- El calendario por fecha natural y las ventanas 5h históricas consumen solo endpoints backend allowlisted; actividad Hermes agregada pertenece a una fase posterior separada.

--- a/apps/web/src/modules/usage/api/usage-http.ts
+++ b/apps/web/src/modules/usage/api/usage-http.ts
@@ -3,7 +3,7 @@ import 'server-only'
 import http from 'node:http'
 import https from 'node:https'
 
-import type { UsageCalendarRange, UsageCalendarResponse, UsageCurrentResponse } from '@contracts/read-models'
+import type { UsageCalendarRange, UsageCalendarResponse, UsageCurrentResponse, UsageFiveHourWindowsResponse } from '@contracts/read-models'
 
 export const USAGE_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'
 
@@ -135,4 +135,15 @@ export async function fetchUsageCalendar(range: UsageCalendarRange = 'current_cy
   const allowedRanges: UsageCalendarRange[] = ['current_cycle', 'previous_cycle', '7d', '30d']
   const safeRange = allowedRanges.includes(range) ? range : 'current_cycle'
   return requestUsageJson<UsageCalendarResponse>(`${baseUrl}/api/v1/usage/calendar?range=${encodeURIComponent(safeRange)}`)
+}
+
+export async function fetchUsageFiveHourWindows(limit = 8): Promise<UsageFiveHourWindowsResponse> {
+  const baseUrl = getUsageApiBaseUrl()
+
+  if (!baseUrl) {
+    throw new UsageApiError('not_configured', { status: 0, code: 'not_configured' })
+  }
+
+  const safeLimit = Math.max(1, Math.min(24, Math.trunc(limit)))
+  return requestUsageJson<UsageFiveHourWindowsResponse>(`${baseUrl}/api/v1/usage/five-hour-windows?limit=${safeLimit}`)
 }

--- a/apps/web/src/modules/usage/view-models/usage-five-hour-windows.fixture.ts
+++ b/apps/web/src/modules/usage/view-models/usage-five-hour-windows.fixture.ts
@@ -1,0 +1,31 @@
+import type { UsageFiveHourWindows } from '@contracts/read-models'
+
+export const usageFiveHourWindowsFixture: UsageFiveHourWindows = {
+  empty_reason: null,
+  windows: [
+    {
+      started_at: '2026-04-26T18:04:00+00:00',
+      ended_at: '2026-04-26T23:04:00+00:00',
+      peak_used_percent: 26,
+      delta_percent: 26,
+      samples_count: 12,
+      status: 'normal',
+    },
+    {
+      started_at: '2026-04-26T13:04:00+00:00',
+      ended_at: '2026-04-26T18:04:00+00:00',
+      peak_used_percent: 84,
+      delta_percent: 48,
+      samples_count: 16,
+      status: 'high',
+    },
+    {
+      started_at: '2026-04-26T08:04:00+00:00',
+      ended_at: '2026-04-26T13:04:00+00:00',
+      peak_used_percent: 96,
+      delta_percent: 62,
+      samples_count: 18,
+      status: 'critical',
+    },
+  ],
+}

--- a/docs/frontend-implementation-handoff.md
+++ b/docs/frontend-implementation-handoff.md
@@ -87,7 +87,7 @@ apps/web/src/app/
   vault/page.tsx
   vault/[...path]/page.tsx          # opcional si la navegación es por ruta
   healthcheck/page.tsx
-  usage/page.tsx                    # Usage Codex/Hermes current-state
+  usage/page.tsx                    # Usage Codex/Hermes current-state + calendario + ventanas 5h
 ```
 
 ## 3.2 Módulos funcionales

--- a/docs/frontend-ui-spec.md
+++ b/docs/frontend-ui-spec.md
@@ -83,7 +83,7 @@ Diseñar un shell de navegación estable y escaneable que:
 ├── /vault
 │   └── /vault/[...path]           # navegación documental si se implementa por ruta
 ├── /healthcheck
-└── /usage                         # Usage Codex/Hermes current-state + calendario por fecha natural
+└── /usage                         # Usage Codex/Hermes current-state + calendario + ventanas 5h históricas
 ```
 
 ## 2.3 IA del shell

--- a/openspec/phase-17-4b-usage-five-hour-windows-ui.md
+++ b/openspec/phase-17-4b-usage-five-hour-windows-ui.md
@@ -1,0 +1,30 @@
+# Phase 17.4b — Usage five-hour windows UI
+
+## Objetivo
+Integrar en `/usage` las ventanas 5h históricas dedicadas cerradas en 17.4a, manteniendo la página server-only, read-only y sin actividad Hermes.
+
+## Alcance
+- Extender adapter server-only con `fetchUsageFiveHourWindows(8)`.
+- Añadir fixture fallback saneada de ventanas 5h.
+- Renderizar panel responsive `Ventanas 5h históricas` con inicio/fin, pico, delta intra-ventana, muestras, estado y barra de pico.
+- Actualizar `verify:usage-server-only` para fijar endpoint de ventanas y grid/list responsive.
+- Incorporar follow-up menor de Chopper de PR #74: test explícito de límites inválidos para `/five-hour-windows`.
+- Actualizar docs vivas y AGENTS del módulo Usage.
+
+## Fuera de alcance
+- Backend nuevo o cambio semántico del endpoint 17.4a.
+- Actividad Hermes local agregada, `state.db`, perfiles dominantes, sesiones/mensajes/tool calls o tokens.
+- Selector interactivo de rangos.
+- Escritura, export o acciones operativas.
+
+## Verify esperado
+- `npm run verify:usage-server-only`.
+- `npm --prefix apps/web run typecheck`.
+- `npm --prefix apps/web run build`.
+- `npm run verify:visual-baseline`.
+- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q`.
+- `git diff --check`.
+- Browser smoke `/usage`: panel de ventanas visible, consola limpia y sin overflow horizontal.
+
+## Review
+Usopp + Chopper. Usopp revisa UX/responsive/copy; Chopper revisa que la UI no exponga paths, raw payload ni actividad Hermes y que el adapter siga server-only.

--- a/openspec/phase-17-4b-verify-checklist.md
+++ b/openspec/phase-17-4b-verify-checklist.md
@@ -1,0 +1,23 @@
+# Phase 17.4b verify checklist
+
+## Scope decision
+- [x] 17.4b se limita a UI de ventanas 5h históricas.
+- [x] No añade actividad Hermes ni nueva fuente.
+- [x] Follow-up menor de Chopper de PR #74 queda cubierto con test de límites inválidos.
+
+## UI contract
+- [x] Adapter server-only consume endpoint fijo `/api/v1/usage/five-hour-windows?limit=`.
+- [x] Fixture fallback saneada añadida.
+- [x] `/usage` renderiza panel `Ventanas 5h históricas`.
+- [x] Panel muestra inicio/fin, pico, delta intra-ventana, muestras, estado y barra.
+- [x] No muestra actividad Hermes, prompts, conversaciones, tokens, raw payload ni paths runtime.
+- [x] Guardrail `verify:usage-server-only` actualizado.
+
+## Verify evidence
+- [x] `npm run verify:usage-server-only`.
+- [x] `npm --prefix apps/web run typecheck`.
+- [x] `npm --prefix apps/web run build` → `/usage` dinámica (`ƒ`).
+- [x] `npm run verify:visual-baseline`.
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` → 9 passed.
+- [x] `git diff --check`.
+- [x] Browser smoke `/usage` contra API local de la rama: panel de ventanas visible, consola limpia y `document.body.scrollWidth <= window.innerWidth`.

--- a/scripts/check-usage-server-only.mjs
+++ b/scripts/check-usage-server-only.mjs
@@ -28,14 +28,20 @@ if (!http.includes('/api/v1/usage/current')) {
 if (!http.includes('/api/v1/usage/calendar?range=')) {
   failures.push('usage adapter must call the fixed calendar endpoint with allowlisted range')
 }
-if (!http.includes('UsageCalendarRange') || !http.includes('UsageCalendarResponse')) {
-  failures.push('usage adapter must type calendar ranges and responses via shared contracts')
+if (!http.includes('/api/v1/usage/five-hour-windows?limit=')) {
+  failures.push('usage adapter must call the fixed five-hour windows endpoint with allowlisted limit')
+}
+if (!http.includes('UsageCalendarRange') || !http.includes('UsageCalendarResponse') || !http.includes('UsageFiveHourWindowsResponse')) {
+  failures.push('usage adapter must type calendar and five-hour windows responses via shared contracts')
 }
 if (!page.includes('Calendario por fecha natural') || !page.includes('Europe/Madrid')) {
   failures.push('usage page must render the natural-date calendar with timezone context')
 }
 if (!page.includes('usage-calendar-grid') || !page.includes('primary_windows_count')) {
   failures.push('usage page must render a responsive calendar grid without generic table overflow')
+}
+if (!page.includes('Ventanas 5h históricas') || !page.includes('usage-windows-list') || !page.includes('delta_percent')) {
+  failures.push('usage page must render dedicated five-hour windows without generic table overflow')
 }
 if (http.includes('path=') || http.includes('target=') || http.includes('method=')) {
   failures.push('usage adapter must not grow generic proxy parameters')

--- a/scripts/visual-verify-baseline.mjs
+++ b/scripts/visual-verify-baseline.mjs
@@ -106,7 +106,8 @@ const routes = [
       'stale, not_configured o fallback quedan visibles como fuente degradada/no tiempo real',
       'fórmulas y privacidad hacen wrap sin filtrar detalles internos del host',
       'el calendario por fecha natural aparece como grid/cards responsive sin scroll horizontal obligatorio',
-      'actividad Hermes agregada y endpoint dedicado de ventanas históricas siguen fuera de esta fase',
+      'las ventanas 5h históricas aparecen como lista/cards responsive sin scroll horizontal obligatorio',
+      'actividad Hermes agregada sigue fuera de esta fase',
     ],
   },
 ]


### PR DESCRIPTION
## Resumen
- Integra en `/usage` el endpoint de 17.4a `GET /api/v1/usage/five-hour-windows?limit=8`.
- Añade adapter server-only `fetchUsageFiveHourWindows(8)` y fixture fallback saneada.
- Renderiza panel responsive `Ventanas 5h históricas` con inicio/fin, pico, delta intra-ventana, muestras, estado y barra de pico.
- Actualiza guardrail `verify:usage-server-only`, baseline visual, docs frontend y AGENTS del módulo Usage.
- Cubre follow-up menor de Chopper en PR #74: test explícito de límites inválidos para `/five-hour-windows` sin eco de path sensible.

## Alcance
Incluye:
- UI visible de ventanas 5h históricas en `/usage`.
- Adapter server-only a endpoint fijo, con limit saneado.
- CSS responsive para lista/cards sin tabla ni scroll horizontal obligatorio.
- Docs/OpenSpec/Engram de 17.4b.

Fuera de alcance:
- Actividad Hermes agregada / `state.db` / perfiles dominantes / sesiones / mensajes / tool calls / tokens.
- Cambios semánticos del backend 17.4a.
- Selector interactivo de rangos.
- Escritura/export/acciones operativas.

## Verify Zoro
- `npm run verify:usage-server-only`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build` → `/usage` sigue dinámica (`ƒ`)
- `npm run verify:visual-baseline`
- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` → 9 passed
- `git diff --check`
- Browser smoke `/usage` contra API local de la rama: panel de ventanas visible, consola limpia y sin overflow horizontal.

## Nota operativa
Se limpiaron procesos dev tracked de la sesión anterior. Persistía un listener externo en `0.0.0.0:3001` sin PID visible para este usuario; no bloquea la PR. El smoke final de 17.4b se hizo con API de rama en `127.0.0.1:8010` y web en `127.0.0.1:3011`.

## Review solicitada
- Usopp: UI/UX/responsive/copy del panel de ventanas 5h y su encaje en `/usage`.
- Chopper: server-only/no leakage, ausencia de actividad Hermes/raw/path runtime y guardrail.
