### PR TITLE
feat: add system metrics backend read model

### DIFF
--- a/.engram/issue-36-1-system-metrics-backend-closeout.md
+++ b/.engram/issue-36-1-system-metrics-backend-closeout.md
@@ -1,0 +1,63 @@
+# Issue #36.1 system metrics backend — closeout
+
+## Fase
+36.1 — Backend read model/API foundation.
+
+## Rama
+`zoro/issue-36-1-system-metrics-backend`.
+
+## Resultado
+Se implementa el backend read-only para métricas de sistema sin tocar UI ni frontend:
+
+- `GET /api/v1/system/metrics`.
+- Módulo `apps/api/src/modules/system`.
+- Contrato TypeScript `SystemMetricsResponse`.
+- Guardrail `npm run verify:system-metrics-backend-policy`.
+
+## Decisiones técnicas
+- RAM usada se calcula como `MemTotal - MemAvailable` desde `/proc/meminfo`, siguiendo review de Franky en 36.0.
+- Disco usa `shutil.disk_usage('/')`; el payload público no expone `/`, solo `fastapi-visible-root-filesystem`.
+- Uptime se parsea desde `/proc/uptime` y se serializa solo como días/horas/minutos.
+- Cada familia (`ram`, `disk`, `uptime`) degrada independientemente a `source_state='unknown'` con valores `null` si falla o viene malformada.
+- El envelope usa `status='ready'` si todo está live y `status='source_unavailable'` si alguna familia degrada.
+- Querystrings cliente como `path`, `mount`, `device`, `command`, `url`, `method`, `host` o `target` no controlan la fuente ni se ecoan.
+
+## Seguridad
+No se serializa:
+- paths host crudos;
+- mount table;
+- device names;
+- hostname;
+- process list;
+- users;
+- raw `/proc`;
+- stdout/stderr/raw output;
+- logs, tracebacks o excepciones;
+- tokens, `.env`, credenciales.
+
+El backend no usa shell, `subprocess`, comandos `free`/`df`/`uptime`, Docker, systemd ni discovery de filesystem.
+
+## Archivos relevantes
+- `apps/api/src/modules/system/service.py`.
+- `apps/api/src/modules/system/router.py`.
+- `apps/api/src/modules/system/AGENTS.md`.
+- `apps/api/tests/test_system_metrics_api.py`.
+- `scripts/check-system-metrics-backend-policy.mjs`.
+- `packages/contracts/src/read-models.ts`.
+- `docs/api-modules.md`.
+- `docs/read-models.md`.
+- `docs/security-perimeter.md`.
+
+## Verify
+Ejecutado antes de commit/PR:
+- `python3 -m py_compile apps/api/src/modules/system/*.py apps/api/tests/test_system_metrics_api.py`.
+- `PYTHONPATH=. pytest apps/api/tests/test_system_metrics_api.py -q` — 3 passed.
+- `PYTHONPATH=. pytest apps/api/tests/test_perimeter_api.py apps/api/tests/test_healthcheck_dashboard_api.py -q` — 50 passed.
+- `npm run verify:system-metrics-backend-policy`.
+- `npm run verify:perimeter-policy`.
+- `npm run verify:healthcheck-source-policy`.
+- `npm --prefix apps/web run typecheck`.
+- `git diff --check`.
+
+## Siguiente paso
+Pedir review Franky + Chopper. Si se aprueba y mergea, 36.2 debe implementar el adapter server-only/frontend header sin reabrir backend salvo ajuste menor revisado.

--- a/.engram/issue-36-1-system-metrics-backend-closeout.md
+++ b/.engram/issue-36-1-system-metrics-backend-closeout.md
@@ -61,3 +61,7 @@ Ejecutado antes de commit/PR:
 
 ## Siguiente paso
 Pedir review Franky + Chopper. Si se aprueba y mergea, 36.2 debe implementar el adapter server-only/frontend header sin reabrir backend salvo ajuste menor revisado.
+
+## Review recibida
+- Franky: `approve` por comentario de PR; aprobación formal bloqueada por cuenta compartida/autora. Follow-ups no bloqueantes: en 36.2 definir polling/TTL si hay refresh; si FastAPI se ejecuta en contenedor, documentar que el disco representa la raíz visible por runtime.
+- Chopper: `approve` por comentario de PR; aprobación formal bloqueada por cuenta compartida/autora. Follow-up no bloqueante: el endpoint solo es aceptable dentro del perímetro privado; si se expone fuera de LAN/Tailscale/private proxy, requiere auth/sesión/rate-limit antes.

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -9,6 +9,7 @@ from .modules.vault.router import router as vault_router
 from .modules.healthcheck.router import router as healthcheck_router
 from .modules.dashboard.router import router as dashboard_router
 from .modules.usage.router import router as usage_router
