### PR TITLE
feat: show system metrics in header

### DIFF
--- a/.engram/issue-36-2-system-metrics-header-closeout.md
+++ b/.engram/issue-36-2-system-metrics-header-closeout.md
@@ -1,0 +1,16 @@
+# Issue #36.2 — frontend server-only adapter + header integration
+
+## Scope
+- Adapter frontend server-only para `GET /api/v1/system/metrics`.
+- Snapshot server-side desde root layout dinámico.
+- Header global con RAM, disco y uptime visibles en `Topbar`.
+- Responsive desktop/tablet/mobile sin fetch de navegador ni env pública.
+
+## Boundary
+- No `NEXT_PUBLIC_*`.
+- No browser fetch al backend interno.
+- No backend URL ni raw errors renderizados.
+- No polling/cache/TTL en esta fase.
+
+## Verify
+Pendiente de completar antes de PR: typecheck, build, visual baseline, backend test, smoke HTML/DOM anti-fugas y `git diff --check`.

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -460,27 +460,40 @@ button {
   }
 
   .topbar__status-group {
+    display: grid !important;
+    flex: 0 0 100%;
+    grid-template-columns: minmax(0, 1fr);
     justify-content: flex-start;
+    justify-items: start;
+    min-width: 100%;
     width: 100%;
   }
 
   .topbar__metrics-strip {
     display: grid !important;
+    flex: 0 0 100%;
     grid-template-columns: repeat(3, minmax(0, 1fr));
+    min-width: 100%;
+    order: 2;
+    overflow: visible;
     width: 100%;
+  }
+
+  .topbar__status-group > .status-badge {
+    order: 1;
   }
 
   .topbar__metric-chip {
     grid-template-columns: minmax(0, 1fr);
     gap: 2px;
     justify-items: start;
+    min-width: 0;
   }
 
   .topbar__metric-label,
   .topbar__metric-value {
     max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    overflow-wrap: anywhere;
   }
 
   .page-header__title {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -305,6 +305,47 @@ button {
   min-width: 0;
 }
 
+.topbar__status-group {
+  flex: 1;
+}
+
+.topbar__metrics-strip {
+  flex: 1 1 auto;
+  flex-wrap: nowrap;
+  overflow: hidden;
+}
+
+.topbar__metric-chip {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, auto);
+  align-items: baseline;
+  gap: 5px;
+  min-width: 0;
+  max-width: 100%;
+  white-space: nowrap;
+}
+
+.topbar__metric-label {
+  color: #9aa7bd;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.topbar__metric-value {
+  font-size: 13px;
+  line-height: 1.1;
+}
+
+.topbar__metric-detail {
+  min-width: 0;
+  overflow: hidden;
+  color: #aab4c8;
+  font-size: 11px;
+  text-overflow: ellipsis;
+}
+
 .app-shell {
   display: grid;
   grid-template-columns: 248px minmax(0, 1fr);
@@ -326,6 +367,10 @@ button {
 @media (max-width: 1180px) {
   .layout-grid--dashboard-metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .topbar__metric-detail {
+    display: none;
   }
 }
 
@@ -377,6 +422,12 @@ button {
     display: none;
   }
 
+  .topbar__metrics-strip {
+    order: 3;
+    flex-basis: 100%;
+    justify-content: flex-start !important;
+  }
+
   .app-shell__overlay {
     display: block;
     position: fixed;
@@ -411,6 +462,25 @@ button {
   .topbar__status-group {
     justify-content: flex-start;
     width: 100%;
+  }
+
+  .topbar__metrics-strip {
+    display: grid !important;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .topbar__metric-chip {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 2px;
+    justify-items: start;
+  }
+
+  .topbar__metric-label,
+  .topbar__metric-value {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .page-header__title {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,23 +1,42 @@
 import type { Metadata } from 'next'
 
+import { fetchSystemMetrics, SystemMetricsApiError } from '@/modules/system/api/system-metrics-http'
+import { createHeaderSystemMetricsSnapshot, createUnavailableHeaderSystemMetrics } from '@/modules/system/view-models/system-metrics-summary'
 import { AppShell } from '@/shared/ui/app-shell/AppShell'
 
 import './globals.css'
+
+export const dynamic = 'force-dynamic'
 
 export const metadata: Metadata = {
   title: 'Mugiwara Control Panel',
   description: 'Private Mugiwara/Hermes control plane',
 }
 
-export default function RootLayout({
+async function loadHeaderSystemMetrics() {
+  try {
+    const response = await fetchSystemMetrics()
+    return createHeaderSystemMetricsSnapshot(response.data)
+  } catch (error) {
+    if (error instanceof SystemMetricsApiError && error.code === 'not_configured') {
+      return createUnavailableHeaderSystemMetrics('not_configured')
+    }
+
+    return createUnavailableHeaderSystemMetrics('unavailable')
+  }
+}
+
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const headerSystemMetrics = await loadHeaderSystemMetrics()
+
   return (
     <html lang="es">
       <body>
-        <AppShell>{children}</AppShell>
+        <AppShell systemMetrics={headerSystemMetrics}>{children}</AppShell>
       </body>
     </html>
   )

--- a/apps/web/src/modules/AGENTS.md
+++ b/apps/web/src/modules/AGENTS.md
@@ -8,4 +8,5 @@ Features y módulos funcionales del frontend (dashboard, mugiwaras, skills, memo
 - Evitar dependencias cruzadas desordenadas.
 - **Vigilar `.gitignore`** y no subir mocks, capturas o outputs sensibles no saneados.
 - `usage`: Usage/Codex quota read-only frontend consuming server-only current snapshot, calendar, dedicated five-hour windows and aggregated Hermes activity adapters; no client-side backend URL or Hermes profiles root exposure.
+- `system`: adapter frontend server-only para `GET /api/v1/system/metrics` y view-model del header global; sin fetch de navegador, sin `NEXT_PUBLIC_*`, sin URL backend ni errores crudos en cliente.
 - Si nace un módulo nuevo, documentarlo aquí y en docs.

--- a/apps/web/src/modules/system/AGENTS.md
+++ b/apps/web/src/modules/system/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md — apps/web/src/modules/system
+
+## Rol
+Módulo frontend read-only para métricas globales de sistema consumidas por el header del shell.
+
+## Reglas
+- El adapter HTTP debe ser `server-only` y usar únicamente `MUGIWARA_CONTROL_PANEL_API_URL` en servidor.
+- No introducir `NEXT_PUBLIC_*`, fetch desde navegador al backend interno ni route/proxy genérico.
+- No renderizar URL backend, paths host, stack traces, errores crudos, stdout/stderr, logs ni detalles de configuración.
+- El header recibe solo snapshot serializable saneado y degrada a valores `—` si la fuente falta o falla.
+- Si se añade polling, cache/TTL o refresh cliente, abrir microfase propia y pedir review Franky + Chopper.

--- a/apps/web/src/modules/system/api/system-metrics-http.ts
+++ b/apps/web/src/modules/system/api/system-metrics-http.ts
@@ -1,0 +1,133 @@
+import 'server-only'
+
+import type { SystemMetrics, SystemMetricsResponse } from '@contracts/read-models'
+
+export const SYSTEM_METRICS_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'
+
+type SystemMetricsApiErrorCode = 'not_configured' | 'invalid_config' | `http_${number}` | 'invalid_payload' | 'fetch_failed'
+
+export class SystemMetricsApiError extends Error {
+  constructor(readonly code: SystemMetricsApiErrorCode) {
+    super(code)
+    this.name = 'SystemMetricsApiError'
+  }
+}
+
+function trimTrailingSlash(value: string) {
+  return value.replace(/\/$/, '')
+}
+
+function parseSystemMetricsApiBaseUrl(value: string) {
+  let parsed: URL
+
+  try {
+    parsed = new URL(value)
+  } catch {
+    throw new SystemMetricsApiError('invalid_config')
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new SystemMetricsApiError('invalid_config')
+  }
+
+  return trimTrailingSlash(value)
+}
+
+export function getSystemMetricsApiBaseUrl() {
+  const value = process.env[SYSTEM_METRICS_API_BASE_URL_ENV]
+  return value ? parseSystemMetricsApiBaseUrl(value) : null
+}
+
+function isSystemMetricSourceState(value: unknown): value is SystemMetrics['ram']['source_state'] {
+  return value === 'live' || value === 'unknown'
+}
+
+function isSystemMetricsState(value: unknown): value is SystemMetrics['source_state'] {
+  return value === 'live' || value === 'degraded'
+}
+
+function isNullableFiniteNumber(value: unknown): value is number | null {
+  return value === null || (typeof value === 'number' && Number.isFinite(value))
+}
+
+function isCapacityMetric(value: unknown): value is SystemMetrics['ram'] {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const candidate = value as SystemMetrics['ram']
+  return (
+    isNullableFiniteNumber(candidate.used_bytes) &&
+    isNullableFiniteNumber(candidate.total_bytes) &&
+    isNullableFiniteNumber(candidate.used_percent) &&
+    isSystemMetricSourceState(candidate.source_state)
+  )
+}
+
+function isUptimeMetric(value: unknown): value is SystemMetrics['uptime'] {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const candidate = value as SystemMetrics['uptime']
+  return (
+    isNullableFiniteNumber(candidate.days) &&
+    isNullableFiniteNumber(candidate.hours) &&
+    isNullableFiniteNumber(candidate.minutes) &&
+    isSystemMetricSourceState(candidate.source_state)
+  )
+}
+
+function isSystemMetrics(value: unknown): value is SystemMetrics {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const candidate = value as SystemMetrics
+  return (
+    isCapacityMetric(candidate.ram) &&
+    isCapacityMetric(candidate.disk) &&
+    isUptimeMetric(candidate.uptime) &&
+    typeof candidate.updated_at === 'string' &&
+    isSystemMetricsState(candidate.source_state)
+  )
+}
+
+function parseSystemMetricsResponse(payload: unknown): SystemMetricsResponse {
+  if (!payload || typeof payload !== 'object') {
+    throw new SystemMetricsApiError('invalid_payload')
+  }
+
+  const candidate = payload as SystemMetricsResponse
+  if (!isSystemMetrics(candidate.data)) {
+    throw new SystemMetricsApiError('invalid_payload')
+  }
+
+  return candidate
+}
+
+export async function fetchSystemMetrics(): Promise<SystemMetricsResponse> {
+  const baseUrl = getSystemMetricsApiBaseUrl()
+
+  if (!baseUrl) {
+    throw new SystemMetricsApiError('not_configured')
+  }
+
+  let response: Response
+  try {
+    response = await fetch(`${baseUrl}/api/v1/system/metrics`, {
+      cache: 'no-store',
+      headers: {
+        Accept: 'application/json',
+      },
+    })
+  } catch {
+    throw new SystemMetricsApiError('fetch_failed')
+  }
+
+  if (!response.ok) {
+    throw new SystemMetricsApiError(`http_${response.status}`)
+  }
+
+  return parseSystemMetricsResponse(await response.json())
+}

--- a/apps/web/src/modules/system/view-models/system-metrics-summary.ts
+++ b/apps/web/src/modules/system/view-models/system-metrics-summary.ts
@@ -1,0 +1,35 @@
+import type { SystemMetrics } from '@contracts/read-models'
+
+import type { HeaderSystemMetrics, HeaderSystemMetricsSourceState } from '@/shared/ui/app-shell/system-metrics'
+
+const UNKNOWN_CAPACITY_METRIC: SystemMetrics['ram'] = {
+  used_bytes: null,
+  total_bytes: null,
+  used_percent: null,
+  source_state: 'unknown',
+}
+
+const UNKNOWN_UPTIME_METRIC: SystemMetrics['uptime'] = {
+  days: null,
+  hours: null,
+  minutes: null,
+  source_state: 'unknown',
+}
+
+export function createUnavailableHeaderSystemMetrics(sourceState: HeaderSystemMetricsSourceState): HeaderSystemMetrics {
+  return {
+    ram: UNKNOWN_CAPACITY_METRIC,
+    disk: UNKNOWN_CAPACITY_METRIC,
+    uptime: UNKNOWN_UPTIME_METRIC,
+    sourceState,
+  }
+}
+
+export function createHeaderSystemMetricsSnapshot(metrics: SystemMetrics): HeaderSystemMetrics {
+  return {
+    ram: metrics.ram,
+    disk: metrics.disk,
+    uptime: metrics.uptime,
+    sourceState: metrics.source_state === 'live' ? 'live' : 'degraded',
+  }
+}

--- a/apps/web/src/shared/ui/app-shell/AppShell.tsx
+++ b/apps/web/src/shared/ui/app-shell/AppShell.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useId, useRef, useState, type ReactNode } from 'react'
 
+import type { HeaderSystemMetrics } from './system-metrics'
 import { appTheme } from '@/shared/theme/tokens'
 import { SidebarNav } from '@/shared/ui/navigation/SidebarNav'
 
@@ -9,9 +10,10 @@ import { Topbar } from './Topbar'
 
 type AppShellProps = {
   children: ReactNode
+  systemMetrics: HeaderSystemMetrics
 }
 
-export function AppShell({ children }: AppShellProps) {
+export function AppShell({ children, systemMetrics }: AppShellProps) {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false)
   const [isDesktop, setIsDesktop] = useState(true)
   const navId = useId()
@@ -82,6 +84,7 @@ export function AppShell({ children }: AppShellProps) {
           menuButtonRef={menuButtonRef}
           navId={navId}
           isMobileNavOpen={isMobileNavOpen}
+          systemMetrics={systemMetrics}
           onToggleNavigation={() => setIsMobileNavOpen((current) => !current)}
         />
 

--- a/apps/web/src/shared/ui/app-shell/Topbar.tsx
+++ b/apps/web/src/shared/ui/app-shell/Topbar.tsx
@@ -54,8 +54,8 @@ function formatUptimeValue(metric: UptimeMetric) {
   return `${metric.days}d ${metric.hours}h ${metric.minutes}m`
 }
 
-function metricTitle(label: string, state: CapacityMetric['source_state'] | UptimeMetric['source_state']) {
-  return state === 'live' ? label : `${label} no disponible`
+function metricLabel(label: string) {
+  return label
 }
 
 function SystemMetricChip({ label, value, detail, muted }: { label: string; value: string; detail?: string; muted?: boolean }) {
@@ -96,19 +96,19 @@ function HeaderSystemMetricsStrip({ metrics }: { metrics: HeaderSystemMetrics })
       }}
     >
       <SystemMetricChip
-        label={metricTitle('RAM', metrics.ram.source_state)}
+        label={metricLabel('RAM')}
         value={ramPercent}
         detail={formatCapacityValue(metrics.ram)}
         muted={isUnavailable || metrics.ram.source_state !== 'live'}
       />
       <SystemMetricChip
-        label={metricTitle('Disco', metrics.disk.source_state)}
+        label={metricLabel('Disco')}
         value={diskPercent}
         detail={formatCapacityValue(metrics.disk)}
         muted={isUnavailable || metrics.disk.source_state !== 'live'}
       />
       <SystemMetricChip
-        label={metricTitle('Uptime', metrics.uptime.source_state)}
+        label={metricLabel('Uptime')}
         value={formatUptimeValue(metrics.uptime)}
         muted={isUnavailable || metrics.uptime.source_state !== 'live'}
       />

--- a/apps/web/src/shared/ui/app-shell/Topbar.tsx
+++ b/apps/web/src/shared/ui/app-shell/Topbar.tsx
@@ -2,6 +2,7 @@
 
 import type { RefObject } from 'react'
 
+import type { HeaderSystemMetrics } from './system-metrics'
 import { appTheme } from '@/shared/theme/tokens'
 import { StatusBadge } from '@/shared/ui/status/StatusBadge'
 
@@ -9,10 +10,125 @@ type TopbarProps = {
   navId: string
   menuButtonRef: RefObject<HTMLButtonElement | null>
   isMobileNavOpen: boolean
+  systemMetrics: HeaderSystemMetrics
   onToggleNavigation: () => void
 }
 
-export function Topbar({ navId, menuButtonRef, isMobileNavOpen, onToggleNavigation }: TopbarProps) {
+type CapacityMetric = HeaderSystemMetrics['ram']
+type UptimeMetric = HeaderSystemMetrics['uptime']
+
+function formatBytes(value: number | null) {
+  if (value === null) {
+    return '—'
+  }
+
+  const gibibytes = value / 1024 ** 3
+  if (gibibytes >= 10) {
+    return `${Math.round(gibibytes)} GB`
+  }
+
+  return `${gibibytes.toFixed(1)} GB`
+}
+
+function formatPercent(value: number | null) {
+  if (value === null) {
+    return '—'
+  }
+
+  return `${Math.round(value)}%`
+}
+
+function formatCapacityValue(metric: CapacityMetric) {
+  if (metric.used_bytes === null || metric.total_bytes === null) {
+    return '—'
+  }
+
+  return `${formatBytes(metric.used_bytes)} / ${formatBytes(metric.total_bytes)}`
+}
+
+function formatUptimeValue(metric: UptimeMetric) {
+  if (metric.days === null || metric.hours === null || metric.minutes === null) {
+    return '—'
+  }
+
+  return `${metric.days}d ${metric.hours}h ${metric.minutes}m`
+}
+
+function metricTitle(label: string, state: CapacityMetric['source_state'] | UptimeMetric['source_state']) {
+  return state === 'live' ? label : `${label} no disponible`
+}
+
+function SystemMetricChip({ label, value, detail, muted }: { label: string; value: string; detail?: string; muted?: boolean }) {
+  return (
+    <span
+      className="topbar__metric-chip"
+      style={{
+        border: `1px solid ${muted ? 'rgba(255, 255, 255, 0.08)' : 'rgba(90, 157, 219, 0.24)'}`,
+        borderRadius: appTheme.radius.md,
+        background: muted ? 'rgba(255, 255, 255, 0.025)' : 'rgba(90, 157, 219, 0.08)',
+        color: muted ? appTheme.colors.textMuted : appTheme.colors.textPrimary,
+        padding: '7px 9px',
+      }}
+      title={detail ? `${label}: ${value} · ${detail}` : `${label}: ${value}`}
+    >
+      <span className="topbar__metric-label">{label}</span>
+      <strong className="topbar__metric-value">{value}</strong>
+      {detail ? <span className="topbar__metric-detail">{detail}</span> : null}
+    </span>
+  )
+}
+
+function HeaderSystemMetricsStrip({ metrics }: { metrics: HeaderSystemMetrics }) {
+  const isUnavailable = metrics.sourceState === 'not_configured' || metrics.sourceState === 'unavailable'
+  const ramPercent = formatPercent(metrics.ram.used_percent)
+  const diskPercent = formatPercent(metrics.disk.used_percent)
+
+  return (
+    <div
+      className="topbar__metrics-strip"
+      aria-label="Métricas resumidas del sistema"
+      style={{
+        display: 'flex',
+        alignItems: 'stretch',
+        justifyContent: 'flex-end',
+        gap: '8px',
+        minWidth: 0,
+      }}
+    >
+      <SystemMetricChip
+        label={metricTitle('RAM', metrics.ram.source_state)}
+        value={ramPercent}
+        detail={formatCapacityValue(metrics.ram)}
+        muted={isUnavailable || metrics.ram.source_state !== 'live'}
+      />
+      <SystemMetricChip
+        label={metricTitle('Disco', metrics.disk.source_state)}
+        value={diskPercent}
+        detail={formatCapacityValue(metrics.disk)}
+        muted={isUnavailable || metrics.disk.source_state !== 'live'}
+      />
+      <SystemMetricChip
+        label={metricTitle('Uptime', metrics.uptime.source_state)}
+        value={formatUptimeValue(metrics.uptime)}
+        muted={isUnavailable || metrics.uptime.source_state !== 'live'}
+      />
+    </div>
+  )
+}
+
+function statusForMetrics(sourceState: HeaderSystemMetrics['sourceState']) {
+  if (sourceState === 'live') {
+    return 'operativo'
+  }
+
+  if (sourceState === 'degraded') {
+    return 'revision'
+  }
+
+  return 'sin-datos'
+}
+
+export function Topbar({ navId, menuButtonRef, isMobileNavOpen, systemMetrics, onToggleNavigation }: TopbarProps) {
   return (
     <header
       style={{
@@ -62,7 +178,8 @@ export function Topbar({ navId, menuButtonRef, isMobileNavOpen, onToggleNavigati
           </div>
         </div>
 
-        <div className="topbar__status-group" style={{ display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
+        <div className="topbar__status-group" style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: '10px', flexWrap: 'wrap', minWidth: 0 }}>
+          <HeaderSystemMetricsStrip metrics={systemMetrics} />
           <span
             className="topbar__command-chip"
             style={{
@@ -75,7 +192,7 @@ export function Topbar({ navId, menuButtonRef, isMobileNavOpen, onToggleNavigati
           >
             ⌘K command (soon)
           </span>
-          <StatusBadge status="operativo" />
+          <StatusBadge status={statusForMetrics(systemMetrics.sourceState)} />
         </div>
       </div>
     </header>

--- a/apps/web/src/shared/ui/app-shell/system-metrics.ts
+++ b/apps/web/src/shared/ui/app-shell/system-metrics.ts
@@ -1,0 +1,10 @@
+import type { SystemMetrics } from '@contracts/read-models'
+
+export type HeaderSystemMetricsSourceState = 'live' | 'degraded' | 'not_configured' | 'unavailable'
+
+export type HeaderSystemMetrics = {
+  ram: SystemMetrics['ram']
+  disk: SystemMetrics['disk']
+  uptime: SystemMetrics['uptime']
+  sourceState: HeaderSystemMetricsSourceState
+}

--- a/docs/frontend-implementation-handoff.md
+++ b/docs/frontend-implementation-handoff.md
@@ -121,6 +121,10 @@ apps/web/src/modules/
     api/
     view-models/
     index.ts
+  system/
+    api/                  # adapter server-only para métricas globales del header
+    view-models/          # snapshot serializable para AppShell/Topbar
+    index.ts              # opcional si el módulo crece
 ```
 
 ## 3.3 Shared

--- a/docs/frontend-ui-spec.md
+++ b/docs/frontend-ui-spec.md
@@ -98,9 +98,10 @@ Diseñar un shell de navegación estable y escaneable que:
 
 ### Topbar
 - identidad del producto
+- métricas globales siempre visibles: RAM, disco y uptime desde snapshot server-only saneado
 - búsqueda futura o comando rápido reservado
 - estado global resumido
-- timestamp / última actualización
+- timestamp / última actualización cuando la superficie lo aporte
 
 ### Convención de navegación
 - sidebar persistente en desktop

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -141,6 +141,15 @@ Antes de cerrar cambios que toquen Dashboard/Healthcheck config o fallback, ejec
 npm run verify:health-dashboard-server-only
 ```
 
+## System metrics header
+El header global consume `GET /api/v1/system/metrics` desde Phase 36.2 mediante un adapter frontend `server-only`:
+
+1. `apps/web/src/modules/system/api/system-metrics-http.ts` importa `server-only`, lee solo `MUGIWARA_CONTROL_PANEL_API_URL` y valida esquema `http:`/`https:`.
+2. `apps/web/src/app/layout.tsx` es dinámico (`force-dynamic`), obtiene un snapshot server-side por request/navegación y pasa props serializables a `AppShell`/`Topbar`.
+3. `AppShell` y `Topbar` siguen siendo client components por la navegación responsive, pero no hacen fetch, no leen `process.env` y no conocen la URL backend.
+4. Si la API falta, falla o devuelve payload inválido, el header muestra métricas `—` y estado degradado/sin datos sin URL backend, errores crudos, stack traces, paths host ni detalles de configuración.
+5. Este primer corte no añade polling, cache/TTL ni refresh cliente. Si se introduce refresco posterior, requiere diseño y review Franky + Chopper.
+
 ## Decisiones relacionadas
 La planificación inicial vive en `openspec/phase-12-3e-server-only-migration-plan.md`, el diseño específico de Skills BFF vive en `openspec/phase-12-3g-skills-bff-design.md`, la implementación vive en `openspec/phase-12-3h-skills-bff-implementation.md`, Vault vive en `openspec/phase-12-4-vault-readonly-api.md` y Health/Dashboard en `openspec/phase-12-5-health-dashboard-aggregation.md`.
 

--- a/openspec/issue-36-2-system-metrics-header.md
+++ b/openspec/issue-36-2-system-metrics-header.md
@@ -1,0 +1,51 @@
+# Issue #36.2 — Frontend server-only adapter + header integration
+
+## Estado
+- **Fase:** 36.2 — frontend server-only adapter + header integration.
+- **Rama:** `zoro/issue-36-2-system-metrics-header`.
+- **Issue:** #36 Always-visible header system metrics.
+- **Base previa:** PR #85 / 36.1 backend-only, ya mergeada.
+
+## Objetivo
+Consumir `GET /api/v1/system/metrics` desde un adapter server-only de Next.js e integrar RAM, disco y uptime en el header global (`AppShell`/`Topbar`) siempre visible.
+
+## Diseño aplicado
+1. `apps/web/src/modules/system/api/system-metrics-http.ts`:
+   - `import 'server-only'`;
+   - env privada `MUGIWARA_CONTROL_PANEL_API_URL`;
+   - validación `http:`/`https:`;
+   - endpoint fijo `/api/v1/system/metrics`;
+   - `cache: 'no-store'`;
+   - errores por código interno, nunca mensajes raw renderizados.
+2. `apps/web/src/app/layout.tsx`:
+   - `export const dynamic = 'force-dynamic'`;
+   - carga snapshot server-side;
+   - convierte errores a snapshot degradado con `—`;
+   - pasa props serializables a `AppShell`.
+3. `AppShell`/`Topbar`:
+   - siguen como client components por navegación mobile;
+   - no hacen fetch ni leen env;
+   - renderizan RAM, disco y uptime con jerarquía compacta.
+4. Responsive:
+   - desktop muestra porcentaje + usado/total cuando cabe;
+   - tablet oculta detalle usado/total para no saturar;
+   - mobile usa tres chips en grid, sin command chip, con el header apilado sin overflow horizontal.
+
+## Decisiones explícitas
+- Sin `NEXT_PUBLIC_*`.
+- Sin fetch browser directo al backend.
+- Sin exponer backend URL, paths host, errores crudos, stack traces ni payloads internos.
+- Sin polling, cache/TTL ni refresh cliente en esta fase; por tanto Franky no es reviewer obligatorio salvo que se añada esa capacidad en fase posterior.
+
+## Verify esperado
+- `npm --prefix apps/web run typecheck`.
+- `npm --prefix apps/web run build`.
+- `npm run verify:visual-baseline`.
+- `PYTHONPATH=. pytest apps/api/tests/test_system_metrics_api.py -q`.
+- Smoke HTML/DOM contra fugas: backend URL, `NEXT_PUBLIC`, paths internos, raw errors.
+- `git diff --check`.
+
+## Review
+- Usopp: header visible, jerarquía, responsive desktop/tablet/mobile y ruido visual.
+- Chopper: server-only boundary, no-leakage, ausencia de URL backend/env pública/raw errors en cliente.
+- Franky: no solicitado en esta fase porque no hay polling/cache/TTL/runtime nuevo.


### PR DESCRIPTION
## Resumen

Implementa la fase 36.2 de #36: adapter frontend server-only para métricas de sistema e integración de RAM/disco/uptime en el header global siempre visible.

## Cambios

- Nuevo adapter `apps/web/src/modules/system/api/system-metrics-http.ts` con `import 'server-only'`, env privada `MUGIWARA_CONTROL_PANEL_API_URL`, endpoint fijo `/api/v1/system/metrics` y `cache: 'no-store'`.
- Nuevo view-model serializable para degradar a valores `—` sin errores crudos.
- `RootLayout` dinámico (`force-dynamic`) carga el snapshot server-side y pasa props a `AppShell`/`Topbar`.
- `Topbar` muestra RAM, disco y uptime con chips compactos; desktop muestra porcentaje + usado/total, tablet oculta detalle largo y mobile usa grid de 3 chips.
- Docs/OpenSpec/Engram actualizados para fijar la frontera 36.2.

## Seguridad / frontera

- Sin `NEXT_PUBLIC_*`.
- Sin fetch browser directo al backend interno.
- Sin exponer backend URL, paths host, stack traces ni errores crudos en el header.
- Sin polling, cache/TTL ni refresh cliente en esta fase; por tanto Franky no es reviewer obligatorio según el plan.

## Verify ejecutado

- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build`
- `npm run verify:visual-baseline`
- `PYTHONPATH=. pytest apps/api/tests/test_system_metrics_api.py -q` → 3 passed
- Smoke API real: `GET /api/v1/system/metrics` vía backend local → 200 con payload saneado.
- Smoke HTML live `/dashboard` contra fugas: sin backend URL, `MUGIWARA_CONTROL_PANEL_API_URL`, `NEXT_PUBLIC`, raw errors, `/proc/meminfo` ni `/proc/uptime`; header contiene RAM/Disco/Uptime.
- Smoke HTML con env inválida `file:///tmp/private-backend`: sin URL interna, `NEXT_PUBLIC`, stack trace ni raw system errors; header degrada.
- Browser smoke `/dashboard`: consola limpia, `documentElement.scrollWidth <= clientWidth`, métricas visibles en header.
- `git diff --check`

## Review solicitada

- Usopp: jerarquía visual del header, ruido permanente, responsive desktop/tablet/mobile.
- Chopper: frontera server-only, ausencia de URL backend/env pública/raw errors en cliente y no-leakage.

#36 sigue abierta hasta 36.3 guardrails/canon/closeout final.
