### PR TITLE
docs: plan issue 36 header system metrics

### DIFF
--- a/.engram/issue-36-header-system-metrics-plan-closeout.md
+++ b/.engram/issue-36-header-system-metrics-plan-closeout.md
@@ -1,0 +1,56 @@
+# Issue #36 header system metrics — planning closeout
+
+## Fase
+36.0 — Planning / architecture.
+
+## Fecha
+2026-04-27.
+
+## Rama
+`zoro/issue-36-header-system-metrics-plan`.
+
+## Resultado
+Se inició issue #36 sin implementar la feature. La fase deja plan SDD/TDD ejecutable para añadir métricas de sistema siempre visibles en el header, separando el trabajo en backend host-adjacent read model, frontend server-only/header integration y guardrails/docs/canon.
+
+## Estado real verificado
+- `main` estaba limpio y alineado con `origin/main` antes de crear rama.
+- Issue #36 está abierto con label `enhancement`.
+- No había PRs abiertas.
+- Solo seguían abiertos #36 y #40.
+- Phase 18 Healthcheck producers está cerrada/canonizada por PR #83 y no se reabre.
+- Phase 17 Usage está cerrada y no se toca.
+
+## Decisiones de planificación
+- El trabajo futuro debe crear un módulo backend específico `system` para métricas de sistema, no mezclarlo en Healthcheck/Dashboard/Usage.
+- Endpoint recomendado: `GET /api/v1/system/metrics`.
+- El endpoint no debe aceptar input cliente; RAM/disco/uptime salen de fuentes backend-owned allowlisted.
+- Disco debe usar un target explícito y revisado, inicialmente `/` salvo ajuste de Franky, sin exponer path crudo en la respuesta pública.
+- Frontend debe consumir mediante adapter server-only y pasar snapshot saneada al shell/header; nunca fetch directo de navegador a backend interno ni `NEXT_PUBLIC_*` para backend URL.
+- No polling agresivo por defecto; cualquier refresh automático requiere frecuencia/coste documentados y review Franky + Chopper.
+
+## Microfases acordadas
+1. **36.0 Planning / architecture** — esta fase.
+2. **36.1 Backend read model/API foundation** — módulo `system`, endpoint fijo, tests de degradación/no-leakage, review Franky + Chopper.
+3. **36.2 Frontend server-only adapter + header integration** — adapter server-only, shell/header global, responsive/fallback, review Usopp + Chopper.
+4. **36.3 Guardrails, visual baseline, docs/canon and issue closeout** — `verify:system-metrics-server-only` o equivalente, visual/browser smoke, docs/vault, cierre #36.
+
+## Archivos creados
+- `openspec/issue-36-header-system-metrics-plan.md`.
+- `openspec/issue-36-header-system-metrics-planning-verify-checklist.md`.
+- `.engram/issue-36-header-system-metrics-plan-closeout.md`.
+
+## Verify previsto/ejecutado
+- Preflight GitHub/repo ejecutado antes de rama.
+- Revisión dirigida de docs, shell/header, adapters, módulos backend, tests y guardrails.
+- `git diff --check` debe ejecutarse antes del commit.
+- No aplica build/typecheck porque la fase no toca código, package scripts ni JSON.
+
+## Riesgos abiertos para 36.1+
+- Evitar que métricas de sistema se conviertan en consola host o proxy genérico.
+- Elegir y documentar target de disco con criterio operativo.
+- Diseñar un fallback saneado que no oculte degradación ni rompa el header.
+- Resolver la composición server/client del shell sin fetch browser ni fallback congelado en build.
+- Mantener header compacto en mobile sin overflow ni ruido permanente.
+
+## Siguiente paso recomendado
+Ejecutar 36.1 como backend-only con TDD estricto: tests rojos de contrato/no-leakage/degradación, módulo `system`, endpoint fijo, verify backend/perímetro y review Franky + Chopper antes de entrar en UI.

--- a/.engram/issue-36-header-system-metrics-plan-closeout.md
+++ b/.engram/issue-36-header-system-metrics-plan-closeout.md
@@ -42,8 +42,12 @@ Se inició issue #36 sin implementar la feature. La fase deja plan SDD/TDD ejecu
 ## Verify previsto/ejecutado
 - Preflight GitHub/repo ejecutado antes de rama.
 - Revisión dirigida de docs, shell/header, adapters, módulos backend, tests y guardrails.
-- `git diff --check` debe ejecutarse antes del commit.
+- `git diff --check` pasó sin salida.
 - No aplica build/typecheck porque la fase no toca código, package scripts ni JSON.
