### PR TITLE
Phase 17.4c: add Usage Hermes activity backend

### DIFF
--- a/.engram/phase-17-4c-usage-hermes-activity-backend-closeout.md
+++ b/.engram/phase-17-4c-usage-hermes-activity-backend-closeout.md
@@ -1,0 +1,35 @@
+# Phase 17.4c closeout — Usage Hermes activity backend
+
+## Scope
+17.4c adds only the backend read model for Hermes local activity aggregation. It does not add UI and does not close #51.
+
+## Decision
+17.4c was not split further because the safe scope is one backend-only boundary: read-only profile-state aggregation behind server-side configuration, with no writer, no runtime producer and no visible UI.
+
+## Implemented
+- `GET /api/v1/usage/hermes-activity?range=7d|30d|current_cycle|previous_cycle`.
+- `UsageService` optional `MUGIWARA_HERMES_PROFILES_ROOT` server-side config.
+- Explicit Mugiwara profile allowlist.
+- Read-only SQLite access to profile state databases using `mode=ro`.
+- Aggregated output only: sessions, messages, tool calls, first/last activity, activity level and dominant profile.
+- 422 saneado para rangos inválidos.
+- Shared TS contracts for `UsageHermesActivity`.
+- `verify:usage-server-only` extended with backend guardrails for Hermes activity.
+- Docs updated: `docs/api-modules.md`, `docs/read-models.md`, `docs/runtime-config.md`.
+
+## Privacy boundary
+The endpoint does not select or serialize raw prompts, conversations, tool payloads, user IDs, chat IDs, delivery targets, tokens by session/conversation, costs, billing URLs, headers, cookies, secrets, logs, model config, titles or profile DB paths.
+
+## Verify
+- Red initial: usage tests failed before implementation because `UsageService` did not accept `hermes_profiles_root` and no endpoint existed.
+- `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py`.
+- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` → 12 passed.
+- `npm run verify:usage-server-only` → passed after backend guardrail update.
+- `npm --prefix apps/web run typecheck` → passed.
+- `npm --prefix apps/web run build` → passed; `/usage` remains dynamic (`ƒ`).
+- `git diff --check` → passed.
+- TestClient smoke with `MUGIWARA_HERMES_PROFILES_ROOT` configured locally returned `ready` aggregates without profile DB path or sensitive markers.
+
+## Deferred
+- 17.4d UI activity panel in `/usage`.
+- Final #51 closeout/canon after UI exists and reviews pass.

--- a/apps/api/src/modules/usage/router.py
+++ b/apps/api/src/modules/usage/router.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, Query
 
 from ...shared.contracts import resource_response
-from .service import DEFAULT_USAGE_WINDOWS_LIMIT, MAX_USAGE_WINDOWS_LIMIT, USAGE_REFRESH_INTERVAL_MINUTES, UsageCalendarRange, UsageService
+from .service import (
+    DEFAULT_USAGE_WINDOWS_LIMIT,
+    HERMES_ACTIVITY_SOURCE_LABEL,
+    MAX_USAGE_WINDOWS_LIMIT,
+    USAGE_REFRESH_INTERVAL_MINUTES,
+    UsageActivityRange,
+    UsageCalendarRange,
+    UsageService,
+)
 
 router = APIRouter(prefix='/api/v1/usage', tags=['usage'])
 _service = UsageService()
@@ -61,5 +69,21 @@ def get_usage_five_hour_windows(
             'sanitized': True,
             'source': 'codex-usage-snapshot-sqlite',
             'limit': limit,
+        },
+    )
+
+
+@router.get('/hermes-activity')
+def get_usage_hermes_activity(range: UsageActivityRange = '7d', service: UsageService = Depends(get_usage_service)) -> dict:
+    activity = service.get_hermes_activity(range)
+    return resource_response(
+        resource='usage.hermes_activity',
+        status=service.hermes_activity_status_for(activity),
+        data=activity,
+        meta={
+            'read_only': True,
+            'sanitized': True,
+            'source': HERMES_ACTIVITY_SOURCE_LABEL,
+            'range': range,
         },
     )

--- a/apps/api/src/modules/usage/service.py
+++ b/apps/api/src/modules/usage/service.py
@@ -5,6 +5,7 @@ from datetime import datetime, time, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Literal
 from zoneinfo import ZoneInfo
+import os
 import sqlite3
 
 CODEX_USAGE_DB_PATH = Path('/srv/crew-core/runtime/usage/codex-usage.sqlite')
@@ -12,8 +13,12 @@ USAGE_REFRESH_INTERVAL_MINUTES = 15
 USAGE_STALE_AFTER_MINUTES = 45
 USAGE_CALENDAR_TIMEZONE = ZoneInfo('Europe/Madrid')
 UsageCalendarRange = Literal['current_cycle', 'previous_cycle', '7d', '30d']
+UsageActivityRange = Literal['current_cycle', 'previous_cycle', '7d', '30d']
 MAX_USAGE_WINDOWS_LIMIT = 24
 DEFAULT_USAGE_WINDOWS_LIMIT = 8
+HERMES_PROFILES_ROOT_ENV = 'MUGIWARA_HERMES_PROFILES_ROOT'
+HERMES_ACTIVITY_SOURCE_LABEL = 'hermes-profile-state-aggregate'
+HERMES_ACTIVITY_PROFILES = ('luffy', 'zoro', 'nami', 'usopp', 'sanji', 'chopper', 'robin', 'franky', 'brook', 'jinbe')
 
 
 def _parse_datetime(value: str | None) -> datetime | None:
@@ -124,8 +129,10 @@ class UsageSnapshot:
 
 
 class UsageService:
-    def __init__(self, *, db_path: Path = CODEX_USAGE_DB_PATH, now: Callable[[], str] = _iso_now):
+    def __init__(self, *, db_path: Path = CODEX_USAGE_DB_PATH, hermes_profiles_root: Path | None = None, now: Callable[[], str] = _iso_now):
         self.db_path = db_path
+        configured_profiles_root = os.environ.get(HERMES_PROFILES_ROOT_ENV)
+        self.hermes_profiles_root = hermes_profiles_root if hermes_profiles_root is not None else (Path(configured_profiles_root) if configured_profiles_root else None)
         self._now = now
 
     def current_status(self) -> str:
@@ -270,6 +277,60 @@ class UsageService:
         if payload.get('empty_reason') == 'not_configured':
             return 'not_configured'
         if not payload.get('windows'):
+            return 'not_configured'
+        return 'ready'
+
+    def get_hermes_activity(self, range_name: UsageActivityRange) -> dict[str, Any]:
+        start_at, end_at, range_empty_reason = self._activity_window(range_name)
+        if self.hermes_profiles_root is None or not self.hermes_profiles_root.exists() or not self.hermes_profiles_root.is_dir():
+            return self._empty_hermes_activity(range_name, start_at=start_at, end_at=end_at, empty_reason='not_configured')
+        if range_empty_reason is not None:
+            return self._empty_hermes_activity(range_name, start_at=start_at, end_at=end_at, empty_reason=range_empty_reason)
+
+        profiles = []
+        for profile in HERMES_ACTIVITY_PROFILES:
+            state_db = self.hermes_profiles_root / profile / 'state.db'
+            profile_summary = self._load_hermes_profile_activity(profile=profile, state_db=state_db, start_at=start_at, end_at=end_at)
+            if profile_summary is not None and profile_summary['sessions_count'] > 0:
+                profiles.append(profile_summary)
+
+        profiles.sort(key=lambda item: (-item['messages_count'], -item['tool_calls_count'], item['profile']))
+        totals = self._activity_totals(profiles)
+        return {
+            'range': {
+                'name': range_name,
+                'started_at': _isoformat_utc(start_at),
+                'ended_at': _isoformat_utc(end_at),
+            },
+            'totals': totals,
+            'profiles': profiles,
+            'privacy': {
+                'mode': 'read_only_aggregated',
+                'correlation': 'orientativa',
+                'exclusions': [
+                    'prompts_crudos',
+                    'conversaciones',
+                    'payloads_herramientas',
+                    'tokens_por_sesion',
+                    'identificadores_usuario',
+                    'identificadores_chat',
+                    'destinos_entrega',
+                    'secretos',
+                    'cabeceras',
+                    'galletas_http',
+                    'logs_crudos',
+                ],
+            },
+            'empty_reason': None if totals['sessions_count'] > 0 else 'not_configured',
+        }
+
+    @staticmethod
+    def hermes_activity_status_for(payload: dict[str, Any]) -> str:
+        if payload.get('empty_reason') == 'not_configured':
+            return 'not_configured'
+        if payload.get('empty_reason') == 'unknown':
+            return 'unknown'
+        if payload.get('totals', {}).get('sessions_count', 0) <= 0:
             return 'not_configured'
         return 'ready'
 
@@ -422,6 +483,124 @@ class UsageService:
                 }
             )
         return days
+
+    def _activity_window(self, range_name: UsageActivityRange) -> tuple[datetime, datetime, str | None]:
+        now = _parse_datetime(self._now()) or datetime.now(timezone.utc)
+        latest = self._load_latest_snapshot()
+        cycle_start = _parse_datetime(latest.secondary_cycle_start_at) if latest is not None else None
+        cycle_reset = _parse_datetime(latest.secondary_reset_at) if latest is not None else None
+        if range_name == 'current_cycle':
+            if cycle_start is None or cycle_reset is None:
+                return now, now, 'not_configured'
+            return cycle_start, min(now, cycle_reset), None
+        if range_name == 'previous_cycle':
+            if cycle_start is None or cycle_reset is None:
+                return now, now, 'not_configured'
+            cycle_length = cycle_reset - cycle_start
+            return cycle_start - cycle_length, cycle_start, None
+        days = 30 if range_name == '30d' else 7
+        return now - timedelta(days=days), now, None
+
+    def _empty_hermes_activity(self, range_name: UsageActivityRange, *, start_at: datetime, end_at: datetime, empty_reason: str) -> dict[str, Any]:
+        return {
+            'range': {
+                'name': range_name,
+                'started_at': _isoformat_utc(start_at),
+                'ended_at': _isoformat_utc(end_at),
+            },
+            'totals': {
+                'profiles_count': 0,
+                'sessions_count': 0,
+                'messages_count': 0,
+                'tool_calls_count': 0,
+                'dominant_profile': None,
+            },
+            'profiles': [],
+            'privacy': {
+                'mode': 'read_only_aggregated',
+                'correlation': 'orientativa',
+                'exclusions': [
+                    'prompts_crudos',
+                    'conversaciones',
+                    'payloads_herramientas',
+                    'tokens_por_sesion',
+                    'identificadores_usuario',
+                    'identificadores_chat',
+                    'destinos_entrega',
+                    'secretos',
+                    'cabeceras',
+                    'galletas_http',
+                    'logs_crudos',
+                ],
+            },
+            'empty_reason': empty_reason,
+        }
+
+    @staticmethod
+    def _activity_level(messages_count: int, tool_calls_count: int) -> str:
+        score = messages_count + (tool_calls_count * 2)
+        if score >= 40:
+            return 'high'
+        if score >= 10:
+            return 'medium'
+        return 'low'
+
+    @staticmethod
+    def _activity_totals(profiles: list[dict[str, Any]]) -> dict[str, Any]:
+        sessions_count = sum(int(profile['sessions_count']) for profile in profiles)
+        messages_count = sum(int(profile['messages_count']) for profile in profiles)
+        tool_calls_count = sum(int(profile['tool_calls_count']) for profile in profiles)
+        dominant_profile = profiles[0]['profile'] if profiles else None
+        return {
+            'profiles_count': len(profiles),
+            'sessions_count': sessions_count,
+            'messages_count': messages_count,
+            'tool_calls_count': tool_calls_count,
+            'dominant_profile': dominant_profile,
+        }
+
+    def _load_hermes_profile_activity(self, *, profile: str, state_db: Path, start_at: datetime, end_at: datetime) -> dict[str, Any] | None:
+        if not state_db.exists() or not state_db.is_file():
+            return None
+        try:
+            con = sqlite3.connect(f'file:{state_db}?mode=ro', uri=True)
+            con.row_factory = sqlite3.Row
+            row = con.execute(
+                """
+                SELECT
+                    COUNT(*) AS sessions_count,
+                    COALESCE(SUM(message_count), 0) AS messages_count,
+                    COALESCE(SUM(tool_call_count), 0) AS tool_calls_count,
+                    MIN(started_at) AS first_activity_epoch,
+                    MAX(started_at) AS last_activity_epoch
+                FROM sessions
+                WHERE started_at >= ? AND started_at <= ?
+                """,
+                (start_at.timestamp(), end_at.timestamp()),
+            ).fetchone()
+        except sqlite3.Error:
+            return None
+        finally:
+            try:
+                con.close()
+            except UnboundLocalError:
+                pass
+        if row is None or int(row['sessions_count'] or 0) <= 0:
+            return None
+        sessions_count = int(row['sessions_count'] or 0)
+        messages_count = int(row['messages_count'] or 0)
+        tool_calls_count = int(row['tool_calls_count'] or 0)
+        first_epoch = float(row['first_activity_epoch'])
+        last_epoch = float(row['last_activity_epoch'])
+        return {
+            'profile': profile,
+            'sessions_count': sessions_count,
+            'messages_count': messages_count,
+            'tool_calls_count': tool_calls_count,
+            'first_activity_at': datetime.fromtimestamp(first_epoch, timezone.utc).isoformat(),
+            'last_activity_at': datetime.fromtimestamp(last_epoch, timezone.utc).isoformat(),
+            'activity_level': self._activity_level(messages_count, tool_calls_count),
+        }
 
     def _load_latest_snapshot(self) -> UsageSnapshot | None:
         if not self.db_path.exists() or not self.db_path.is_file():

--- a/apps/api/tests/test_usage_api.py
+++ b/apps/api/tests/test_usage_api.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 from fastapi.testclient import TestClient
 
@@ -127,6 +128,114 @@ def _insert_usage_snapshot(
 
 def _override_usage_service(service: UsageService):
     app.dependency_overrides[get_usage_service] = lambda: service
+
+
+def _epoch(value: str) -> float:
+    return datetime.fromisoformat(value.replace('Z', '+00:00')).timestamp()
+
+
+def _create_hermes_state_db(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    con.execute(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            user_id TEXT,
+            model TEXT,
+            model_config TEXT,
+            system_prompt TEXT,
+            parent_session_id TEXT,
+            started_at REAL NOT NULL,
+            ended_at REAL,
+            end_reason TEXT,
+            message_count INTEGER DEFAULT 0,
+            tool_call_count INTEGER DEFAULT 0,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cache_read_tokens INTEGER DEFAULT 0,
+            cache_write_tokens INTEGER DEFAULT 0,
+            reasoning_tokens INTEGER DEFAULT 0,
+            billing_provider TEXT,
+            billing_base_url TEXT,
+            billing_mode TEXT,
+            estimated_cost_usd REAL,
+            actual_cost_usd REAL,
+            cost_status TEXT,
+            cost_source TEXT,
+            pricing_version TEXT,
+            title TEXT,
+            FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
+        )
+        """
+    )
+    for row in rows:
+        con.execute(
+            """
+            INSERT INTO sessions (
+                id, source, user_id, model, model_config, system_prompt, parent_session_id,
+                started_at, ended_at, end_reason, message_count, tool_call_count,
+                input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+                reasoning_tokens, billing_provider, billing_base_url, billing_mode,
+                estimated_cost_usd, actual_cost_usd, cost_status, cost_source,
+                pricing_version, title
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                row['id'],
+                row.get('source', 'telegram'),
+                row.get('user_id', 'secret-user-123'),
+                row.get('model', 'secret-model-name'),
+                row.get('model_config', '{"api_key":"synthetic-token"}'),
+                row.get('system_prompt', 'raw prompt body should never leak'),
+                row.get('parent_session_id'),
+                _epoch(row['started_at']),
+                _epoch(row.get('ended_at', row['started_at'])),
+                row.get('end_reason', 'stop'),
+                row.get('message_count', 0),
+                row.get('tool_call_count', 0),
+                row.get('input_tokens', 999999),
+                row.get('output_tokens', 999999),
+                row.get('cache_read_tokens', 999999),
+                row.get('cache_write_tokens', 999999),
+                row.get('reasoning_tokens', 999999),
+                row.get('billing_provider', 'secret-provider'),
+                row.get('billing_base_url', 'https://token.example.invalid'),
+                row.get('billing_mode', 'secret-mode'),
+                row.get('estimated_cost_usd', 42.0),
+                row.get('actual_cost_usd', 43.0),
+                row.get('cost_status', 'secret-cost'),
+                row.get('cost_source', 'secret-source'),
+                row.get('pricing_version', 'secret-pricing'),
+                row.get('title', 'conversation title should never leak'),
+            ),
+        )
+    con.commit()
+    con.close()
+
+
+def _assert_no_usage_activity_leakage(payload: dict[str, Any]) -> None:
+    serialized = str(payload).lower()
+    forbidden = [
+        'state.db',
+        '/home/agentops',
+        'secret-user-123',
+        'synthetic-token',
+        'raw prompt body',
+        'conversation title',
+        'secret-model-name',
+        'token.example.invalid',
+        '999999',
+        '42.0',
+        '43.0',
+        'chat_id',
+        'delivery',
+        'cookie',
+        'authorization',
+    ]
+    for marker in forbidden:
+        assert marker not in serialized
 
 
 def teardown_function():
@@ -408,6 +517,85 @@ def test_usage_five_hour_windows_rejects_invalid_limits_without_echoing_sensitiv
         payload = response.json()
         assert payload == {'detail': {'code': 'validation_error', 'message': 'Request validation failed.'}}
         assert '/srv/crew-core/runtime/usage' not in str(payload)
+
+
+def test_usage_hermes_activity_aggregates_profile_sessions_without_leaking_sensitive_state(tmp_path):
+    profiles_root = tmp_path / 'profiles'
+    _create_hermes_state_db(
+        profiles_root / 'zoro' / 'state.db',
+        [
+            {'id': 'zoro-session-1', 'started_at': '2026-04-25T12:00:00+00:00', 'message_count': 8, 'tool_call_count': 3},
+            {'id': 'zoro-session-2', 'started_at': '2026-04-26T09:00:00+00:00', 'message_count': 4, 'tool_call_count': 1},
+            {'id': 'old-zoro-session', 'started_at': '2026-04-10T09:00:00+00:00', 'message_count': 50, 'tool_call_count': 50},
+        ],
+    )
+    _create_hermes_state_db(
+        profiles_root / 'franky' / 'state.db',
+        [
+            {'id': 'franky-session-1', 'started_at': '2026-04-24T10:00:00+00:00', 'message_count': 5, 'tool_call_count': 1},
+        ],
+    )
+    _override_usage_service(UsageService(db_path=tmp_path / 'missing-codex.sqlite', hermes_profiles_root=profiles_root, now=lambda: '2026-04-27T10:00:00+00:00'))
+
+    response = TestClient(app).get('/api/v1/usage/hermes-activity?range=7d')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'usage.hermes_activity'
+    assert payload['status'] == 'ready'
+    assert payload['meta'] == {
+        'read_only': True,
+        'sanitized': True,
+        'source': 'hermes-profile-state-aggregate',
+        'range': '7d',
+    }
+    assert payload['data']['range']['name'] == '7d'
+    assert payload['data']['totals'] == {
+        'profiles_count': 2,
+        'sessions_count': 3,
+        'messages_count': 17,
+        'tool_calls_count': 5,
+        'dominant_profile': 'zoro',
+    }
+    profiles = payload['data']['profiles']
+    assert profiles[0] == {
+        'profile': 'zoro',
+        'sessions_count': 2,
+        'messages_count': 12,
+        'tool_calls_count': 4,
+        'first_activity_at': '2026-04-25T12:00:00+00:00',
+        'last_activity_at': '2026-04-26T09:00:00+00:00',
+        'activity_level': 'medium',
+    }
+    assert profiles[1]['profile'] == 'franky'
+    assert profiles[1]['activity_level'] == 'low'
+    assert payload['data']['privacy']['correlation'] == 'orientativa'
+    _assert_no_usage_activity_leakage(payload)
+
+
+def test_usage_hermes_activity_degrades_when_profiles_root_is_not_configured(tmp_path):
+    _override_usage_service(UsageService(db_path=tmp_path / 'missing-codex.sqlite', hermes_profiles_root=None, now=lambda: '2026-04-27T10:00:00+00:00'))
+
+    response = TestClient(app).get('/api/v1/usage/hermes-activity?range=7d')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['status'] == 'not_configured'
+    assert payload['data']['profiles'] == []
+    assert payload['data']['totals']['profiles_count'] == 0
+    _assert_no_usage_activity_leakage(payload)
+
+
+def test_usage_hermes_activity_rejects_unknown_ranges_without_echoing_sensitive_values(tmp_path):
+    _override_usage_service(UsageService(db_path=tmp_path / 'missing.sqlite', hermes_profiles_root=tmp_path / 'profiles', now=lambda: '2026-04-27T10:00:00+00:00'))
+
+    response = TestClient(app).get('/api/v1/usage/hermes-activity?range=/home/agentops/.hermes/profiles/zoro/state.db')
+
+    assert response.status_code == 422
+    payload = response.json()
+    assert payload == {'detail': {'code': 'validation_error', 'message': 'Request validation failed.'}}
+    assert '/home/agentops' not in str(payload)
+    assert 'state.db' not in str(payload)
 
 
 def test_usage_calendar_does_not_count_cycle_reset_as_daily_delta(tmp_path):

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -75,8 +75,11 @@
 - serializar calendario por fecha natural en zona `Europe/Madrid`, deltas diarios del ciclo semanal Codex calculados por segmento continuo para no contar resets como consumo, tramos parciales por inicio/reset de ciclo, número de ventanas 5h y pico diario sin prompts, raw payload ni actividad Hermes
 - exponer `GET /api/v1/usage/five-hour-windows?limit=8` como read model dedicado de últimas ventanas 5h, agrupado por inicio/reset de ventana normalizado a minuto UTC y limitado a `1..24`
 - serializar ventanas 5h solo con inicio, fin, pico %, delta positivo intra-ventana, muestras y estado; sin paths runtime, prompts, raw payload ni actividad Hermes
+- exponer `GET /api/v1/usage/hermes-activity?range=7d|30d|current_cycle|previous_cycle` como read model backend-only de actividad Hermes agregada por perfiles allowlisted
+- leer perfiles Hermes solo si `MUGIWARA_HERMES_PROFILES_ROOT` está configurado en servidor; abrir cada SQLite de perfil en `mode=ro` y no exponer la ruta del fichero ni el root configurado
+- serializar actividad Hermes solo como agregados por perfil/rango: sesiones, mensajes, tool calls, primera/última actividad, perfil dominante e índice bajo/medio/alto; sin prompts, conversaciones, tool payloads, tokens por sesión/conversación, IDs, targets, secretos, headers, cookies ni logs
 - degradar DB ausente/ilegible/sin snapshots a `not_configured`/`unknown` visible, nunca a dato sano silencioso
-- mantener actividad Hermes local para subfase separada y saneada
+- mantener la UI de actividad Hermes para subfase separada 17.4d
 
 ### `system`
 - estado general del servidor y señales operativas de alto nivel

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -130,6 +130,21 @@ Uso:
 - no incluir actividad Hermes, prompts, conversaciones, tokens, raw payload, rutas runtime ni causalidad por perfil
 - limitar la respuesta con `limit` validado (`1..24`) y degradar fuente ausente/ilegible a `not_configured` sin path runtime
 
+### `usage.hermes_activity`
+Campos esperados:
+- `range` con rango allowlisted (`7d`, `30d`, `current_cycle`, `previous_cycle`) y timestamps de corte
+- `totals` con perfiles activos, sesiones, mensajes, tool calls y perfil dominante
+- `profiles[]` con `profile`, `sessions_count`, `messages_count`, `tool_calls_count`, primera/última actividad y `activity_level` (`low`, `medium`, `high`)
+- `privacy` con modo agregado/read-only y correlación orientativa
+- `empty_reason` (`not_configured`, `unknown` o `null`)
+
+Uso:
+- exponer actividad Hermes local solo como agregados por perfil/rango para orientar correlación con consumo Codex, sin afirmar causalidad exacta
+- leer únicamente perfiles Mugiwara allowlisted y abrir cada SQLite de perfil en `mode=ro`
+- usar `MUGIWARA_HERMES_PROFILES_ROOT` como configuración server-only; no serializar ni documentar el valor runtime, ruta de `state.db` ni paths host
+- no seleccionar ni devolver `user_id`, `model_config`, `system_prompt`, `title`, tokens, costes, billing URLs, contenidos, conversaciones, prompts, payloads de herramientas, chat IDs, targets, secretos, cabeceras, cookies ni logs
+- degradar raíz no configurada, perfiles ausentes o DB ilegible a `not_configured` sin ruta interna
+
 ### `memory.agent_summary`
 Campos esperados:
 - `mugiwara_slug`

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -29,6 +29,22 @@ npm run verify:perimeter-policy
 | --- | --- | --- | --- |
 | `MUGIWARA_CONTROL_PANEL_API_URL` | `/memory`, `/mugiwaras`, `/skills` BFF/server loaders, `/vault`, `/dashboard`, `/healthcheck` | Server-only | Base URL del backend para superficies que deben resolver datos desde servidor o frontera BFF. Debe apuntar a loopback, red privada o Tailscale/private hostname; no es configuración pública de navegador. |
 | `MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS` | `/skills` BFF write routes | Server-only | Allowlist separada por comas de orígenes exactos `http:`/`https:` permitidos para `POST`/`PUT` de Skills. Debe contener solo orígenes privados/locales/Tailscale; si falta, las escrituras BFF devuelven `403 trusted_origins_not_configured`. |
+| `MUGIWARA_HERMES_PROFILES_ROOT` | Backend `usage.hermes_activity` | Server-only | Raíz local de perfiles Hermes usada solo por el backend para agregados read-only. Si falta, el endpoint degrada a `not_configured`; el valor runtime y las rutas de bases de datos no se serializan en API ni UI. |
+
+## Usage
+`/usage` usa fuentes server-side/read-only desde Phase 17:
+
+1. El frontend consume el backend mediante adapter `server-only` y `MUGIWARA_CONTROL_PANEL_API_URL`, sin `NEXT_PUBLIC_*` ni lectura directa de env en la página.
+2. `GET /api/v1/usage/current`, `calendar` y `five-hour-windows` leen únicamente la SQLite saneada de Codex usage.
+3. `GET /api/v1/usage/hermes-activity` lee actividad Hermes solo si `MUGIWARA_HERMES_PROFILES_ROOT` está configurado en el backend; abre perfiles allowlisted en modo lectura y serializa únicamente agregados por perfil/rango.
+4. La actividad Hermes no devuelve rutas, prompts, conversaciones, payloads de herramientas, tokens por sesión/conversación, identificadores, secrets, cabeceras, cookies ni logs; si la fuente falta o falla, degrada a `not_configured`.
+5. La UI de actividad queda para 17.4d; 17.4c solo fija el contrato backend saneado.
+
+Antes de cerrar cambios que toquen Usage config, ejecutar:
+
+```bash
+npm run verify:usage-server-only
+```
 
 ## Memory
 `/memory` usa el patrón server-only desde Phase 12.3c:

--- a/openspec/phase-17-4c-usage-hermes-activity-backend.md
+++ b/openspec/phase-17-4c-usage-hermes-activity-backend.md
@@ -1,0 +1,67 @@
+# Phase 17.4c — Usage Hermes activity backend
+
+## Decisión de corte
+17.4c **no se divide más** antes de implementar.
+
+Motivo: el alcance viable y seguro queda limitado a una sola frontera backend/read-only:
+- endpoint fijo `GET /api/v1/usage/hermes-activity?range=...`;
+- lectura local server-side de perfiles Hermes allowlisted;
+- salida agregada por perfil/rango;
+- sin UI visible, sin escritura y sin productor/timer nuevo.
+
+Sí queda separado de 17.4d porque la UI de actividad y el closeout final de #51 mezclan otra frontera visible y requieren review Usopp + Chopper.
+
+## Objetivo
+Añadir un read model backend de actividad Hermes local agregada para `/usage`, manteniendo el contrato de seguridad de #51:
+- read-only;
+- server-only;
+- deny-by-default;
+- sin raw prompts;
+- sin conversaciones;
+- sin tool payloads crudos;
+- sin tokens por sesión/conversación;
+- sin rutas de `state.db` en payloads;
+- sin chat IDs, delivery targets, user IDs, secretos, headers, cookies ni logs.
+
+## Alcance implementado
+- Nuevo endpoint: `GET /api/v1/usage/hermes-activity?range=7d|30d|current_cycle|previous_cycle`.
+- Config server-only: `MUGIWARA_HERMES_PROFILES_ROOT`.
+- Perfiles allowlisted: tripulación Mugiwara explícita.
+- SQLite profile state abierto en `mode=ro`.
+- Agregados por perfil/rango:
+  - sesiones;
+  - mensajes;
+  - tool calls;
+  - primera/última actividad;
+  - nivel `low|medium|high`;
+  - perfil dominante por volumen agregado.
+- Rango `current_cycle`/`previous_cycle` reutiliza el ciclo Codex si hay snapshot; si no, degrada de forma visible.
+
+## Fuera de alcance
+- UI de actividad Hermes en `/usage`.
+- Cierre de #51.
+- Proyecciones o causalidad Codex↔Hermes.
+- Model/platform breakdown.
+- Tokens, costes, sesiones individuales, conversaciones, prompts o tool payloads.
+- Productor nuevo, timer, cronjob o copia intermedia de datos.
+
+## TDD
+Tests rojos iniciales añadidos antes de implementación:
+- agregación por perfiles desde DBs sintéticas sin fuga de campos sensibles;
+- degradación cuando la raíz de perfiles no está configurada;
+- rechazo 422 saneado de rango no allowlisted.
+
+## Verificación esperada
+- `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py`
+- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q`
+- `npm run verify:usage-server-only`
+- `npm --prefix apps/web run typecheck`
+- `git diff --check`
+- smoke TestClient contra fuente real si `MUGIWARA_HERMES_PROFILES_ROOT` está configurado localmente, verificando que no aparecen paths ni marcadores sensibles.
+
+## Review
+Obligatoria:
+- Franky: operabilidad, config server-only, lectura SQLite read-only y degradaciones.
+- Chopper: privacidad, no leakage y frontera de datos Hermes.
+
+Usopp no aplica en 17.4c porque no hay UI visible; entra en 17.4d.