+from .modules.system.router import router as system_router
 
 SECURITY_HEADERS = {
     'X-Content-Type-Options': 'nosniff',
@@ -65,6 +66,7 @@ app.include_router(vault_router)
 app.include_router(healthcheck_router)
 app.include_router(dashboard_router)
 app.include_router(usage_router)
+app.include_router(system_router)
 
 
 @app.get('/health')

--- a/apps/api/src/modules/system/AGENTS.md
+++ b/apps/api/src/modules/system/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md — apps/api/src/modules/system
+
+## Rol
+Módulo backend read-only para métricas saneadas de sistema usadas por el header global.
+
+## Reglas
+- Exponer solo el endpoint fijo `GET /api/v1/system/metrics`.
+- No aceptar `path`, `mount`, `device`, `command`, `url`, `method`, `host`, `target` ni parámetros cliente para elegir fuentes.
+- No usar shell, `subprocess`, comandos `free`/`df`/`uptime`, Docker, systemd, discovery de filesystem ni consola host genérica.
+- RAM se calcula desde fuente OS allowlisted; si se usa `/proc/meminfo`, `used = MemTotal - MemAvailable`.
+- Disco usa el target backend-owned `/`, documentado públicamente solo como raíz visible por FastAPI; no serializar el path crudo.
+- Uptime se deriva de fuente OS allowlisted y se serializa solo como días/horas/minutos.
+- No exponer paths, mount table, devices, hostname, process list, users, raw `/proc`, stdout/stderr, logs, excepciones, stack traces, tokens ni credenciales.
+- Degradar por familia (`ram`, `disk`, `uptime`) sin filtrar internals.

--- a/apps/api/src/modules/system/__init__.py
+++ b/apps/api/src/modules/system/__init__.py
@@ -1,0 +1,3 @@
+from .router import router
+
+__all__ = ['router']

--- a/apps/api/src/modules/system/router.py
+++ b/apps/api/src/modules/system/router.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from ...shared.contracts import resource_response
+from .service import SYSTEM_METRICS_DISK_TARGET_LABEL, SYSTEM_METRICS_SOURCE_LABEL, SystemMetricsService
+
+router = APIRouter(prefix='/api/v1/system', tags=['system'])
+_service = SystemMetricsService()
+
+
+def get_system_metrics_service() -> SystemMetricsService:
+    return _service
+
+
+@router.get('/metrics')
+def get_system_metrics(service: SystemMetricsService = Depends(get_system_metrics_service)) -> dict:
+    metrics = service.get_metrics()
+    return resource_response(
+        resource='system.metrics',
+        status=service.status_for(metrics),
+        data=metrics,
+        meta={
+            'read_only': True,
+            'sanitized': True,
+            'source': SYSTEM_METRICS_SOURCE_LABEL,
+            'disk_target': SYSTEM_METRICS_DISK_TARGET_LABEL,
+        },
+    )

--- a/apps/api/src/modules/system/service.py
+++ b/apps/api/src/modules/system/service.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Protocol
+import shutil
+
+SYSTEM_METRICS_DISK_TARGET = '/'
+SYSTEM_METRICS_DISK_TARGET_LABEL = 'fastapi-visible-root-filesystem'
+SYSTEM_METRICS_SOURCE_LABEL = 'os-allowlisted-system-metrics'
+
+SourceState = str
+
+
+class DiskUsageSnapshot(Protocol):
+    total: int
+    used: int
+    free: int
+
+
+@dataclass(frozen=True)
+class CapacityMetric:
+    used_bytes: int | None
+    total_bytes: int | None
+    used_percent: float | None
+    source_state: SourceState
+
+    @classmethod
+    def unknown(cls) -> 'CapacityMetric':
+        return cls(used_bytes=None, total_bytes=None, used_percent=None, source_state='unknown')
+
+    def to_public(self) -> dict:
+        return {
+            'used_bytes': self.used_bytes,
+            'total_bytes': self.total_bytes,
+            'used_percent': self.used_percent,
+            'source_state': self.source_state,
+        }
+
+
+@dataclass(frozen=True)
+class UptimeMetric:
+    days: int | None
+    hours: int | None
+    minutes: int | None
+    source_state: SourceState
+
+    @classmethod
+    def unknown(cls) -> 'UptimeMetric':
+        return cls(days=None, hours=None, minutes=None, source_state='unknown')
+
+    def to_public(self) -> dict:
+        return {
+            'days': self.days,
+            'hours': self.hours,
+            'minutes': self.minutes,
+            'source_state': self.source_state,
+        }
+
+
+class SystemMetricsService:
+    def __init__(
+        self,
+        *,
+        meminfo_reader: Callable[[], str] | None = None,
+        disk_usage_reader: Callable[[], DiskUsageSnapshot] | None = None,
+        uptime_reader: Callable[[], str] | None = None,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._meminfo_reader = meminfo_reader or self._read_proc_meminfo
+        self._disk_usage_reader = disk_usage_reader or self._read_disk_usage
+        self._uptime_reader = uptime_reader or self._read_proc_uptime
+        self._now = now or (lambda: datetime.now(timezone.utc))
+
+    def get_metrics(self) -> dict:
+        ram = self._safe_ram_metric()
+        disk = self._safe_disk_metric()
+        uptime = self._safe_uptime_metric()
+        source_state = 'live' if all(metric.source_state == 'live' for metric in (ram, disk, uptime)) else 'degraded'
+
+        return {
+            'ram': ram.to_public(),
+            'disk': disk.to_public(),
+            'uptime': uptime.to_public(),
+            'updated_at': _format_updated_at(self._now()),
+            'source_state': source_state,
+        }
+
+    def status_for(self, metrics: dict) -> str:
+        if metrics.get('source_state') == 'live':
+            return 'ready'
+        return 'source_unavailable'
+
+    def _safe_ram_metric(self) -> CapacityMetric:
+        try:
+            return _parse_meminfo(self._meminfo_reader())
+        except Exception:
+            return CapacityMetric.unknown()
+
+    def _safe_disk_metric(self) -> CapacityMetric:
+        try:
+            usage = self._disk_usage_reader()
+            return _capacity_metric(total_bytes=usage.total, used_bytes=usage.used)
+        except Exception:
+            return CapacityMetric.unknown()
+
+    def _safe_uptime_metric(self) -> UptimeMetric:
+        try:
+            return _parse_uptime(self._uptime_reader())
+        except Exception:
+            return UptimeMetric.unknown()
+
+    @staticmethod
+    def _read_proc_meminfo() -> str:
+        return Path('/proc/meminfo').read_text(encoding='utf-8')
+
+    @staticmethod
+    def _read_proc_uptime() -> str:
+        return Path('/proc/uptime').read_text(encoding='utf-8')
+
+    @staticmethod
+    def _read_disk_usage() -> DiskUsageSnapshot:
+        return shutil.disk_usage(SYSTEM_METRICS_DISK_TARGET)
+
+
+def _parse_meminfo(content: str) -> CapacityMetric:
+    values_kb: dict[str, int] = {}
+    for line in content.splitlines():
+        if ':' not in line:
+            continue
+        key, rest = line.split(':', 1)
+        if key not in {'MemTotal', 'MemAvailable'}:
+            continue
+        parts = rest.strip().split()
+        if not parts:
+            raise ValueError('missing meminfo value')
+        values_kb[key] = int(parts[0])
+
+    total_kb = values_kb['MemTotal']
+    available_kb = values_kb['MemAvailable']
+    total_bytes = total_kb * 1024
+    used_bytes = (total_kb - available_kb) * 1024
+    return _capacity_metric(total_bytes=total_bytes, used_bytes=used_bytes)
+
+
+def _capacity_metric(*, total_bytes: int, used_bytes: int) -> CapacityMetric:
+    if total_bytes <= 0 or used_bytes < 0 or used_bytes > total_bytes:
+        raise ValueError('invalid capacity metric')
+    used_percent = round((used_bytes / total_bytes) * 100, 1)
+    return CapacityMetric(
+        used_bytes=used_bytes,
+        total_bytes=total_bytes,
+        used_percent=used_percent,
+        source_state='live',
+    )
+
+
+def _parse_uptime(content: str) -> UptimeMetric:
+    first_value = content.strip().split()[0]
+    total_seconds = int(float(first_value))
+    if total_seconds < 0:
+        raise ValueError('invalid uptime')
+
+    days, remainder = divmod(total_seconds, 86_400)
+    hours, remainder = divmod(remainder, 3_600)
+    minutes, _seconds = divmod(remainder, 60)
+    return UptimeMetric(days=days, hours=hours, minutes=minutes, source_state='live')
+
+
+def _format_updated_at(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    value = value.astimezone(timezone.utc).replace(microsecond=0)
+    return value.isoformat().replace('+00:00', 'Z')

--- a/apps/api/tests/test_system_metrics_api.py
+++ b/apps/api/tests/test_system_metrics_api.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from apps.api.src.main import app
+from apps.api.src.modules.system.router import get_system_metrics_service
+from apps.api.src.modules.system.service import SystemMetricsService
+
+
+def _override_system_service(service: SystemMetricsService) -> None:
+    app.dependency_overrides[get_system_metrics_service] = lambda: service
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.clear()
+
+
+def _assert_no_system_metrics_leakage(value: Any) -> None:
+    serialized = str(value).lower()
+    forbidden = [
+        '/srv/',
+        '/home/',
+        '/proc/',
+        '.env',
+        'token',
+        'secret',
+        'password',
+        'stdout',
+        'stderr',
+        'raw_output',
+        'traceback',
+        'mount',
+        'device',
+        'hostname',
+        'process',
+        'users',
+        'command',
+        'df -h',
+        'free -m',
+        'uptime output',
+    ]
+    for marker in forbidden:
+        assert marker not in serialized
+
+
+def test_system_metrics_returns_sanitized_allowlisted_snapshot() -> None:
+    service = SystemMetricsService(
+        meminfo_reader=lambda: 'MemTotal: 1000 kB\nMemFree: 999 kB\nMemAvailable: 250 kB\n',
+        disk_usage_reader=lambda: SimpleNamespace(total=2000, used=500, free=1500),
+        uptime_reader=lambda: '93780.42 111.00\n',
+        now=lambda: datetime(2026, 4, 27, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    _override_system_service(service)
+
+    response = TestClient(app).get('/api/v1/system/metrics')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'system.metrics'
+    assert payload['status'] == 'ready'
+    assert payload['meta'] == {
+        'read_only': True,
+        'sanitized': True,
+        'source': 'os-allowlisted-system-metrics',
+        'disk_target': 'fastapi-visible-root-filesystem',
+    }
+    assert payload['data'] == {
+        'ram': {
+            'used_bytes': 768000,
+            'total_bytes': 1024000,
+            'used_percent': 75.0,
+            'source_state': 'live',
+        },
+        'disk': {
+            'used_bytes': 500,
+            'total_bytes': 2000,
+            'used_percent': 25.0,
+            'source_state': 'live',
+        },
+        'uptime': {
+            'days': 1,
+            'hours': 2,
+            'minutes': 3,
+            'source_state': 'live',
+        },
+        'updated_at': '2026-04-27T12:00:00Z',
+        'source_state': 'live',
+    }
+    _assert_no_system_metrics_leakage(payload)
+
+
+def test_system_metrics_degrades_each_source_without_raw_errors_or_host_paths() -> None:
+    def disk_failure():
+        raise OSError('/srv/private/disk failed with token=abc and stdout=raw')
+
+    service = SystemMetricsService(
+        meminfo_reader=lambda: 'MemTotal: not-a-number kB\nMemAvailable: 1 kB\n',
+        disk_usage_reader=disk_failure,
+        uptime_reader=lambda: 'uptime output from /proc/uptime is malformed',
+        now=lambda: datetime(2026, 4, 27, 12, 5, 0, tzinfo=timezone.utc),
+    )
+    _override_system_service(service)
+
+    response = TestClient(app).get('/api/v1/system/metrics')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'system.metrics'
+    assert payload['status'] == 'source_unavailable'
+    assert payload['data']['source_state'] == 'degraded'
+    assert payload['data']['ram'] == {
+        'used_bytes': None,
+        'total_bytes': None,
+        'used_percent': None,
+        'source_state': 'unknown',
+    }
+    assert payload['data']['disk'] == {
+        'used_bytes': None,
+        'total_bytes': None,
+        'used_percent': None,
+        'source_state': 'unknown',
+    }
+    assert payload['data']['uptime'] == {
+        'days': None,
+        'hours': None,
+        'minutes': None,
+        'source_state': 'unknown',
+    }
+    assert payload['data']['updated_at'] == '2026-04-27T12:05:00Z'
+    _assert_no_system_metrics_leakage(payload)
+    assert '/srv/private' not in response.text
+    assert 'token=abc' not in response.text
+    assert 'stdout=raw' not in response.text
+    assert 'uptime output' not in response.text
+
+
+def test_system_metrics_does_not_accept_or_echo_client_controlled_targets() -> None:
+    service = SystemMetricsService(
+        meminfo_reader=lambda: 'MemTotal: 1000 kB\nMemAvailable: 500 kB\n',
+        disk_usage_reader=lambda: SimpleNamespace(total=100, used=10, free=90),
+        uptime_reader=lambda: '60.00 0.00\n',
+        now=lambda: datetime(2026, 4, 27, 12, 10, 0, tzinfo=timezone.utc),
+    )
+    _override_system_service(service)
+
+    response = TestClient(app).get(
+        '/api/v1/system/metrics?path=/srv/private&mount=/secret&device=/dev/sda&command=df+-h&url=https://token.example'
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'system.metrics'
+    assert payload['status'] == 'ready'
+    assert payload['data']['disk']['used_bytes'] == 10
+    assert '/srv/private' not in response.text
+    assert '/secret' not in response.text
+    assert '/dev/sda' not in response.text
+    assert 'df' not in response.text.lower()
+    assert 'token.example' not in response.text
+    _assert_no_system_metrics_leakage(payload)

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -85,8 +85,15 @@
 - la UI `/usage` consume la actividad Hermes agregada en 17.4d como correlación orientativa y no como causalidad exacta por perfil
 
 ### `system`
-- estado general del servidor y señales operativas de alto nivel
-- evitar convertirlo en consola de administración
+- exponer `GET /api/v1/system/metrics` como read model backend-only para métricas de sistema usadas por el header global futuro
+- serializar solo RAM usada/total/porcentaje, disco usado/total/porcentaje, uptime en días/horas/minutos, `updated_at` y estado de fuente saneado
+- calcular RAM usada como `MemTotal - MemAvailable` cuando se usa `/proc/meminfo`, para no inflar uso por cache/buffers
+- medir disco contra el target backend-owned `/`, documentado públicamente como `fastapi-visible-root-filesystem`; no serializar path crudo, mount table ni device names
+- leer uptime desde fuente OS allowlisted y devolver solo días/horas/minutos, sin raw `/proc` ni salida de comandos
+- degradar por familia (`ram`, `disk`, `uptime`) a `unknown` cuando una fuente falte o venga malformada; no filtrar excepciones, paths, logs, stdout/stderr ni detalles host
+- no aceptar input cliente para elegir `path`, `mount`, `device`, `command`, `url`, `method`, `host` o `target`
+- no usar shell, `subprocess`, comandos `free`/`df`/`uptime`, Docker, systemd, discovery de filesystem ni consola host genérica
+- bloquear la frontera backend con `npm run verify:system-metrics-backend-policy`
 
 ## Capas por módulo
 Cada módulo debe poder crecer con estas capas:

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -150,6 +150,22 @@ Uso:
 - no seleccionar ni devolver `user_id`, `model_config`, `system_prompt`, `title`, tokens, costes, billing URLs, contenidos, conversaciones, prompts, payloads de herramientas, chat IDs, targets, secretos, cabeceras, cookies ni logs
 - degradar raíz no configurada, perfiles ausentes o DB ilegible a `not_configured` sin ruta interna
 
+### `system.metrics`
+Campos esperados:
+- `ram.used_bytes`, `ram.total_bytes`, `ram.used_percent`, `ram.source_state`
+- `disk.used_bytes`, `disk.total_bytes`, `disk.used_percent`, `disk.source_state`
+- `uptime.days`, `uptime.hours`, `uptime.minutes`, `uptime.source_state`
+- `updated_at`
+- `source_state` global (`live` o `degraded`)
+
+Uso:
+- alimentar el header global siempre visible en una fase frontend posterior
+- mantener el backend como única frontera de lectura host-adjacent para RAM/disco/uptime
+- calcular RAM usada como `MemTotal - MemAvailable` cuando se usa `/proc/meminfo`
+- representar el disco como target backend-owned `fastapi-visible-root-filesystem`, sin serializar path crudo, mount table ni device names
+- degradar cada familia a `unknown` si la fuente falla o viene malformada, sin exponer excepción, raw `/proc`, paths, stdout/stderr, logs, hostname, usuarios ni procesos
+- no aceptar input cliente para elegir paths, mounts, devices, commands, URLs, methods, hosts o targets
+
 ### `memory.agent_summary`
 Campos esperados:
 - `mugiwara_slug`

--- a/docs/security-perimeter.md
+++ b/docs/security-perimeter.md
@@ -90,7 +90,8 @@ Forbidden in errors/logs:
 - skill contents;
 - diff previews;
 - `expected_sha256` or hashes;
-- raw host command output, stdout/stderr, Docker/systemd/log excerpts.
+- raw host command output, stdout/stderr, Docker/systemd/log excerpts;
+- system metrics internals such as raw `/proc` content, mount table, device names, hostname, process list, users or disk target paths.
 
 ## Relationship with #16
 Phase 13.5 closed the perimeter hardening block, so issue #16 started next as a separate Healthcheck/Dashboard hardening track.

--- a/openspec/issue-36-1-system-metrics-backend-verify-checklist.md
+++ b/openspec/issue-36-1-system-metrics-backend-verify-checklist.md
@@ -1,0 +1,75 @@
+# Issue #36.1 — Backend system metrics verify checklist
+
+## Preflight
+- [x] `git status --short --branch` en repo.
+- [x] `git fetch origin --prune`.
+- [x] `git switch main`.
+- [x] `git pull --ff-only origin main`.
+- [x] `gh issue view 36` confirma #36 abierto.
+- [x] `gh pr list --state open` confirma sin PRs abiertas.
+- [x] `gh issue list --state open` confirma solo #36 y #40.
+- [x] Identidad Git local configurada como Zoro.
+- [x] Rama creada: `zoro/issue-36-1-system-metrics-backend`.
+
+## Contexto
+- [x] Engram: observación `Issue 36 header metrics planning strategy` consultada.
+- [x] Plan 36.0 leído: `openspec/issue-36-header-system-metrics-plan.md`.
+- [x] Patrones backend revisados: `usage`, `healthcheck`, `main.py`, `shared.contracts` y tests existentes.
+- [x] Docs vivas revisadas: `docs/api-modules.md`, `docs/read-models.md`, `docs/security-perimeter.md`.
+
+## TDD
+- [x] Test rojo escrito antes de implementación: `apps/api/tests/test_system_metrics_api.py`.
+  - Resultado inicial: falla con `ModuleNotFoundError: No module named 'apps.api.src.modules.system'`.
+- [x] Implementación mínima hasta verde:
+  - `apps/api/src/modules/system/service.py`.
+  - `apps/api/src/modules/system/router.py`.
+  - `apps/api/src/modules/system/__init__.py`.
+  - `apps/api/src/modules/system/AGENTS.md`.
+  - Registro en `apps/api/src/main.py`.
+- [x] Tests verdes: `PYTHONPATH=. pytest apps/api/tests/test_system_metrics_api.py -q`.
+
+## Contrato
+- [x] Endpoint fijo `GET /api/v1/system/metrics`.
+- [x] Resource envelope `resource='system.metrics'`.
+- [x] Meta `read_only`, `sanitized`, `source='os-allowlisted-system-metrics'`.
+- [x] Disk target público saneado `fastapi-visible-root-filesystem`, sin path crudo.
+- [x] RAM: `MemTotal - MemAvailable`.
+- [x] Disco: target backend-owned `/` vía `shutil.disk_usage('/')`.
+- [x] Uptime: parseo estrecho de `/proc/uptime` a días/horas/minutos.
+- [x] Degradación por familia a `source_state='unknown'` y valores `null`.
+- [x] Sin input cliente para seleccionar fuentes.
+- [x] Sin raw errors/paths/logs/stdout/stderr/host internals en respuesta.
+
+## Guardrails/docs
+- [x] Guardrail creado: `scripts/check-system-metrics-backend-policy.mjs`.
+- [x] Script npm añadido: `verify:system-metrics-backend-policy`.
+- [x] Contratos TypeScript actualizados en `packages/contracts/src/read-models.ts`.
+- [x] Docs actualizadas:
+  - `docs/api-modules.md`.
+  - `docs/read-models.md`.
+  - `docs/security-perimeter.md`.
+- [x] OpenSpec 36.1 creado.
+- [x] Closeout `.engram` creado.
+
+## Verify final
+- [x] `python3 -m py_compile apps/api/src/modules/system/*.py apps/api/tests/test_system_metrics_api.py`.
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_system_metrics_api.py -q`.
+  - Resultado: 3 passed.
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_perimeter_api.py apps/api/tests/test_healthcheck_dashboard_api.py -q`.
+  - Resultado: 50 passed.
+- [x] `npm run verify:system-metrics-backend-policy`.
+- [x] `npm run verify:perimeter-policy`.
+- [x] `npm run verify:healthcheck-source-policy`.
+- [x] `npm --prefix apps/web run typecheck`.
+- [x] `git diff --check`.
+- [x] `git status --short --branch` revisado.
+
+## Review/PR
+- [ ] Commit con trailers Mugiwara.
+- [ ] Rama pusheada.
+- [ ] PR abierta.
+- [ ] Comentario de handoff en PR.
+- [ ] Franky invocado y respuesta registrada.
+- [ ] Chopper invocado y respuesta registrada.
+- [ ] No cerrar #36 todavía.
+- [ ] No tocar #40.

--- a/openspec/issue-36-1-system-metrics-backend-verify-checklist.md
+++ b/openspec/issue-36-1-system-metrics-backend-verify-checklist.md
@@ -65,11 +65,20 @@
 - [x] `git status --short --branch` revisado.
 
 ## Review/PR
-- [ ] Commit con trailers Mugiwara.
-- [ ] Rama pusheada.
-- [ ] PR abierta.
-- [ ] Comentario de handoff en PR.
-- [ ] Franky invocado y respuesta registrada.
-- [ ] Chopper invocado y respuesta registrada.
-- [ ] No cerrar #36 todavía.
-- [ ] No tocar #40.
+- [x] Commit con trailers Mugiwara.
+  - Commit: `5d31598` (`feat: add system metrics backend read model`).
+- [x] Rama pusheada.
+- [x] PR abierta.
+  - PR: https://github.com/asistentes-mugiwara/mugiwara-control-panel/pull/85.
+- [x] Comentario de handoff en PR.
+  - Comentario: https://github.com/asistentes-mugiwara/mugiwara-control-panel/pull/85#issuecomment-4327111361.
+- [x] Franky invocado y respuesta registrada.
+  - Decisión: `approve` por comentario; aprobación formal bloqueada por cuenta compartida/autora.
+  - Comentario: https://github.com/asistentes-mugiwara/mugiwara-control-panel/pull/85#issuecomment-4327129685.
+  - Follow-ups: en 36.2 definir polling/TTL si se añade refresh; si FastAPI acaba en contenedor, documentar que disco representa la raíz visible por runtime.
+- [x] Chopper invocado y respuesta registrada.
+  - Decisión: `approve` por comentario; aprobación formal bloqueada por cuenta compartida/autora.
+  - Comentario: https://github.com/asistentes-mugiwara/mugiwara-control-panel/pull/85#issuecomment-4327151013.
+  - Follow-up: endpoint aceptable solo dentro del perímetro privado; si se expone fuera de LAN/Tailscale/private proxy, requiere auth/sesión/rate-limit.
+- [x] No cerrar #36 todavía.
+- [x] No tocar #40.

--- a/openspec/issue-36-1-system-metrics-backend.md
+++ b/openspec/issue-36-1-system-metrics-backend.md
@@ -1,0 +1,92 @@
+# Issue #36.1 — Backend system metrics read model/API
+
+## Estado
+- **Fase:** 36.1 — Backend read model/API foundation.
+- **Rama:** `zoro/issue-36-1-system-metrics-backend`.
+- **Issue:** [#36 Always-visible header system metrics](https://github.com/asistentes-mugiwara/mugiwara-control-panel/issues/36).
+- **Alcance:** backend/API/contracts/docs/guardrail. Sin UI, sin adapter frontend, sin polling, sin cierre de #36.
+
+## Objetivo
+Crear la primera frontera backend read-only para métricas de sistema que luego consumirá el header global:
+
+```text
+GET /api/v1/system/metrics
+```
+
+## Contrato implementado
+Envelope:
+
+```json
+{
+  "resource": "system.metrics",
+  "status": "ready | source_unavailable",
+  "data": {
+    "ram": { "used_bytes": 1, "total_bytes": 2, "used_percent": 50.0, "source_state": "live" },
+    "disk": { "used_bytes": 1, "total_bytes": 2, "used_percent": 50.0, "source_state": "live" },
+    "uptime": { "days": 0, "hours": 1, "minutes": 2, "source_state": "live" },
+    "updated_at": "2026-04-27T12:00:00Z",
+    "source_state": "live | degraded"
+  },
+  "meta": {
+    "read_only": true,
+    "sanitized": true,
+    "source": "os-allowlisted-system-metrics",
+    "disk_target": "fastapi-visible-root-filesystem"
+  }
+}
+```
+
+## Decisiones
+- Módulo nuevo: `apps/api/src/modules/system`.
+- Endpoint fijo: `GET /api/v1/system/metrics`.
+- RAM: parseo estrecho de `/proc/meminfo`; usado = `MemTotal - MemAvailable`, no `MemTotal - MemFree`.
+- Disco: `shutil.disk_usage('/')`; el path real no se serializa y se documenta como `fastapi-visible-root-filesystem`.
+- Uptime: parseo estrecho de `/proc/uptime`; salida solo días/horas/minutos.
+- Degradación: cada familia (`ram`, `disk`, `uptime`) puede caer a `source_state: unknown` con valores `null`; el envelope pasa a `source_unavailable` y `data.source_state: degraded`.
+- Errores: no se devuelven mensajes raw ni excepciones.
+- Sin input cliente: querystrings tipo `path`, `mount`, `device`, `command`, `url`, `method`, `host`, `target` no controlan fuentes ni se ecoan.
+
+## Fuera de alcance
+- UI/header visible.
+- Adapter frontend server-only.
+- Polling, refresh automático, caché/TTL.
+- Guardrail frontend/bundle.
+- Cierre de issue #36.
+- Issue #40.
+
+## Seguridad y no-leakage
+El endpoint no debe exponer:
+- paths crudos (`/srv`, `/home`, `/proc`, disco target real);
+- mount table;
+- device names;
+- hostname;
+- process list;
+- users;
+- raw `/proc`;
+- stdout/stderr/raw output;
+- logs, tracebacks o excepciones;
+- tokens, `.env`, credenciales.
+
+El guardrail `npm run verify:system-metrics-backend-policy` fija la frontera backend:
+- endpoint y router registrados;
+- fuente RAM/disco/uptime allowlisted;
+- no shell/subprocess/comandos host;
+- tests de no-leakage y querystring cliente;
+- docs vivas actualizadas.
+
+## Review esperado
+- **Franky:** semántica operativa RAM/disco/uptime, target disco, degradación y coste.
+- **Chopper:** host boundary, no-leakage, ausencia de consola host y saneado de errores.
+
+Usopp queda fuera de 36.1 porque no hay UI.
+
+## Verify esperado
+- Red inicial: `PYTHONPATH=. pytest apps/api/tests/test_system_metrics_api.py -q` falla por módulo inexistente.
+- Green: `PYTHONPATH=. pytest apps/api/tests/test_system_metrics_api.py -q`.
+- `python3 -m py_compile apps/api/src/modules/system/*.py apps/api/tests/test_system_metrics_api.py`.
+- `PYTHONPATH=. pytest apps/api/tests/test_perimeter_api.py apps/api/tests/test_healthcheck_dashboard_api.py -q`.
+- `npm run verify:system-metrics-backend-policy`.
+- `npm run verify:perimeter-policy`.
+- `npm run verify:healthcheck-source-policy`.
+- `npm --prefix apps/web run typecheck` si se toca `packages/contracts`.
+- `git diff --check`.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "audit:web": "cd apps/web && npm audit",
     "verify:backup-health-status-producer": "node scripts/check-backup-health-status-producer.mjs",
     "verify:backup-health-status-runner": "node scripts/check-backup-health-status-runner.mjs",
-    "write:backup-health-status": "python3 scripts/write-backup-health-status.py"
+    "write:backup-health-status": "python3 scripts/write-backup-health-status.py",
+    "verify:system-metrics-backend-policy": "node scripts/check-system-metrics-backend-policy.mjs"
   },
   "overrides": {
     "postcss": "8.5.10"

--- a/packages/contracts/src/read-models.ts
+++ b/packages/contracts/src/read-models.ts
@@ -166,6 +166,31 @@ export type SystemSignal = {
   freshness: Freshness
 }
 
+export type SystemMetricSourceState = 'live' | 'unknown'
+export type SystemMetricsState = 'live' | 'degraded'
+
+export type SystemCapacityMetric = {
+  used_bytes: number | null
+  total_bytes: number | null
+  used_percent: number | null
+  source_state: SystemMetricSourceState
+}
+
+export type SystemUptimeMetric = {
+  days: number | null
+  hours: number | null
+  minutes: number | null
+  source_state: SystemMetricSourceState
+}
+
+export type SystemMetrics = {
+  ram: SystemCapacityMetric
+  disk: SystemCapacityMetric
+  uptime: SystemUptimeMetric
+  updated_at: string
+  source_state: SystemMetricsState
+}
+
 export type UsageFreshness = {
   state: 'fresh' | 'stale' | 'unknown'
   age_minutes: number | null
@@ -302,4 +327,5 @@ export type UsageCurrentResponse = ResourceEnvelope<UsageCurrent, { read_only: t
 export type UsageCalendarResponse = ResourceEnvelope<UsageCalendar, { read_only: true; sanitized: true; source: string; range: UsageCalendarRange; timezone: 'Europe/Madrid' }>
 export type UsageFiveHourWindowsResponse = ResourceEnvelope<UsageFiveHourWindows, { read_only: true; sanitized: true; source: string; limit: number }>
 export type UsageHermesActivityResponse = ResourceEnvelope<UsageHermesActivity, { read_only: true; sanitized: true; source: string; range: UsageActivityRange }>
+export type SystemMetricsResponse = ResourceEnvelope<SystemMetrics, { read_only: true; sanitized: true; source: string; disk_target: 'fastapi-visible-root-filesystem' }>
 export type SystemSignalsResponse = ResourceEnvelope<{ items: SystemSignal[] }, { count: number }>

--- a/scripts/check-system-metrics-backend-policy.mjs
+++ b/scripts/check-system-metrics-backend-policy.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * Static guardrail for Issue #36.1 system metrics backend policy.
+ *
+ * Keeps system metrics as a fixed read-only backend endpoint, not a host console.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = process.cwd()
+const paths = {
+  packageJson: join(repoRoot, 'package.json'),
+  systemModule: join(repoRoot, 'apps/api/src/modules/system'),
+  mainPy: join(repoRoot, 'apps/api/src/main.py'),
+  systemTests: join(repoRoot, 'apps/api/tests/test_system_metrics_api.py'),
+  apiModulesDoc: join(repoRoot, 'docs/api-modules.md'),
+  readModelsDoc: join(repoRoot, 'docs/read-models.md'),
+}
+
+const failures = []
+
+function read(pathName, label) {
+  if (!existsSync(pathName)) {
+    failures.push(`missing ${label} at ${pathName}`)
+    return ''
+  }
+  return readFileSync(pathName, 'utf8')
+}
+
+function listPythonFiles(dir) {
+  if (!existsSync(dir)) {
+    failures.push(`missing system metrics module directory at ${dir}`)
+    return []
+  }
+  const files = []
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry)
+    const stat = statSync(fullPath)
+    if (stat.isDirectory()) {
+      if (entry !== '__pycache__') files.push(...listPythonFiles(fullPath))
+    } else if (entry.endsWith('.py')) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+function mustInclude(text, snippet, label) {
+  if (!text.includes(snippet)) failures.push(`${label} must include: ${snippet}`)
+}
+
+const packageJsonText = read(paths.packageJson, 'package.json')
+const mainPy = read(paths.mainPy, 'FastAPI main')
+const servicePy = read(join(paths.systemModule, 'service.py'), 'system metrics service')
+const routerPy = read(join(paths.systemModule, 'router.py'), 'system metrics router')
+const testsPy = read(paths.systemTests, 'system metrics tests')
+const apiModulesDoc = read(paths.apiModulesDoc, 'API modules doc')
+const readModelsDoc = read(paths.readModelsDoc, 'read models doc')
+
+let packageJson
+try {
+  packageJson = JSON.parse(packageJsonText)
+} catch {
+  failures.push('package.json must be valid JSON')
+}
+
+if (packageJson?.scripts?.['verify:system-metrics-backend-policy'] !== 'node scripts/check-system-metrics-backend-policy.mjs') {
+  failures.push('package.json must expose verify:system-metrics-backend-policy')
+}
+
+mustInclude(mainPy, 'from .modules.system.router import router as system_router', 'FastAPI main')
+mustInclude(mainPy, 'app.include_router(system_router)', 'FastAPI main')
+mustInclude(routerPy, "router = APIRouter(prefix='/api/v1/system', tags=['system'])", 'system metrics router')
+mustInclude(routerPy, "@router.get('/metrics')", 'system metrics router')
+mustInclude(routerPy, "resource='system.metrics'", 'system metrics router')
+mustInclude(routerPy, "'read_only': True", 'system metrics router')
+mustInclude(routerPy, "'sanitized': True", 'system metrics router')
+mustInclude(routerPy, "'disk_target': SYSTEM_METRICS_DISK_TARGET_LABEL", 'system metrics router')
+
+const requiredServiceSnippets = [
+  "SYSTEM_METRICS_DISK_TARGET = '/'",
+  "SYSTEM_METRICS_DISK_TARGET_LABEL = 'fastapi-visible-root-filesystem'",
+  "Path('/proc/meminfo').read_text(encoding='utf-8')",
+  "Path('/proc/uptime').read_text(encoding='utf-8')",
+  'shutil.disk_usage(SYSTEM_METRICS_DISK_TARGET)',
+  "values_kb['MemTotal']",
+  "values_kb['MemAvailable']",
+  "source_state = 'live' if all(metric.source_state == 'live'",
+]
+for (const snippet of requiredServiceSnippets) mustInclude(servicePy, snippet, 'system metrics service')
+
+const forbiddenSourcePatterns = [
+  { pattern: /\bimport\s+subprocess\b/, label: 'import subprocess' },
+  { pattern: /\bfrom\s+subprocess\s+import\b/, label: 'from subprocess import' },
+  { pattern: /\bsubprocess\s*\./, label: 'subprocess usage' },
+  { pattern: /\bos\.system\s*\(/, label: 'os.system' },
+  { pattern: /\bshell\s*=\s*True\b/, label: 'shell=True' },
+  { pattern: /\bexec\s*\(/, label: 'exec()' },
+  { pattern: /\beval\s*\(/, label: 'eval()' },
+  { pattern: /\b(command|path|mount|device|url|method|host|target)\s*:\s*str/, label: 'client-controlled host selector parameter' },
+  { pattern: /\b(os\.listdir|os\.scandir|os\.walk|glob\.glob|Path\.home|Path\.cwd|\.rglob)\s*\(/, label: 'filesystem discovery' },
+  { pattern: /\b(requests|httpx|urllib\.request)\b/, label: 'generic network fetch' },
+]
+
+for (const filePath of listPythonFiles(paths.systemModule)) {
+  const text = readFileSync(filePath, 'utf8')
+  for (const { pattern, label } of forbiddenSourcePatterns) {
+    if (pattern.test(text)) failures.push(`system metrics backend must not contain ${label}: ${filePath}`)
+  }
+}
+
+const requiredTestSnippets = [
+  'test_system_metrics_returns_sanitized_allowlisted_snapshot',
+  'MemTotal: 1000 kB',
+  'MemAvailable: 250 kB',
+  'test_system_metrics_degrades_each_source_without_raw_errors_or_host_paths',
+  'test_system_metrics_does_not_accept_or_echo_client_controlled_targets',
+  '_assert_no_system_metrics_leakage',
+]
+for (const snippet of requiredTestSnippets) mustInclude(testsPy, snippet, 'system metrics tests')
+
+mustInclude(apiModulesDoc, 'GET /api/v1/system/metrics', 'API modules doc')
+mustInclude(apiModulesDoc, 'fastapi-visible-root-filesystem', 'API modules doc')
+mustInclude(readModelsDoc, 'system.metrics', 'read models doc')
+mustInclude(readModelsDoc, 'MemTotal - MemAvailable', 'read models doc')
+
+if (failures.length > 0) {
+  console.error('System metrics backend policy check failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log('System metrics backend policy check passed.')


### PR DESCRIPTION
## Resumen

Implementa 36.1 backend-only para #36: read model/API de métricas de sistema, sin UI/header ni polling.

## Cambios

- Nuevo módulo backend `apps/api/src/modules/system`.
- Nuevo endpoint fijo `GET /api/v1/system/metrics`.
- Contrato compartido `SystemMetricsResponse` en `packages/contracts`.
- Tests TDD para caso normal, degradación por fuente y no-echo/no-input cliente.
- Guardrail `npm run verify:system-metrics-backend-policy`.
- Docs/OpenSpec/Engram actualizados.

## Contrato de seguridad

- Sin input cliente para seleccionar `path`, `mount`, `device`, `command`, `url`, `method`, `host` o `target`.
- Sin shell, `subprocess`, comandos `free`/`df`/`uptime`, Docker, systemd ni discovery host.
- RAM usada = `MemTotal - MemAvailable` si se usa `/proc/meminfo`.
- Disco = target backend-owned `/`, expuesto solo como `fastapi-visible-root-filesystem`.
- Uptime = días/horas/minutos, sin raw `/proc`.
- Degradación por familia `ram`/`disk`/`uptime` a `unknown`, sin raw errors.
- No serializa paths, mount table, devices, hostname, process list, users, raw `/proc`, stdout/stderr, logs, tracebacks, tokens, `.env` ni credenciales.

## TDD / Verify ejecutado

- Red inicial: `PYTHONPATH=. pytest apps/api/tests/test_system_metrics_api.py -q` falló con `ModuleNotFoundError: No module named 'apps.api.src.modules.system'`.
- `python3 -m py_compile apps/api/src/modules/system/*.py apps/api/tests/test_system_metrics_api.py`
- `PYTHONPATH=. pytest apps/api/tests/test_system_metrics_api.py -q` → 3 passed
- `PYTHONPATH=. pytest apps/api/tests/test_perimeter_api.py apps/api/tests/test_healthcheck_dashboard_api.py -q` → 50 passed
- `npm run verify:system-metrics-backend-policy`
- `npm run verify:perimeter-policy`
- `npm run verify:healthcheck-source-policy`
- `npm --prefix apps/web run typecheck`
- `git diff --check`

## Fuera de alcance

- UI/header visible.
- Frontend adapter server-only.
- Polling/cache/TTL.
- Cierre de #36.
- Issue #40.

## Review solicitada

- Franky: semántica RAM/disco/uptime, target disco, degradación, operabilidad.
- Chopper: frontera host-adjacent, no-leakage, ausencia de consola host/proxy genérico.

Usopp entra en 36.2 cuando haya UI/header responsive.