+
+## Review recibida
+- Franky: `mergeable_with_minor_followups`. Follow-ups para 36.1+: RAM usada como `MemTotal - MemAvailable` si se usa `/proc/meminfo`; documentar `/` como raíz visible por FastAPI; degradación parcial por familia; review Franky + Chopper si aparece refresh automático.
+- Chopper: `approve` por comentario de PR; GitHub bloqueó aprobación formal por cuenta compartida/autora. Follow-ups para 36.1/36.2: test/guardrail no-leakage recursivo, ausencia de shell/subprocess/comandos host y smoke HTML/DOM/bundle contra backend URL, `NEXT_PUBLIC_*`, paths internos y errores crudos.
 
 ## Riesgos abiertos para 36.1+
 - Evitar que métricas de sistema se conviertan en consola host o proxy genérico.

--- a/openspec/issue-36-header-system-metrics-plan.md
+++ b/openspec/issue-36-header-system-metrics-plan.md
@@ -156,6 +156,12 @@ Review:
 ### 36.1 — Backend read model/API foundation
 Objetivo: crear el módulo backend read-only `system` y endpoint fijo `GET /api/v1/system/metrics`.
 
+Follow-ups incorporados tras review 36.0:
+- Si se usa `/proc/meminfo`, RAM usada debe calcularse como `MemTotal - MemAvailable`, no `MemTotal - MemFree`.
+- El target de disco inicial `/` debe documentarse como “filesystem raíz visible por el proceso FastAPI” y revalidarse si el despliegue pasa a contenedor/namespace distinto.
+- La degradación debe permitir distinguir fuente RAM/disco/uptime fallida sin exponer internals.
+- Añadir test/guardrail explícito de no-leakage recursivo y de ausencia de shell/subprocess/comandos host.
+
 Alcance:
 - Dominio/servicio/router `system` con capas simples y tests.
 - Contrato compartido si el patrón del repo lo pide (`packages/contracts/src/read-models.ts`).
@@ -193,6 +199,9 @@ Review:
 
 ### 36.2 — Frontend server-only adapter + header integration
 Objetivo: mostrar las métricas saneadas en el header global siempre visible.
+
+Follow-up incorporado tras review 36.0:
+- El verify de 36.2 debe incluir smoke HTML/DOM/bundle para confirmar que no aparecen backend URL, `NEXT_PUBLIC_*`, paths internos ni errores crudos.
 
 Alcance:
 - Adapter server-only `system`/`system-metrics` con endpoint fijo.

