### PR TITLE
feat: add usage Hermes activity UI

### DIFF
--- a/.engram/phase-17-4d-usage-hermes-activity-ui-closeout.md
+++ b/.engram/phase-17-4d-usage-hermes-activity-ui-closeout.md
@@ -1,0 +1,33 @@
+# Phase 17.4d closeout — Usage Hermes activity UI + #51
+
+## Resultado
+Phase 17.4d integra la actividad Hermes agregada en `/usage` y prepara el cierre final de #51.
+
+## Cambios técnicos
+- Adapter server-only `fetchUsageHermesActivity('7d')` consume `GET /api/v1/usage/hermes-activity?range=7d`.
+- `/usage` carga current snapshot, calendario, ventanas 5h y actividad Hermes en paralelo, manteniendo fallback saneado.
+- Añadida fixture sintética `usage-hermes-activity.fixture.ts`.
+- Panel `Actividad Hermes agregada` muestra perfiles activos, sesiones, mensajes, tool calls, perfil dominante, primera/última señal y nivel bajo/medio/alto.
+- Copy de actividad declara correlación orientativa; no atribuye causalidad exacta Codex por perfil.
+- Metodología del ciclo semanal Codex compactada a `SurfaceCard` para reducir peso visual.
+- Badge de calendario permite wrap dentro de cards para corregir micro-overflow menor.
+- Guardrail `verify:usage-server-only` ampliado para fijar adapter/UI de Hermes activity y evitar regresiones de leakage.
+
+## Frontera de seguridad
+La UI no muestra root de perfiles, rutas de `state.db`, prompts, conversaciones crudas, payloads de herramientas, tokens por sesión/conversación, user IDs, chat IDs, delivery targets, secretos, headers, cookies, logs ni valores de configuración runtime. Solo serializa y renderiza agregados saneados ya entregados por backend.
+
+## Decisión de división
+17.4d no se dividió más: no toca backend, fuente, runtime, productores, cache ni polling. El alcance homogéneo era UI server-only + fallback + docs/canon.
+
+## Verify
+- Red inicial: `npm run verify:usage-server-only` falló antes de implementar el adapter/UI de Hermes activity.
+- `npm run verify:usage-server-only` → passed.
+- `npm --prefix apps/web run typecheck` → passed.
+- `npm --prefix apps/web run build` → `/usage` dinámica (`ƒ`).
+- `npm run verify:visual-baseline` → checklist actualizado/passed.
+- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` → 12 passed.
+- `git diff --check` → passed.
+- Browser smoke `/usage` contra API local de la rama: panel visible, consola limpia, sin backend URL/root Hermes/rutas de DB en DOM y sin overflow horizontal en viewport inspeccionado.
+
+## Review requerido
+Usopp + Chopper obligatorios. Franky no se requiere salvo que aparezcan cambios backend/runtime/fuente/polling/cache.

--- a/.engram/phase-17-4d-usage-hermes-activity-ui-closeout.md
+++ b/.engram/phase-17-4d-usage-hermes-activity-ui-closeout.md
@@ -29,5 +29,7 @@ La UI no muestra root de perfiles, rutas de `state.db`, prompts, conversaciones 
 - `git diff --check` → passed.
 - Browser smoke `/usage` contra API local de la rama: panel visible, consola limpia, sin backend URL/root Hermes/rutas de DB en DOM y sin overflow horizontal en viewport inspeccionado.
 
-## Review requerido
-Usopp + Chopper obligatorios. Franky no se requiere salvo que aparezcan cambios backend/runtime/fuente/polling/cache.
+## Review
+- Chopper: `approve` seguridad/no-leakage en PR #77, comentario manual por limitación de cuenta compartida.
+- Usopp: `approve` UI/UX/copy/responsive en PR #77, comentario manual por limitación de cuenta compartida; follow-up menor no bloqueante: si `/usage` crece más, valorar bloque Hermes compactable/plegable en móvil.
+- Franky no requerido: no hubo cambio backend/runtime/fuente/polling/cache.

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -217,6 +217,55 @@ button {
   font-weight: 800;
 }
 
+.usage-calendar-day .status-badge {
+  white-space: normal;
+}
+
+.usage-hermes-activity-summary,
+.usage-hermes-activity-row__metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.usage-hermes-activity-summary dt,
+.usage-hermes-activity-row__metrics dt {
+  color: #9aa7bd;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.usage-hermes-activity-summary dd,
+.usage-hermes-activity-row__metrics dd {
+  margin: 2px 0 0;
+  font-weight: 800;
+}
+
+.usage-hermes-activity-list {
+  display: grid;
+  gap: 12px;
+}
+
+.usage-hermes-activity-row {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 18px;
+  background: rgba(232, 181, 106, 0.08);
+}
+
+.usage-hermes-activity-row__main {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
 .responsive-code {
   overflow-x: auto;
   white-space: pre-wrap;
@@ -377,11 +426,14 @@ button {
   }
 
   .usage-calendar-day__metrics,
-  .usage-window-row__metrics {
+  .usage-window-row__metrics,
+  .usage-hermes-activity-summary,
+  .usage-hermes-activity-row__metrics {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .usage-window-row__main {
+  .usage-window-row__main,
+  .usage-hermes-activity-row__main {
     flex-direction: column;
   }
 }

--- a/apps/web/src/app/usage/page.tsx
+++ b/apps/web/src/app/usage/page.tsx
@@ -1,10 +1,11 @@
 import type { ResourceStatus } from '@contracts/resource'
-import type { UsageCalendar, UsageCalendarDayStatus, UsageCurrent, UsageFiveHourWindows, UsageWindowStatus } from '@contracts/read-models'
+import type { UsageActivityLevel, UsageCalendar, UsageCalendarDayStatus, UsageCurrent, UsageFiveHourWindows, UsageHermesActivity, UsageWindowStatus } from '@contracts/read-models'
 
-import { fetchUsageCalendar, fetchUsageCurrent, fetchUsageFiveHourWindows, UsageApiError } from '@/modules/usage/api/usage-http'
+import { fetchUsageCalendar, fetchUsageCurrent, fetchUsageFiveHourWindows, fetchUsageHermesActivity, UsageApiError } from '@/modules/usage/api/usage-http'
 import { usageCalendarFixture } from '@/modules/usage/view-models/usage-calendar.fixture'
 import { usageCurrentFixture } from '@/modules/usage/view-models/usage-current.fixture'
 import { usageFiveHourWindowsFixture } from '@/modules/usage/view-models/usage-five-hour-windows.fixture'
+import { usageHermesActivityFixture } from '@/modules/usage/view-models/usage-hermes-activity.fixture'
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
 import { StatePanel } from '@/shared/ui/state/StatePanel'
@@ -26,6 +27,7 @@ type UsagePageData = {
   usage: UsageCurrent
   calendar: UsageCalendar
   fiveHourWindows: UsageFiveHourWindows
+  hermesActivity: UsageHermesActivity
   resourceStatus: ResourceStatus | 'fallback'
   notice: UsageNotice | null
   isSnapshotMode: boolean
@@ -55,24 +57,39 @@ const calendarStatusMap: Record<UsageCalendarDayStatus, { appStatus: AppStatus; 
   unknown: { appStatus: 'sin-datos', label: 'Sin datos', accent: 'sky' },
 }
 
+const activityLevelMap: Record<UsageActivityLevel, { label: string; appStatus: AppStatus; accent: 'sky' | 'success' | 'warning' | 'danger' }> = {
+  low: { label: 'Baja', appStatus: 'operativo', accent: 'success' },
+  medium: { label: 'Media', appStatus: 'revision', accent: 'warning' },
+  high: { label: 'Alta', appStatus: 'incidencia', accent: 'danger' },
+}
+
 async function getInitialUsageData(): Promise<UsagePageData> {
   try {
-    const [currentResponse, calendarResponse, fiveHourWindowsResponse] = await Promise.all([
+    const [currentResponse, calendarResponse, fiveHourWindowsResponse, hermesActivityResponse] = await Promise.all([
       fetchUsageCurrent(),
       fetchUsageCalendar('current_cycle'),
       fetchUsageFiveHourWindows(8),
+      fetchUsageHermesActivity('7d'),
     ])
     const usage = currentResponse.data
     const calendar = calendarResponse.data
     const fiveHourWindows = fiveHourWindowsResponse.data
+    const hermesActivity = hermesActivityResponse.data
 
-    const responseStatus = currentResponse.status !== 'ready' ? currentResponse.status : calendarResponse.status !== 'ready' ? calendarResponse.status : fiveHourWindowsResponse.status
+    const responseStatus = currentResponse.status !== 'ready'
+      ? currentResponse.status
+      : calendarResponse.status !== 'ready'
+        ? calendarResponse.status
+        : fiveHourWindowsResponse.status !== 'ready'
+          ? fiveHourWindowsResponse.status
+          : hermesActivityResponse.status
 
     if (responseStatus !== 'ready') {
       return {
         usage,
         calendar,
         fiveHourWindows,
+        hermesActivity,
         resourceStatus: responseStatus,
         isSnapshotMode: responseStatus === 'stale',
         notice: noticeFromResourceStatus(responseStatus),
@@ -83,6 +100,7 @@ async function getInitialUsageData(): Promise<UsagePageData> {
       usage,
       calendar,
       fiveHourWindows,
+      hermesActivity,
       resourceStatus: currentResponse.status,
       notice: null,
       isSnapshotMode: false,
@@ -94,6 +112,7 @@ async function getInitialUsageData(): Promise<UsagePageData> {
       usage: usageCurrentFixture,
       calendar: usageCalendarFixture,
       fiveHourWindows: usageFiveHourWindowsFixture,
+      hermesActivity: usageHermesActivityFixture,
       resourceStatus: 'fallback',
       isSnapshotMode: true,
       notice: {
@@ -395,7 +414,7 @@ function UsageCalendarPanel({ calendar, isSnapshotMode }: { calendar: UsageCalen
     <SurfaceCard title="Calendario por fecha natural" eyebrow={`Ciclo semanal Codex · ${calendar.timezone}`} accent="gold" elevated>
       <div style={{ display: 'grid', gap: '12px' }}>
         <p style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
-          Primera lectura histórica saneada: agrupa por fecha natural Europe/Madrid, sin prompts, conversaciones, tokens ni actividad Hermes. El delta diario se calcula por segmentos continuos del ciclo semanal Codex para no contar resets como consumo.
+          Primera lectura histórica saneada: agrupa por fecha natural Europe/Madrid, sin contenido privado ni actividad Hermes. El delta diario se calcula por segmentos continuos del ciclo semanal Codex para no contar resets como consumo.
         </p>
         {isSnapshotMode ? (
           <p style={{ margin: 0, color: appTheme.colors.brandGold400, lineHeight: 1.5 }}>
@@ -451,8 +470,106 @@ function UsageCalendarPanel({ calendar, isSnapshotMode }: { calendar: UsageCalen
   )
 }
 
+function formatActivityCount(value: number) {
+  return new Intl.NumberFormat('es-ES').format(value)
+}
+
+function formatProfileName(profile: string | null) {
+  if (!profile) {
+    return 'Sin perfil dominante'
+  }
+
+  return profile.charAt(0).toUpperCase() + profile.slice(1)
+}
+
+function UsageHermesActivityPanel({ activity, isSnapshotMode }: { activity: UsageHermesActivity; isSnapshotMode: boolean }) {
+  const profiles = activity.profiles.slice(0, 8)
+  const dominantProfile = formatProfileName(activity.totals.dominant_profile)
+
+  return (
+    <SurfaceCard title="Actividad Hermes agregada" eyebrow="Últimos 7 días · correlación orientativa" accent="gold" elevated>
+      <div style={{ display: 'grid', gap: '14px' }}>
+        <p style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
+          Lectura read-only de actividad local Hermes por perfiles Mugiwara allowlisted. Es una correlación orientativa con el ritmo Codex: no atribuye causalidad exacta ni muestra actividad por sesión.
+        </p>
+        {isSnapshotMode ? (
+          <p style={{ margin: 0, color: appTheme.colors.brandGold400, lineHeight: 1.5 }}>
+            Actividad mostrada desde fallback saneado: valida composición visual, no representa lectura real.
+          </p>
+        ) : null}
+        <dl className="usage-hermes-activity-summary" aria-label="Resumen agregado de actividad Hermes">
+          <div>
+            <dt>Perfiles activos</dt>
+            <dd>{formatActivityCount(activity.totals.profiles_count)}</dd>
+          </div>
+          <div>
+            <dt>Sesiones</dt>
+            <dd>{formatActivityCount(activity.totals.sessions_count)}</dd>
+          </div>
+          <div>
+            <dt>Mensajes</dt>
+            <dd>{formatActivityCount(activity.totals.messages_count)}</dd>
+          </div>
+          <div>
+            <dt>Tool calls</dt>
+            <dd>{formatActivityCount(activity.totals.tool_calls_count)}</dd>
+          </div>
+        </dl>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px', alignItems: 'center' }}>
+          <StatusBadge status={activity.totals.dominant_profile ? 'revision' : 'sin-datos'} label={`Perfil dominante: ${dominantProfile}`} />
+          <span style={{ color: appTheme.colors.textSecondary }}>Rango: {formatTimestamp(activity.range.started_at)} → {formatTimestamp(activity.range.ended_at)}</span>
+        </div>
+        <div className="usage-hermes-activity-list" role="list" aria-label="Actividad Hermes agregada por perfil">
+          {profiles.length > 0 ? (
+            profiles.map((profile) => {
+              const level = activityLevelMap[profile.activity_level]
+              return (
+                <article className="usage-hermes-activity-row" key={profile.profile} role="listitem" aria-label={`${formatProfileName(profile.profile)}: actividad ${level.label.toLowerCase()}`}>
+                  <div className="usage-hermes-activity-row__main">
+                    <div>
+                      <p style={{ margin: 0, color: appTheme.colors.textMuted, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Perfil Mugiwara</p>
+                      <h3 style={{ margin: '4px 0 0', fontSize: '18px' }}>{formatProfileName(profile.profile)}</h3>
+                    </div>
+                    <StatusBadge status={level.appStatus} label={`Actividad ${level.label}`} />
+                  </div>
+                  <dl className="usage-hermes-activity-row__metrics">
+                    <div>
+                      <dt>Sesiones</dt>
+                      <dd>{formatActivityCount(profile.sessions_count)}</dd>
+                    </div>
+                    <div>
+                      <dt>Mensajes</dt>
+                      <dd>{formatActivityCount(profile.messages_count)}</dd>
+                    </div>
+                    <div>
+                      <dt>Tool calls</dt>
+                      <dd>{formatActivityCount(profile.tool_calls_count)}</dd>
+                    </div>
+                  </dl>
+                  <p style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.5 }}>
+                    Primera/última señal agregada: {formatTimestamp(profile.first_activity_at)} → {formatTimestamp(profile.last_activity_at)}.
+                  </p>
+                </article>
+              )
+            })
+          ) : (
+            <StatePanel
+              status="sin-datos"
+              title="Actividad Hermes sin datos"
+              description={activity.empty_reason === 'not_configured' ? 'La fuente de actividad Hermes aún no está configurada en backend.' : 'No hay actividad agregada suficiente para este rango.'}
+              eyebrow="Actividad Hermes"
+              ariaRole="region"
+              ariaLabel="Actividad Hermes agregada sin datos"
+            />
+          )}
+        </div>
+      </div>
+    </SurfaceCard>
+  )
+}
+
 export default async function UsagePage() {
-  const { usage, calendar, fiveHourWindows, notice, isSnapshotMode } = await getInitialUsageData()
+  const { usage, calendar, fiveHourWindows, hermesActivity, notice, isSnapshotMode } = await getInitialUsageData()
   const recommendationStatus = recommendationStatusMap[usage.recommendation.state]
 
   return (
@@ -460,7 +577,7 @@ export default async function UsagePage() {
       <PageHeader
         eyebrow="Uso"
         title="Uso Codex/Hermes"
-        subtitle="Cuota Codex, ciclos de reset y actividad local saneada. Primera vista read-only centrada en el snapshot actual."
+        subtitle="Cuota Codex, ciclos de reset, ventanas 5h y actividad local agregada saneada."
         mugiwaraSlug="franky"
         detailPills={[
           `Plan: ${usage.plan.type}`,
@@ -484,12 +601,9 @@ export default async function UsagePage() {
         </StatePanel>
       ) : null}
 
-      <StatePanel
-        status="revision"
-        title="El ciclo semanal Codex no es calendario lunes-domingo"
-        description={usage.methodology.cycle_copy}
-        eyebrow="Metodología"
-      />
+      <SurfaceCard title="Ciclo semanal Codex" eyebrow="Metodología" accent="sky">
+        <p style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>{usage.methodology.cycle_copy}</p>
+      </SurfaceCard>
 
       <section className="layout-grid layout-grid--dashboard-metrics section-block" aria-label="Estado actual de Usage">
         <WindowCard title="Ventana 5h" window={usage.primary_window} />
@@ -527,18 +641,25 @@ export default async function UsagePage() {
         <UsageWindowsPanel windows={fiveHourWindows} isSnapshotMode={isSnapshotMode} />
       </section>
 
+      <section className="section-block" aria-label="Actividad Hermes Usage">
+        <UsageHermesActivityPanel activity={hermesActivity} isSnapshotMode={isSnapshotMode} />
+      </section>
+
       <section className="section-block layout-grid layout-grid--content-aside">
-        <SurfaceCard title="Qué entra en esta vista" eyebrow="Alcance Phase 17.4b" accent="gold">
+        <SurfaceCard title="Qué entra en esta vista" eyebrow="Alcance Phase 17.4d" accent="gold">
           <ul style={{ margin: 0, paddingLeft: '18px', color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
             <li>Snapshot actual saneado de Codex usage.</li>
             <li>Ventana 5h y ciclo semanal Codex con rangos calculados por reset.</li>
             <li>Calendario por fecha natural Europe/Madrid con delta diario, ventanas 5h y pico diario saneados.</li>
             <li>Ventanas 5h históricas dedicadas con pico, delta intra-ventana y muestras.</li>
-            <li>Actividad Hermes agregada queda para 17.4c/17.4d.</li>
+            <li>Actividad Hermes agregada por perfil y rango, tratada como correlación orientativa.</li>
           </ul>
         </SurfaceCard>
         <SurfaceCard title="Seguridad de datos" eyebrow="Deny by default" accent="sky">
           <p style={{ marginTop: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>{usage.methodology.privacy}</p>
+          <p style={{ margin: '10px 0 0', color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
+            La actividad Hermes se muestra solo como agregados saneados. No se enseñan contenidos, identificadores privados, rutas internas, secretos, cabeceras, cookies, logs ni payloads crudos.
+          </p>
           <p style={{ marginBottom: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
             Fórmulas: {usage.methodology.primary_window_formula}; {usage.methodology.secondary_cycle_formula}.
           </p>

--- a/apps/web/src/modules/AGENTS.md
+++ b/apps/web/src/modules/AGENTS.md
@@ -7,5 +7,5 @@ Features y módulos funcionales del frontend (dashboard, mugiwaras, skills, memo
 - Mantener una correspondencia clara entre módulo UI y módulo de producto.
 - Evitar dependencias cruzadas desordenadas.
 - **Vigilar `.gitignore`** y no subir mocks, capturas o outputs sensibles no saneados.
-- `usage`: Usage/Codex quota read-only frontend consuming server-only current snapshot, calendar and dedicated five-hour windows adapters. Hermes activity stays in a later phase.
+- `usage`: Usage/Codex quota read-only frontend consuming server-only current snapshot, calendar, dedicated five-hour windows and aggregated Hermes activity adapters; no client-side backend URL or Hermes profiles root exposure.
 - Si nace un módulo nuevo, documentarlo aquí y en docs.

--- a/apps/web/src/modules/usage/AGENTS.md
+++ b/apps/web/src/modules/usage/AGENTS.md
@@ -7,5 +7,5 @@ Módulo frontend para la superficie `/usage` de uso Codex/Hermes.
 - Consumir Usage desde adapters server-only; no usar `NEXT_PUBLIC_*` ni URL backend en cliente.
 - Mantener la página read-only.
 - Usar siempre `ciclo semanal Codex`; no presentar el ciclo como semana natural lunes-domingo.
-- No exponer prompts, raw conversations, tokens, user/account IDs, headers ni raw payload.
-- El calendario por fecha natural y las ventanas 5h históricas consumen solo endpoints backend allowlisted; actividad Hermes agregada pertenece a una fase posterior separada.
+- No exponer prompts, conversaciones crudas, payloads de herramientas, tokens por sesión/conversación, user/account IDs, chat IDs, delivery targets, headers, cookies, secretos, rutas internas ni raw payload.
+- El calendario por fecha natural, las ventanas 5h históricas y la actividad Hermes agregada consumen solo endpoints backend allowlisted; la actividad Hermes se presenta como correlación orientativa, no como causalidad exacta.

--- a/apps/web/src/modules/usage/api/usage-http.ts
+++ b/apps/web/src/modules/usage/api/usage-http.ts
@@ -3,7 +3,7 @@ import 'server-only'
 import http from 'node:http'
 import https from 'node:https'
 
-import type { UsageCalendarRange, UsageCalendarResponse, UsageCurrentResponse, UsageFiveHourWindowsResponse } from '@contracts/read-models'
+import type { UsageActivityRange, UsageCalendarRange, UsageCalendarResponse, UsageCurrentResponse, UsageFiveHourWindowsResponse, UsageHermesActivityResponse } from '@contracts/read-models'
 
 export const USAGE_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'
 
@@ -146,4 +146,16 @@ export async function fetchUsageFiveHourWindows(limit = 8): Promise<UsageFiveHou
 
   const safeLimit = Math.max(1, Math.min(24, Math.trunc(limit)))
   return requestUsageJson<UsageFiveHourWindowsResponse>(`${baseUrl}/api/v1/usage/five-hour-windows?limit=${safeLimit}`)
+}
+
+export async function fetchUsageHermesActivity(range: UsageActivityRange = '7d'): Promise<UsageHermesActivityResponse> {
+  const baseUrl = getUsageApiBaseUrl()
+
+  if (!baseUrl) {
+    throw new UsageApiError('not_configured', { status: 0, code: 'not_configured' })
+  }
+
+  const allowedRanges: UsageActivityRange[] = ['current_cycle', 'previous_cycle', '7d', '30d']
+  const safeRange = allowedRanges.includes(range) ? range : '7d'
+  return requestUsageJson<UsageHermesActivityResponse>(`${baseUrl}/api/v1/usage/hermes-activity?range=${encodeURIComponent(safeRange)}`)
 }

--- a/apps/web/src/modules/usage/view-models/usage-hermes-activity.fixture.ts
+++ b/apps/web/src/modules/usage/view-models/usage-hermes-activity.fixture.ts
@@ -1,0 +1,66 @@
+import type { UsageHermesActivity } from '@contracts/read-models'
+
+export const usageHermesActivityFixture: UsageHermesActivity = {
+  range: {
+    name: '7d',
+    started_at: '2026-04-20T06:00:00Z',
+    ended_at: '2026-04-27T06:00:00Z',
+  },
+  totals: {
+    profiles_count: 4,
+    sessions_count: 38,
+    messages_count: 624,
+    tool_calls_count: 217,
+    dominant_profile: 'zoro',
+  },
+  profiles: [
+    {
+      profile: 'zoro',
+      sessions_count: 16,
+      messages_count: 248,
+      tool_calls_count: 109,
+      first_activity_at: '2026-04-20T08:12:00Z',
+      last_activity_at: '2026-04-27T05:48:00Z',
+      activity_level: 'high',
+    },
+    {
+      profile: 'franky',
+      sessions_count: 9,
+      messages_count: 151,
+      tool_calls_count: 54,
+      first_activity_at: '2026-04-21T09:25:00Z',
+      last_activity_at: '2026-04-26T23:10:00Z',
+      activity_level: 'medium',
+    },
+    {
+      profile: 'chopper',
+      sessions_count: 7,
+      messages_count: 132,
+      tool_calls_count: 31,
+      first_activity_at: '2026-04-22T11:04:00Z',
+      last_activity_at: '2026-04-26T21:32:00Z',
+      activity_level: 'medium',
+    },
+    {
+      profile: 'usopp',
+      sessions_count: 6,
+      messages_count: 93,
+      tool_calls_count: 23,
+      first_activity_at: '2026-04-23T10:15:00Z',
+      last_activity_at: '2026-04-26T19:44:00Z',
+      activity_level: 'low',
+    },
+  ],
+  privacy: {
+    mode: 'read_only_aggregated',
+    correlation: 'orientativa',
+    exclusions: [
+      'contenido de mensajes',
+      'payloads de herramientas',
+      'identificadores privados',
+      'rutas internas',
+      'secretos o cabeceras',
+    ],
+  },
+  empty_reason: null,
+}

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -79,7 +79,7 @@
 - leer perfiles Hermes solo si `MUGIWARA_HERMES_PROFILES_ROOT` está configurado en servidor; abrir cada SQLite de perfil en `mode=ro` y no exponer la ruta del fichero ni el root configurado
 - serializar actividad Hermes solo como agregados por perfil/rango: sesiones, mensajes, tool calls, primera/última actividad, perfil dominante e índice bajo/medio/alto; sin prompts, conversaciones, tool payloads, tokens por sesión/conversación, IDs, targets, secretos, headers, cookies ni logs
 - degradar DB ausente/ilegible/sin snapshots a `not_configured`/`unknown` visible, nunca a dato sano silencioso
-- mantener la UI de actividad Hermes para subfase separada 17.4d
+- la UI `/usage` consume la actividad Hermes agregada en 17.4d como correlación orientativa y no como causalidad exacta por perfil
 
 ### `system`
 - estado general del servidor y señales operativas de alto nivel

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -140,6 +140,7 @@ Campos esperados:
 
 Uso:
 - exponer actividad Hermes local solo como agregados por perfil/rango para orientar correlación con consumo Codex, sin afirmar causalidad exacta
+- `/usage` consume el rango inicial `7d` desde adapter server-only y renderiza la actividad como cards responsive, sin tabla ni scroll horizontal obligatorio
 - leer únicamente perfiles Mugiwara allowlisted y abrir cada SQLite de perfil en `mode=ro`
 - usar `MUGIWARA_HERMES_PROFILES_ROOT` como configuración server-only; no serializar ni documentar el valor runtime, ruta de `state.db` ni paths host
 - no seleccionar ni devolver `user_id`, `model_config`, `system_prompt`, `title`, tokens, costes, billing URLs, contenidos, conversaciones, prompts, payloads de herramientas, chat IDs, targets, secretos, cabeceras, cookies ni logs

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -38,7 +38,7 @@ npm run verify:perimeter-policy
 2. `GET /api/v1/usage/current`, `calendar` y `five-hour-windows` leen únicamente la SQLite saneada de Codex usage.
 3. `GET /api/v1/usage/hermes-activity` lee actividad Hermes solo si `MUGIWARA_HERMES_PROFILES_ROOT` está configurado en el backend; abre perfiles allowlisted en modo lectura y serializa únicamente agregados por perfil/rango.
 4. La actividad Hermes no devuelve rutas, prompts, conversaciones, payloads de herramientas, tokens por sesión/conversación, identificadores, secrets, cabeceras, cookies ni logs; si la fuente falta o falla, degrada a `not_configured`.
-5. La UI de actividad queda para 17.4d; 17.4c solo fija el contrato backend saneado.
+5. La UI consume `hermes-activity?range=7d` mediante el mismo adapter server-only y muestra solo agregados por perfil/rango como correlación orientativa, sin valores internos de configuración ni rutas.
 
 Antes de cerrar cambios que toquen Usage config, ejecutar:
 

--- a/openspec/phase-17-4d-usage-hermes-activity-ui-closeout.md
+++ b/openspec/phase-17-4d-usage-hermes-activity-ui-closeout.md
@@ -1,0 +1,47 @@
+# Phase 17.4d — Usage Hermes activity UI + #51 closeout
+
+## Decisión de corte
+17.4d **no se divide más** antes de implementar.
+
+Motivo: tras PR #76 la frontera sensible backend ya está cerrada. Esta microfase queda acotada a UI server-only/read-only, fixture fallback saneada, guardrail, documentación/canon y cierre de #51. No añade endpoints, productores, polling, cache/TTL, escritura, nuevas fuentes ni cambios runtime.
+
+## Alcance
+- Extender el adapter server-only de Usage con `fetchUsageHermesActivity('7d')`.
+- Integrar `/usage` con `GET /api/v1/usage/hermes-activity?range=7d`.
+- Añadir fixture fallback saneada para actividad Hermes agregada.
+- Renderizar panel `Actividad Hermes agregada` sin tabla ni scroll horizontal obligatorio.
+- Mostrar únicamente agregados por perfil/rango: perfiles activos, sesiones, mensajes, tool calls, perfil dominante, primera/última señal y nivel bajo/medio/alto.
+- Explicar la relación Hermes/Codex como **correlación orientativa**, no causalidad exacta por perfil.
+- Compactar la metodología de ciclo semanal Codex para que `/usage` no crezca con avisos pesados.
+- Corregir de forma segura el micro-overflow menor en labels del calendario permitiendo wrap del badge dentro de cards Usage.
+- Actualizar docs vivas, closeout Engram y Project Summary del vault.
+- Comentar/cerrar #51 solo cuando PR, reviews y verify confirmen cierre real.
+
+## Fuera de alcance
+- Phase 18.x Healthcheck producers.
+- Cambios backend o fuente Hermes.
+- Polling frecuente, cache/TTL o métricas nuevas.
+- Exponer `MUGIWARA_HERMES_PROFILES_ROOT`, rutas de perfiles, rutas de `state.db` o detalles de DB.
+- Raw prompts, conversaciones, tool payloads, logs, headers, cookies, user IDs, chat IDs, delivery targets, secretos, costes o tokens por sesión/conversación.
+- Atribución causal exacta de consumo Codex por Mugiwara.
+- Selector de rangos o gráficas complejas.
+
+## Diseño seguro
+- La página sigue siendo server page dinámica (`force-dynamic`) y el adapter conserva `import 'server-only'`.
+- El frontend solo llama endpoints fijos desde `MUGIWARA_CONTROL_PANEL_API_URL` server-only.
+- La UI no lee env directamente ni renderiza valores de configuración.
+- El fallback local contiene datos sintéticos saneados y no rutas/IDs reales.
+- Los textos de privacidad hablan en categorías de exclusión, no en valores runtime.
+
+## Review routing
+- Usopp obligatorio: UI/UX/responsive/copy.
+- Chopper obligatorio: no-leakage y frontera de datos Hermes en UI.
+- Franky no aplica salvo que aparezca cambio backend/runtime/fuente/polling/cache; en esta microfase no aparece.
+
+## Definition of Done
+- `/usage` muestra actividad Hermes agregada con copy de correlación orientativa.
+- No hay scroll horizontal obligatorio en desktop/mobile.
+- Guardrail `verify:usage-server-only` fija endpoint, adapter typed, panel UI y no rendering de internals Hermes.
+- `typecheck`, `build`, `verify:visual-baseline`, backend usage tests y `git diff --check` pasan.
+- Docs/OpenSpec/Engram/Project Summary actualizados.
+- PR abierta y revisada por Usopp + Chopper antes de merge/cierre #51.

--- a/openspec/phase-17-4d-verify-checklist.md
+++ b/openspec/phase-17-4d-verify-checklist.md
@@ -1,0 +1,29 @@
+# Phase 17.4d verify checklist
+
+## Red / TDD
+- [x] Guardrail `verify:usage-server-only` falló antes de implementar UI porque faltaban endpoint `hermes-activity` en adapter, tipo `UsageHermesActivityResponse`, panel `Actividad Hermes agregada` y no-leakage UI.
+
+## Frontend contract
+- [x] Adapter server-only llama endpoint fijo `/api/v1/usage/hermes-activity?range=7d`.
+- [x] Página `/usage` sigue como server page dinámica y no lee env directa.
+- [x] Fixture fallback de actividad Hermes es sintética y saneada.
+- [x] Panel de actividad muestra solo agregados por perfil/rango.
+- [x] Copy declara correlación orientativa y no causalidad exacta.
+- [x] UI no renderiza perfiles root, rutas de DB, `state.db`, prompts crudos, conversaciones, payloads de herramientas, tokens por sesión/conversación, user IDs, chat IDs, delivery targets, secretos, headers/cookies ni logs.
+- [x] Metodología compactada y badge del calendario permite wrap para evitar micro-overflow.
+
+## Verify ejecutado
+- [x] `npm run verify:usage-server-only`
+- [x] `npm --prefix apps/web run typecheck`
+- [x] `npm --prefix apps/web run build`
+- [x] `npm run verify:visual-baseline`
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q`
+- [x] `git diff --check`
+- [x] Browser smoke `/usage`: panel visible, consola limpia, sin backend URL/root Hermes/rutas de DB renderizadas y sin overflow horizontal obligatorio en viewport inspeccionado.
+
+## Review
+- [ ] PR creada.
+- [ ] Handoff comentado en PR.
+- [ ] Usopp invocado y review recibido.
+- [ ] Chopper invocado y review recibido.
+- [ ] #51 comentado/cerrado solo tras merge y canon final.