--- a/openspec/phase-17-4c-verify-checklist.md
+++ b/openspec/phase-17-4c-verify-checklist.md
@@ -1,0 +1,28 @@
+# Phase 17.4c verify checklist — Usage Hermes activity backend
+
+## Red first
+- [x] Tests nuevos añadidos antes del endpoint y del constructor `hermes_profiles_root`.
+- [x] Red inicial confirmado: `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` falló con `UsageService.__init__() got an unexpected keyword argument 'hermes_profiles_root'`.
+
+## Backend contract
+- [x] Endpoint fijo `GET /api/v1/usage/hermes-activity`.
+- [x] Rango tipado/allowlisted: `current_cycle`, `previous_cycle`, `7d`, `30d`.
+- [x] Fuente Hermes detrás de env server-only `MUGIWARA_HERMES_PROFILES_ROOT`.
+- [x] Perfiles Mugiwara allowlisted explícitamente.
+- [x] SQLite abierto en `mode=ro`.
+- [x] No se seleccionan campos sensibles de `sessions` (`user_id`, prompts, model config, tokens, costes, billing URL, title).
+- [x] Payload sin ruta de perfiles ni `state.db` path.
+
+## Verify ejecutado
+- [x] `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py`
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` → 12 passed.
+- [x] `npm run verify:usage-server-only` → passed.
+- [x] `npm --prefix apps/web run typecheck` → passed.
+- [x] `npm --prefix apps/web run build` → passed, `/usage` sigue dinámica (`ƒ`).
+- [x] `git diff --check` → passed.
+- [x] Smoke TestClient con `MUGIWARA_HERMES_PROFILES_ROOT` configurado localmente → `ready`, agregados por perfil, sin path ni marcadores sensibles.
+
+## Pendiente antes de PR
+- [x] Completar verify final.
+- [x] Actualizar closeout `.engram/` y docs.
+- [ ] PR con handoff Franky + Chopper.

--- a/packages/contracts/src/read-models.ts
+++ b/packages/contracts/src/read-models.ts
@@ -256,6 +256,39 @@ export type UsageFiveHourWindows = {
   empty_reason: 'not_configured' | null
 }
 
+export type UsageActivityRange = UsageCalendarRange
+export type UsageActivityLevel = 'low' | 'medium' | 'high'
+
+export type UsageHermesActivity = {
+  range: {
+    name: UsageActivityRange
+    started_at: string
+    ended_at: string
+  }
+  totals: {
+    profiles_count: number
+    sessions_count: number
+    messages_count: number
+    tool_calls_count: number
+    dominant_profile: string | null
+  }
+  profiles: Array<{
+    profile: string
+    sessions_count: number
+    messages_count: number
+    tool_calls_count: number
+    first_activity_at: string
+    last_activity_at: string
+    activity_level: UsageActivityLevel
+  }>
+  privacy: {
+    mode: 'read_only_aggregated'
+    correlation: 'orientativa'
+    exclusions: string[]
+  }
+  empty_reason: 'not_configured' | 'unknown' | null
+}
+
 export type DashboardSummaryResponse = ResourceEnvelope<DashboardSummary, { links_count: number }>
 export type MugiwarasCatalogResponse = ResourceEnvelope<{ items: MugiwaraCard[]; crew_rules_document: CrewRulesDocument }, { count: number; crew_rules_document: string; read_only: true }>
 export type MugiwaraProfileResponse = ResourceEnvelope<MugiwaraProfile, { slug: string; read_only: true }>
@@ -268,4 +301,5 @@ export type HealthcheckSummaryResponse = ResourceEnvelope<{ items: HealthcheckSu
 export type UsageCurrentResponse = ResourceEnvelope<UsageCurrent, { read_only: true; sanitized: true; source: string; refresh_interval_minutes: number }>
 export type UsageCalendarResponse = ResourceEnvelope<UsageCalendar, { read_only: true; sanitized: true; source: string; range: UsageCalendarRange; timezone: 'Europe/Madrid' }>
 export type UsageFiveHourWindowsResponse = ResourceEnvelope<UsageFiveHourWindows, { read_only: true; sanitized: true; source: string; limit: number }>
+export type UsageHermesActivityResponse = ResourceEnvelope<UsageHermesActivity, { read_only: true; sanitized: true; source: string; range: UsageActivityRange }>
 export type SystemSignalsResponse = ResourceEnvelope<{ items: SystemSignal[] }, { count: number }>

--- a/scripts/check-usage-server-only.mjs
+++ b/scripts/check-usage-server-only.mjs
@@ -7,11 +7,19 @@ const repoRoot = process.cwd()
 const httpPath = join(repoRoot, 'apps/web/src/modules/usage/api/usage-http.ts')
 const pagePath = join(repoRoot, 'apps/web/src/app/usage/page.tsx')
 const navPath = join(repoRoot, 'apps/web/src/shared/ui/navigation/SidebarNav.tsx')
+const usageServicePath = join(repoRoot, 'apps/api/src/modules/usage/service.py')
+const usageRouterPath = join(repoRoot, 'apps/api/src/modules/usage/router.py')
 const failures = []
 
 const http = readFileSync(httpPath, 'utf8')
 const page = readFileSync(pagePath, 'utf8')
 const nav = readFileSync(navPath, 'utf8')
+const usageService = readFileSync(usageServicePath, 'utf8')
+const usageRouter = readFileSync(usageRouterPath, 'utf8')
+const activityLoader = usageService.slice(
+  usageService.indexOf('def _load_hermes_profile_activity'),
+  usageService.indexOf('def _load_latest_snapshot'),
+)
 
 if (!http.includes("import 'server-only'")) {
   failures.push('usage http adapter must be server-only guarded')
@@ -66,6 +74,26 @@ if (!page.includes('Ciclo semanal Codex') || !page.includes('ciclo semanal Codex
 }
 if (!nav.includes("href: '/usage'") || !nav.includes("label: 'Uso'")) {
   failures.push('sidebar navigation must expose Uso /usage')
+}
+if (!usageRouter.includes("@router.get('/hermes-activity')") || !usageRouter.includes("resource='usage.hermes_activity'")) {
+  failures.push('usage backend must expose the fixed hermes activity endpoint')
+}
+if (!usageRouter.includes("range: UsageActivityRange = '7d'")) {
+  failures.push('usage hermes activity endpoint must use an allowlisted range type')
+}
+if (!usageService.includes("HERMES_PROFILES_ROOT_ENV = 'MUGIWARA_HERMES_PROFILES_ROOT'")) {
+  failures.push('usage hermes activity must use a private server-side profiles root env')
+}
+if (!usageService.includes('HERMES_ACTIVITY_PROFILES =') || !usageService.includes("'luffy'") || !usageService.includes("'jinbe'")) {
+  failures.push('usage hermes activity must use an explicit Mugiwara profile allowlist')
+}
+if (!usageService.includes("file:{state_db}?mode=ro")) {
+  failures.push('usage hermes activity must open Hermes profile state read-only')
+}
+for (const forbidden of ['SELECT *', 'system_prompt', 'model_config', 'user_id', 'token_count', 'input_tokens', 'output_tokens', 'reasoning_tokens', 'estimated_cost_usd', 'actual_cost_usd', 'billing_base_url', 'title']) {
+  if (activityLoader.includes(forbidden)) {
+    failures.push(`usage hermes activity must not select or serialize sensitive session field: ${forbidden}`)
+  }
 }
 
 if (failures.length > 0) {


### PR DESCRIPTION
## Summary
- Adds backend read-only `GET /api/v1/usage/hermes-activity?range=7d|30d|current_cycle|previous_cycle`.
- Aggregates Hermes profile activity only by allowlisted Mugiwara profile/range: sessions, messages, tool calls, first/last activity, activity level and dominant profile.
- Uses server-only `MUGIWARA_HERMES_PROFILES_ROOT`, opens profile SQLite state in `mode=ro`, and degrades missing/unconfigured sources to `not_configured` without exposing paths.
- Updates contracts, docs, OpenSpec, Engram closeout and `verify:usage-server-only` backend guardrails.

## Security / data boundary
- No raw prompts, conversations, tool payloads, session IDs, user IDs, chat IDs, delivery targets, tokens by session/conversation, costs, billing URLs, headers, cookies, secrets, logs, model config, titles or profile DB paths are selected or serialized.
- Activity correlation remains orientative; no causal attribution to Codex consumption.
- No UI change in this PR; 17.4d remains separate.

## Verify
- Red first: usage tests failed before implementation because `UsageService` did not accept `hermes_profiles_root` and endpoint did not exist.
- `python3 -m py_compile apps/api/src/modules/usage/service.py apps/api/src/modules/usage/router.py apps/api/tests/test_usage_api.py`
- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` → 12 passed
- `npm run verify:usage-server-only` → passed
- `npm --prefix apps/web run typecheck` → passed
- `npm --prefix apps/web run build` → passed; `/usage` remains dynamic (`ƒ`)
- `git diff --check` → passed
- TestClient smoke with server-only profiles root configured locally returned `ready` aggregates without profile DB path or sensitive markers.

## Review requested
- Franky: operational/runtime review for server-only config, read-only SQLite access, degradation semantics and maintainability.
- Chopper: security review for Hermes activity data boundary, no-leakage, endpoint/range validation and deny-by-default posture.

## Out of scope
- UI activity panel and final #51 closeout/canon. Those remain for 17.4d.
- Healthcheck producers, which remain Phase 18.x.