--- a/openspec/issue-36-header-system-metrics-plan.md
+++ b/openspec/issue-36-header-system-metrics-plan.md
@@ -1,0 +1,281 @@
+# Issue #36 — Always-visible header system metrics plan
+
+## Estado
+- **Fase:** 36.0 — Planning / architecture.
+- **Fecha:** 2026-04-27.
+- **Rama:** `zoro/issue-36-header-system-metrics-plan`.
+- **Issue:** [#36 Always-visible header system metrics](https://github.com/asistentes-mugiwara/mugiwara-control-panel/issues/36).
+- **Alcance de esta PR:** planificación, contrato, microfases, verify y frontera de reviewers. No implementa backend, contrato compartido, adapter frontend ni UI final.
+
+## Objetivo del issue
+Añadir una banda de métricas de sistema siempre visible en el header del control panel:
+
+- RAM usada como número.
+- RAM total como número.
+- RAM usada en porcentaje.
+- Disco usado como número.
+- Disco total como número.
+- Disco usado en porcentaje.
+- Uptime del servidor en días, horas y minutos.
+
+## Por qué planificar antes de implementar
+El issue mezcla tres fronteras de riesgo:
+
+1. **Host-adjacent reads:** RAM, disco y uptime salen del sistema operativo o de fuentes derivadas del host.
+2. **Contrato/API backend:** la lectura debe quedar en FastAPI como frontera de seguridad, no en navegador.
+3. **Header visible y responsive:** la UI afecta al app shell global, mobile/tablet/desktop y percepción permanente de estado.
+
+La experiencia de Phase 15–18 en Healthcheck demuestra que las lecturas host-adjacent deben entrar por contratos pequeños, fuentes allowlisted, tests negativos de leakage y review Franky + Chopper. La experiencia de Phase 16–17 demuestra que UI visible y responsive debe entrar separada y con review Usopp cuando ya exista contrato saneado.
+
+## Contexto real consultado
+- `Project Summary - Mugiwara Control Panel` en el vault: Phase 18 Healthcheck producers está cerrada/canonizada por PR #83; solo siguen abiertas #36 y #40.
+- `docs/api-modules.md`, `docs/read-models.md`, `docs/runtime-config.md`, `docs/security-perimeter.md`, `docs/healthcheck-source-policy.md`.
+- `docs/frontend-ui-spec.md` y `docs/frontend-implementation-handoff.md`.
+- `apps/web/src/app/layout.tsx` y shell/header actual:
+  - `AppShell` es client component global.
+  - `Topbar` es client component con identidad, command chip y `StatusBadge` operativo.
+  - `PageHeader` es header de página, no el header global siempre visible.
+- Adapters server-only existentes en `apps/web/src/modules/*/api/*-http.ts` con `import 'server-only'`, env privada `MUGIWARA_CONTROL_PANEL_API_URL`, fallback saneado y rutas fijas.
+- Backend modular actual en `apps/api/src/modules/*` y routers incluidos explícitamente desde `apps/api/src/main.py`.
+- Tests backend existentes en `apps/api/tests/test_*_api.py` y productores Healthcheck.
+- Guardrails existentes: `verify:health-dashboard-server-only`, `verify:perimeter-policy`, `verify:healthcheck-source-policy`, `verify:usage-server-only` y otros checks server-only por módulo.
+- Closeout Phase 18.5: Healthcheck producers completos; no reabrir productores salvo bug/regresión.
+- Closeout Phase 17.4d: Usage cerrado; patrón de server-only/read-only + UI visible + guardrail + visual baseline.
+
+## Decisiones de arquitectura de 36.0
+
+### 1. Crear módulo backend específico `system`
+Preferencia fijada para implementación futura: crear un módulo backend read-only específico, probablemente `apps/api/src/modules/system/`, en vez de mezclar estas métricas dentro de Healthcheck, Dashboard o Usage.
+
+Motivo:
+- Las métricas del header son un read model global de sistema, no un productor Healthcheck ni una agregación de Dashboard.
+- Evita reabrir Phase 18 Healthcheck producers.
+- Permite un endpoint fijo, pequeño y revisable con tests de seguridad propios.
+- Mantiene el backend como frontera única para host-adjacent reads.
+
+Nombre de endpoint recomendado:
+
+```text
+GET /api/v1/system/metrics
+```
+
+Alternativa aceptable si el repo pide otro naming en 36.1: `GET /api/v1/system-metrics`, pero no usar rutas genéricas ni proxy.
+
+### 2. Fuente backend allowlisted, sin input cliente
+El endpoint no debe aceptar `path`, `mount`, `device`, `command`, `url`, `method`, `interval`, `host`, `target` ni otros parámetros controlados por cliente.
+
+Fuente propuesta por métrica:
+
+- **RAM:** lectura OS allowlisted desde APIs Python stdlib/procfs revisadas. Preferir `/proc/meminfo` parseado de forma estrecha si no se introduce dependencia nueva; alternativamente `os.sysconf` solo si permite total/used correcto con criterio operativo documentado. No usar shell.
+- **Disco:** target único backend-owned y documentado. Recomendación inicial: `/` como capacidad operacional del host del control panel, salvo que Franky recomiende otro path operacional. Puede implementarse con `shutil.disk_usage(<target fijo>)`. No exponer el path crudo en la respuesta pública por defecto.
+- **Uptime:** lectura allowlisted desde `/proc/uptime` o API equivalente, parseo estrecho, sin shell y sin comandos tipo `uptime`.
+
+### 3. Salida saneada mínima
+Contrato recomendado para 36.1:
+
+```json
+{
+  "ram": {
+    "used_bytes": 123,
+    "total_bytes": 456,
+    "used_percent": 27.0
+  },
+  "disk": {
+    "used_bytes": 123,
+    "total_bytes": 456,
+    "used_percent": 27.0
+  },
+  "uptime": {
+    "days": 1,
+    "hours": 2,
+    "minutes": 3
+  },
+  "updated_at": "2026-04-27T12:00:00Z",
+  "source_state": "live"
+}
+```
+
+Notas:
+- `used_percent` debe derivarse del mismo snapshot que bytes usados/totales, con redondeo documentado y tests contra total cero/malformado.
+- `source_state` debe usar vocabulario pequeño y final-user-safe: `live`, `degraded`, `not_configured` o equivalente alineado con patrones existentes.
+- No serializar hostname, mount table, device, path, process list, users, raw `/proc`, stdout/stderr, logs, excepciones ni stack traces.
+
+### 4. Frontend: adapter server-only + paso de props al shell
+El shell actual (`AppShell`/`Topbar`) es client-side. La implementación frontend no debe hacer fetch desde browser a la URL real del backend ni leer host metrics en cliente.
+
+Patrón recomendado para 36.2:
+- Añadir un adapter server-only en un módulo nuevo `apps/web/src/modules/system/api/system-metrics-http.ts` con `import 'server-only'`, `MUGIWARA_CONTROL_PANEL_API_URL`, endpoint fijo `/api/v1/system/metrics`, validación `http(s)`, `cache: 'no-store'` salvo decisión explícita de caching.
+- Crear una frontera server component en el layout o wrapper del shell que obtiene el snapshot y lo pasa a `AppShell`/`Topbar` como prop serializable saneada.
+- Mantener `AppShell`/`Topbar` como client components si hace falta para navegación móvil, pero sin fetch directo ni env backend.
+- Hacer el root layout dinámico si lee runtime config (`export const dynamic = 'force-dynamic'`) o aislar la lectura en un server wrapper dinámico equivalente. Verificar que no se congela fallback en build.
+- Fallback/degradado: renderizar banda compacta con valores no disponibles, sin errores crudos ni backend URL.
+
+### 5. No polling agresivo en primera UI
+El primer corte UI debe ser snapshot server-rendered por navegación/request. Si se propone refresh/polling en 36.2 o 36.3, debe documentar frecuencia, coste, caché y reviewer Franky + Chopper. Por defecto: sin polling agresivo.
+
+## Fuera de alcance de 36.0
+- No implementar módulo backend `system`.
+- No modificar `apps/api/src/main.py`.
+- No crear contratos TypeScript definitivos.
+- No tocar `Topbar`, `AppShell`, CSS ni UI final.
+- No añadir scripts de guardrail.
+- No actualizar productores/timers Healthcheck.
+- No tocar issue #40.
+- No cerrar issue #36.
+
+## Microfases propuestas
+
+### 36.0 — Planning / architecture
+**Esta fase.**
+
+Entregables:
+- `openspec/issue-36-header-system-metrics-plan.md`.
+- `openspec/issue-36-header-system-metrics-planning-verify-checklist.md`.
+- `.engram/issue-36-header-system-metrics-plan-closeout.md`.
+- Observación Engram con la estrategia de microfases.
+
+DoD:
+- Estado real de repo, issue, PRs e issues abiertos verificado.
+- Docs, closeouts y shell/header real consultados.
+- Contrato, riesgos, fuera de alcance, reviewers y verify por microfase definidos.
+- PR docs/OpenSpec abierta sin runtime changes.
+
+Verify:
+- `git status --short --branch`.
+- `git fetch origin --prune` + `git switch main` + `git pull --ff-only origin main` antes de rama.
+- `gh issue view 36`.
+- `gh issue list --state open`.
+- `gh pr list --state open`.
+- Lectura dirigida de docs/shell/adapters/backend/tests/guardrails.
+- `git diff --check`.
+
+Review:
+- Franky + Chopper, porque el plan toma decisiones sobre host metrics y frontera de seguridad aunque el diff sea documental.
+- Usopp no bloquea 36.0; entra en 36.2 para UI/header responsive. Si Usopp quiere opinar antes, puede hacerlo como follow-up no bloqueante.
+
+### 36.1 — Backend read model/API foundation
+Objetivo: crear el módulo backend read-only `system` y endpoint fijo `GET /api/v1/system/metrics`.
+
+Alcance:
+- Dominio/servicio/router `system` con capas simples y tests.
+- Contrato compartido si el patrón del repo lo pide (`packages/contracts/src/read-models.ts`).
+- Lectores host allowlisted y estrechos para RAM, disco y uptime.
+- Fallback/degradación saneada si una fuente no está disponible o viene malformada.
+- Sin UI, sin polling, sin guardrail frontend final.
+
+DoD técnico:
+- Endpoint fijo sin input cliente.
+- No shell genérico, no `subprocess`, no comandos `free`, `df`, `uptime`, no Docker/systemd, no filesystem discovery.
+- Disco usa target backend-owned, preferiblemente `/`, con decisión Franky documentada.
+- Respuesta no contiene paths, mount internals, device names, hostname, procesos, usuarios, raw `/proc`, logs, stdout/stderr, stack traces, `.env`, tokens ni credenciales.
+- `updated_at` timezone-aware y saneado.
+- `source_state` explícito.
+
+Tests mínimos:
+- Caso normal RAM/disk/uptime.
+- Fuente RAM ausente/malformada.
+- Fuente disco no disponible o total cero.
+- Fuente uptime ausente/malformada.
+- No-leakage recursivo del payload público.
+- Endpoint rechaza/ignora cualquier intento de input inesperado si se materializa por query/path.
+- Perímetro/headers siguen saneados.
+
+Verify recomendado:
+- `PYTHONPATH=. pytest apps/api/tests/test_system_metrics_api.py -q`.
+- `PYTHONPATH=. pytest apps/api/tests/test_perimeter_api.py apps/api/tests/test_healthcheck_dashboard_api.py -q` si toca main/router común.
+- `python3 -m py_compile` sobre módulos nuevos.
+- `npm run verify:perimeter-policy`.
+- `npm run verify:healthcheck-source-policy` para demostrar que no se reabrió Healthcheck.
+- `git diff --check`.
+
+Review:
+- Franky + Chopper obligatorios.
+
+### 36.2 — Frontend server-only adapter + header integration
+Objetivo: mostrar las métricas saneadas en el header global siempre visible.
+
+Alcance:
+- Adapter server-only `system`/`system-metrics` con endpoint fijo.
+- Tipos compartidos o locales alineados con contrato 36.1.
+- Integración con root layout/AppShell/Topbar pasando snapshot saneada desde servidor a cliente.
+- Render compacto desktop/tablet/mobile.
+- Estado degradado/fallback sobrio sin layout jump ni error crudo.
+- Sin endpoints nuevos ni cambios backend salvo ajuste menor de contrato ya aprobado.
+
+DoD técnico:
+- La URL backend vive solo en `MUGIWARA_CONTROL_PANEL_API_URL`; no `NEXT_PUBLIC_*`.
+- No fetch directo de browser a backend interno.
+- `Topbar` no lee `process.env`, host, `/proc`, filesystem ni URLs arbitrarias.
+- Root/layout dinámico o wrapper dinámico si lee runtime config.
+- Mobile prioriza jerarquía: porcentaje + label corto si no cabe; desktop puede mostrar usados/totales + porcentaje.
+- No overflow horizontal; no ruido visual permanente.
+- Fallback renderiza estado degradado, no stack/error/raw config.
+
+Verify recomendado:
+- Red inicial del futuro `verify:system-metrics-server-only` o check equivalente si se crea en 36.2.
+- `npm --prefix apps/web run typecheck`.
+- `npm --prefix apps/web run build` y comprobar que la ruta/layout afectada no congela fallback si depende de runtime config.
+- `npm run verify:visual-baseline`.
+- Browser smoke en desktop/tablet/mobile: header visible, consola limpia, sin overflow horizontal.
+- Smoke HTML/DOM: no backend URL, no `NEXT_PUBLIC`, no paths internos ni raw errors.
+- Backend tests 36.1 si cambia contrato.
+- `git diff --check`.
+
+Review:
+- Usopp + Chopper obligatorios.
+- Franky si se añade polling, cache/TTL, frecuencia de refresh, cambio de runtime o ajuste operativo.
+
+### 36.3 — Guardrails, visual baseline, docs/canon and issue closeout
+Objetivo: endurecer el contrato completo y cerrar #36 solo después de backend + UI verificados.
+
+Alcance:
+- Añadir guardrail estático específico `verify:system-metrics-server-only` o ampliar guardrail existente solo si encaja de forma clara.
+- Fijar invariantes:
+  - endpoint fijo `/api/v1/system/metrics`;
+  - adapter frontend server-only;
+  - ausencia de `NEXT_PUBLIC_*` para backend;
+  - no browser-side host reads;
+  - no proxy genérico;
+  - no shell/subprocess/comandos host para métricas;
+  - no paths/logs/stdout/stderr/raw `/proc`/mount table/process list/users/hostname.
+- Actualizar docs vivas y Project Summary del vault si la feature queda cerrada.
+- Cerrar issue #36 solo al final, con PR mergeada y verify completo.
+
+Verify recomendado:
+- `npm run verify:system-metrics-server-only`.
+- `npm run verify:perimeter-policy`.
+- `npm run verify:healthcheck-source-policy`.
+- `npm --prefix apps/web run typecheck`.
+- `npm --prefix apps/web run build`.
+- `npm run verify:visual-baseline`.
+- `PYTHONPATH=. pytest apps/api/tests/test_system_metrics_api.py apps/api/tests/test_perimeter_api.py -q`.
+- Browser smoke con API local de la rama.
+- `git diff --check`.
+- `git status --short --branch`.
+
+Review:
+- Chopper + Usopp obligatorios.
+- Franky obligatorio si guardrails/canon documentan refresh/cache/runtime source o si 36.1/36.2 dejaron follow-ups operativos.
+
+## Registro de riesgos
+
+| Riesgo | Impacto | Mitigación |
+| --- | --- | --- |
+| Convertir métricas en consola host genérica | Alto seguridad | Endpoint fijo, sin input cliente, no shell/subprocess, tests negativos y Chopper. |
+| Exponer rutas/mounts/devices/host internals | Alto seguridad | No serializar target disk ni raw source; no-leakage recursivo. |
+| Reabrir Healthcheck producers | Medio/alto scope | Módulo `system` separado; Healthcheck queda intacto salvo guardrail de no regresión. |
+| Header client-side fetch a backend interno | Alto perímetro | Adapter server-only + props serializables; guardrail contra `NEXT_PUBLIC_*` y fetch browser. |
+| Fallback congelado por build estático | Medio UX/operación | Layout/wrapper dinámico si lee runtime config; verify build. |
+| Polling agresivo en header | Medio operación/performance | No polling por defecto; si se introduce, review Franky + Chopper y coste documentado. |
+| Header saturado o rompe mobile | Medio UX | Separar UI en 36.2 con Usopp; visual baseline y browser smoke responsive. |
+| Métricas incoherentes por snapshots distintos | Medio confianza | Calcular cada familia desde snapshot estrecho; documentar redondeo y timestamps. |
+
+## Política de ramas, PR y cierre
+- Rama de planificación: `zoro/issue-36-header-system-metrics-plan`.
+- Cada microfase posterior debe usar rama propia `zoro/issue-36-...` y PR propia.
+- Commits con trailers Mugiwara.
+- No cerrar issue #36 hasta completar 36.3 y validar backend + frontend + guardrails + docs/canon.
+- No tocar issue #40.
+
+## Siguiente paso recomendado tras 36.0
+Ejecutar 36.1 como microfase backend-only con TDD estricto: primero tests rojos de contrato/no-leakage/degradación, después módulo `system`, endpoint fijo y review Franky + Chopper antes de entrar en UI.

--- a/openspec/issue-36-header-system-metrics-planning-verify-checklist.md
+++ b/openspec/issue-36-header-system-metrics-planning-verify-checklist.md
@@ -1,0 +1,86 @@
+# Issue #36 — Planning verify checklist
+
+## Fase
+36.0 — Planning / architecture for always-visible header system metrics.
+
+## Preflight repo/GitHub
+- [x] `git status --short --branch` inicial ejecutado en `/srv/crew-core/projects/mugiwara-control-panel`.
+  - Resultado: `## main...origin/main`, sin cambios locales.
+- [x] `git fetch origin --prune` ejecutado.
+- [x] `git switch main` ejecutado.
+  - Resultado: `Already on 'main'`, rama alineada con `origin/main`.
+- [x] `git pull --ff-only origin main` ejecutado.
+  - Resultado: `Already up to date`.
+- [x] `gh issue view 36` ejecutado.
+  - Resultado: issue #36 abierto, título `Always-visible header system metrics`, label `enhancement`.
+- [x] `gh pr list --state open` ejecutado.
+  - Resultado: `[]`, sin PRs abiertas.
+- [x] `gh issue list --state open` ejecutado.
+  - Resultado: solo #36 y #40 abiertos.
+- [x] Identidad Git local configurada con `/srv/crew-core/scripts/mugiwara-git-identity.sh set zoro .`.
+  - Resultado: `user.name=zoro`, `user.email=asistentes.mugiwara@gmail.com`, `mugiwara.agent=zoro`, hooks Mugiwara activos.
+- [x] Rama creada desde `main` actualizado.
+  - Rama: `zoro/issue-36-header-system-metrics-plan`.
+
+## Contexto consultado
+- [x] `Project Summary - Mugiwara Control Panel` en vault.
+  - Hallazgo: Phase 18 Healthcheck producers cerrado/canonizado por PR #83; #36/#40 son features separadas siguientes.
+- [x] `docs/frontend-ui-spec.md`.
+- [x] `docs/frontend-implementation-handoff.md`.
+- [x] `docs/runtime-config.md`.
+- [x] `docs/security-perimeter.md`.
+- [x] `docs/api-modules.md`.
+- [x] `docs/read-models.md`.
+- [x] `docs/healthcheck-source-policy.md`.
+- [x] Header/shell real en `apps/web`.
+  - `apps/web/src/app/layout.tsx`.
+  - `apps/web/src/shared/ui/app-shell/AppShell.tsx`.
+  - `apps/web/src/shared/ui/app-shell/Topbar.tsx`.
+  - `apps/web/src/shared/ui/app-shell/PageHeader.tsx`.
+- [x] Adapters server-only existentes en `apps/web/src/modules/*/api/*-http.ts`.
+- [x] Estructura backend real en `apps/api/src/modules` y `apps/api/src/main.py`.
+- [x] Patrones de tests backend en `apps/api/tests`.
+- [x] Guardrails en `package.json`.
+  - `verify:health-dashboard-server-only`.
+  - `verify:perimeter-policy`.
+  - `verify:healthcheck-source-policy`.
+  - `verify:usage-server-only`.
+  - otros `verify:*server-only` existentes.
+- [x] Closeout Phase 18.5.
+- [x] Closeout Phase 17.4d/Usage.
+
+## Diseño producido
+- [x] Plan principal creado: `openspec/issue-36-header-system-metrics-plan.md`.
+- [x] Checklist creado: `openspec/issue-36-header-system-metrics-planning-verify-checklist.md`.
+- [x] Closeout de continuidad creado: `.engram/issue-36-header-system-metrics-plan-closeout.md`.
+- [x] Microfases definidas:
+  - 36.0 Planning / architecture.
+  - 36.1 Backend read model/API foundation.
+  - 36.2 Frontend server-only adapter + header integration.
+  - 36.3 Guardrails, visual baseline, docs/canon and issue closeout.
+- [x] Decisión inicial documentada: módulo backend específico `system`, endpoint fijo recomendado `GET /api/v1/system/metrics`.
+- [x] Fronteras de seguridad documentadas: sin input cliente, sin shell/subprocess, sin paths/logs/stdout/stderr/raw host internals.
+- [x] Review esperado documentado: Franky + Chopper para backend/host boundary; Usopp + Chopper para UI; Franky si hay polling/cache/runtime.
+
+## Verify de planificación
+- [x] `git diff --check` pasa.
+  - Resultado: sin salida.
+- [x] `git status --short --branch` confirma solo cambios documentales esperados antes de commit.
+  - Resultado: tres ficheros nuevos: OpenSpec, checklist y closeout `.engram`.
+- [x] Si se toca JSON/package scripts: validar sintaxis. No aplica en 36.0; no se tocaron JSON ni package scripts.
+- [x] No se ha implementado backend metrics.
+- [x] No se ha implementado UI final.
+- [x] No se ha tocado issue #40.
+- [x] No se ha cerrado issue #36.
+
+## PR/review
+- [ ] Commit creado con trailers Mugiwara.
+- [ ] Rama pusheada.
+- [ ] PR de planificación abierta.
+- [ ] Comentario de handoff dejado en PR.
+- [ ] Franky invocado para review operativa del plan host metrics.
+- [ ] Chopper invocado para review de seguridad del plan host metrics.
+- [ ] Respuestas/comentarios de reviewers registrados o bloqueo documentado.
+
+## Notas
+Esta fase es docs/OpenSpec/.engram-only, pero la decisión de arquitectura toca frontera host-adjacent. Por tanto, se pide review Franky + Chopper aunque no haya runtime change.

--- a/openspec/issue-36-header-system-metrics-planning-verify-checklist.md
+++ b/openspec/issue-36-header-system-metrics-planning-verify-checklist.md
@@ -74,13 +74,23 @@
 - [x] No se ha cerrado issue #36.
 
 ## PR/review
-- [ ] Commit creado con trailers Mugiwara.
-- [ ] Rama pusheada.
-- [ ] PR de planificación abierta.
-- [ ] Comentario de handoff dejado en PR.
-- [ ] Franky invocado para review operativa del plan host metrics.
-- [ ] Chopper invocado para review de seguridad del plan host metrics.
-- [ ] Respuestas/comentarios de reviewers registrados o bloqueo documentado.
+- [x] Commit creado con trailers Mugiwara.
+  - Commit: `6f7386d` (`docs: plan issue 36 header system metrics`).
+- [x] Rama pusheada.
+  - Rama remota: `origin/zoro/issue-36-header-system-metrics-plan`.
+- [x] PR de planificación abierta.
+  - PR: https://github.com/asistentes-mugiwara/mugiwara-control-panel/pull/84.
+- [x] Comentario de handoff dejado en PR.
+  - Comentario: https://github.com/asistentes-mugiwara/mugiwara-control-panel/pull/84#issuecomment-4326933020.
+- [x] Franky invocado para review operativa del plan host metrics.
+  - Decisión: `mergeable_with_minor_followups`.
+  - Comentario PR: https://github.com/asistentes-mugiwara/mugiwara-control-panel/pull/84#issuecomment-4326948386.
+  - Follow-ups para 36.1+: RAM usada como `MemTotal - MemAvailable` si se usa `/proc/meminfo`; documentar `/` como raíz visible por FastAPI; degradación parcial por familia; review Franky + Chopper si aparece refresh automático.
+- [x] Chopper invocado para review de seguridad del plan host metrics.
+  - Decisión: `approve` por comentario; aprobación formal bloqueada por GitHub porque la cuenta compartida no puede aprobar su propia PR.
+  - Comentario PR: https://github.com/asistentes-mugiwara/mugiwara-control-panel/pull/84#issuecomment-4326965894.
+  - Follow-ups para 36.1/36.2: test/guardrail no-leakage recursivo, ausencia de shell/subprocess/comandos host y smoke HTML/DOM/bundle contra backend URL, `NEXT_PUBLIC_*`, paths internos y errores crudos.
+- [x] Respuestas/comentarios de reviewers registrados o bloqueo documentado.
 
 ## Notas
 Esta fase es docs/OpenSpec/.engram-only, pero la decisión de arquitectura toca frontera host-adjacent. Por tanto, se pide review Franky + Chopper aunque no haya runtime change.


### PR DESCRIPTION
## Resumen

Planificación 36.0 para issue #36 — Always-visible header system metrics.

Esta PR no implementa la feature. Deja el plan SDD/TDD ejecutable para introducir métricas de sistema siempre visibles en el header sin mezclar backend host-adjacent, UI global y guardrails en una sola PR.

## Entregables

- `openspec/issue-36-header-system-metrics-plan.md`
- `openspec/issue-36-header-system-metrics-planning-verify-checklist.md`
- `.engram/issue-36-header-system-metrics-plan-closeout.md`

## Decisiones principales

- Microfases propuestas:
  - 36.0 Planning / architecture.
  - 36.1 Backend read model/API foundation.
  - 36.2 Frontend server-only adapter + header integration.
  - 36.3 Guardrails, visual baseline, docs/canon and issue closeout.
- Preferencia arquitectónica: módulo backend específico `system`, endpoint fijo `GET /api/v1/system/metrics`.
- Backend como frontera de seguridad: sin input cliente, sin shell/subprocess, sin rutas/mounts/devices/logs/stdout/stderr/raw host internals en respuesta pública.
- Frontend futuro: adapter server-only + props saneadas al shell/header; sin `NEXT_PUBLIC_*` ni fetch browser directo a backend interno.
- No polling agresivo por defecto.

## Verify ejecutado

- `git status --short --branch`
- `git fetch origin --prune`
- `git switch main`
- `git pull --ff-only origin main`
- `gh issue view 36`
- `gh pr list --state open`
- `gh issue list --state open`
- `/srv/crew-core/scripts/mugiwara-git-identity.sh set zoro .`
- revisión dirigida de vault/docs/shell/header/adapters/módulos backend/tests/guardrails
- `git diff --check`
- `git status --short --branch`

No se ejecuta build/typecheck porque el diff es docs/OpenSpec/.engram-only y no toca código, JSON ni package scripts.

## Review solicitada

Aunque el diff es documental, el plan toma decisiones sobre métricas host-adjacent. Solicito:

- Franky: operabilidad de fuente RAM/disco/uptime, target de disco y corte de microfases.
- Chopper: frontera de seguridad, no-leakage y prevención de consola host/proxy genérico.

Usopp queda para 36.2 cuando exista UI/header real, salvo observación temprana no bloqueante.

## Riesgos abiertos

- Elegir target de disco operacional sin exponer path crudo.
- Evitar que el endpoint se convierta en consola host.
- Resolver shell server/client sin fetch browser ni fallback congelado.
- Mantener header compacto y responsive en 36.2.

Closes no issue. #36 sigue abierto hasta terminar backend + UI + guardrails + canon.