--- a/openspec/phase-17-4d-verify-checklist.md
+++ b/openspec/phase-17-4d-verify-checklist.md
@@ -22,8 +22,8 @@
 - [x] Browser smoke `/usage`: panel visible, consola limpia, sin backend URL/root Hermes/rutas de DB renderizadas y sin overflow horizontal obligatorio en viewport inspeccionado.
 
 ## Review
-- [ ] PR creada.
-- [ ] Handoff comentado en PR.
-- [ ] Usopp invocado y review recibido.
-- [ ] Chopper invocado y review recibido.
+- [x] PR creada: #77.
+- [x] Handoff comentado en PR: https://github.com/asistentes-mugiwara/mugiwara-control-panel/pull/77#issuecomment-4324730123
+- [x] Usopp invocado y review recibido: `approve`, comentario manual en PR por bloqueo de aprobación formal con cuenta compartida.
+- [x] Chopper invocado y review recibido: `approve`, comentario manual en PR por bloqueo de aprobación formal con cuenta compartida.
 - [ ] #51 comentado/cerrado solo tras merge y canon final.

--- a/scripts/check-usage-server-only.mjs
+++ b/scripts/check-usage-server-only.mjs
@@ -39,8 +39,11 @@ if (!http.includes('/api/v1/usage/calendar?range=')) {
 if (!http.includes('/api/v1/usage/five-hour-windows?limit=')) {
   failures.push('usage adapter must call the fixed five-hour windows endpoint with allowlisted limit')
 }
-if (!http.includes('UsageCalendarRange') || !http.includes('UsageCalendarResponse') || !http.includes('UsageFiveHourWindowsResponse')) {
-  failures.push('usage adapter must type calendar and five-hour windows responses via shared contracts')
+if (!http.includes('/api/v1/usage/hermes-activity?range=')) {
+  failures.push('usage adapter must call the fixed hermes activity endpoint with allowlisted range')
+}
+if (!http.includes('UsageCalendarRange') || !http.includes('UsageCalendarResponse') || !http.includes('UsageFiveHourWindowsResponse') || !http.includes('UsageHermesActivityResponse')) {
+  failures.push('usage adapter must type calendar, five-hour windows and Hermes activity responses via shared contracts')
 }
 if (!page.includes('Calendario por fecha natural') || !page.includes('Europe/Madrid')) {
   failures.push('usage page must render the natural-date calendar with timezone context')
@@ -50,6 +53,14 @@ if (!page.includes('usage-calendar-grid') || !page.includes('primary_windows_cou
 }
 if (!page.includes('Ventanas 5h históricas') || !page.includes('usage-windows-list') || !page.includes('delta_percent')) {
   failures.push('usage page must render dedicated five-hour windows without generic table overflow')
+}
+if (!page.includes('Actividad Hermes agregada') || !page.includes('usage-hermes-activity-list') || !page.includes('correlación orientativa')) {
+  failures.push('usage page must render Hermes aggregated activity as orientative correlation without generic table overflow')
+}
+for (const forbidden of ['state.db', 'MUGIWARA_HERMES_PROFILES_ROOT', 'conversaciones', 'prompts crudos', 'tokens por sesión', 'tokens por conversación']) {
+  if (page.includes(forbidden)) {
+    failures.push(`usage page must not render Hermes sensitive internals: ${forbidden}`)
+  }
 }
 if (http.includes('path=') || http.includes('target=') || http.includes('method=')) {
   failures.push('usage adapter must not grow generic proxy parameters')

--- a/scripts/visual-verify-baseline.mjs
+++ b/scripts/visual-verify-baseline.mjs
@@ -107,7 +107,8 @@ const routes = [
       'fórmulas y privacidad hacen wrap sin filtrar detalles internos del host',
       'el calendario por fecha natural aparece como grid/cards responsive sin scroll horizontal obligatorio',
       'las ventanas 5h históricas aparecen como lista/cards responsive sin scroll horizontal obligatorio',
-      'actividad Hermes agregada sigue fuera de esta fase',
+      'la actividad Hermes agregada aparece como lista/cards responsive sin scroll horizontal obligatorio',
+      'la correlación Hermes/Codex se describe como orientativa, no causalidad exacta',
     ],
   },
 ]


### PR DESCRIPTION
## Summary
- Adds the Phase 17.4d `/usage` Hermes activity UI on top of the already-merged backend `GET /api/v1/usage/hermes-activity?range=7d`.
- Extends the server-only Usage adapter and adds a sanitized fallback fixture.
- Renders `Actividad Hermes agregada` as responsive cards with aggregate-only counts by profile/range and copy that frames Hermes/Codex as orientative correlation, not exact causality.
- Compacts the Codex weekly-cycle methodology block and fixes the minor calendar badge wrap/overflow issue.
- Updates Usage guardrails, visual baseline checklist, OpenSpec, docs and Engram closeout.

## Security / privacy boundary
- Read-only UI only; no writes, polling, cache/TTL, backend source or runtime config changes.
- No client-side exposure of `MUGIWARA_HERMES_PROFILES_ROOT` or backend URL.
- No root/profile DB paths, `state.db`, raw prompts, conversations, raw tool payloads, per-session/per-conversation tokens, user IDs, chat IDs, delivery targets, secrets, headers/cookies or logs are rendered.
- Activity is shown only as already-sanitized backend aggregates.

## Verify
- Red first: `npm run verify:usage-server-only` failed before implementation because adapter/UI for Hermes activity were missing.
- `npm run verify:usage-server-only`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build` (`/usage` remains dynamic `ƒ`)
- `npm run verify:visual-baseline`
- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` → 12 passed
- `git diff --check`
- Browser smoke `/usage` against local API branch: panel visible, console clean, no backend URL/root Hermes/DB path rendered, no horizontal overflow in inspected viewport.

## Review requested
- Usopp: UI/UX/responsive/copy, including panel hierarchy and calendar badge wrap.
- Chopper: no-leakage/security boundary for Hermes activity UI.
- Franky not requested: this PR does not change backend, runtime source, config, polling/cache/TTL or producers.

Closes the implementation part needed before final #51 closeout after review/merge.
