### PR TITLE
chore: close system metrics guardrails

### DIFF
--- a/.engram/issue-36-3-system-metrics-closeout.md
+++ b/.engram/issue-36-3-system-metrics-closeout.md
@@ -1,0 +1,18 @@
+# Issue #36.3 — system metrics closeout
+
+## Scope
+Closeout final de #36: guardrail server-only frontend, docs/canon y cierre del issue tras 36.1 backend + 36.2 header ya mergeados.
+
+## Invariants fixed
+- Backend endpoint fijo `GET /api/v1/system/metrics`.
+- Frontend adapter `server-only` con `MUGIWARA_CONTROL_PANEL_API_URL`.
+- `RootLayout` dinámico carga snapshot server-side.
+- `AppShell`/`Topbar` no hacen fetch ni leen env.
+- Sin `NEXT_PUBLIC_*`, backend URL ni errores crudos en cliente.
+- Sin polling/cache/TTL.
+
+## Verify
+Completado antes de PR: nuevo `verify:system-metrics-server-only`, `verify:system-metrics-backend-policy`, `verify:perimeter-policy`, `verify:healthcheck-source-policy`, web typecheck/build, visual baseline, backend/perimeter tests, smoke live/invalid-config/browser anti-fugas y `git diff --check`.
+
+## Review plan
+Chopper + Usopp. Franky no es obligatorio porque 36.3 no introduce polling/cache/TTL ni cambia fuente runtime; solo fija guardrails/canon sobre 36.1/36.2.

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -159,12 +159,14 @@ Campos esperados:
 - `source_state` global (`live` o `degraded`)
 
 Uso:
-- alimentar el header global siempre visible en una fase frontend posterior
+- alimentar el header global siempre visible desde `RootLayout` dinámico mediante adapter frontend `server-only`
 - mantener el backend como única frontera de lectura host-adjacent para RAM/disco/uptime
 - calcular RAM usada como `MemTotal - MemAvailable` cuando se usa `/proc/meminfo`
 - representar el disco como target backend-owned `fastapi-visible-root-filesystem`, sin serializar path crudo, mount table ni device names
-- degradar cada familia a `unknown` si la fuente falla o viene malformada, sin exponer excepción, raw `/proc`, paths, stdout/stderr, logs, hostname, usuarios ni procesos
+- degradar cada familia a `unknown` si la fuente falla o viene malformada, y en frontend a valores `—`, sin exponer excepción, raw `/proc`, paths, stdout/stderr, logs, hostname, usuarios, procesos, backend URL ni errores crudos
 - no aceptar input cliente para elegir paths, mounts, devices, commands, URLs, methods, hosts o targets
+- sin `NEXT_PUBLIC_*`, sin fetch browser directo al backend interno y sin proxy genérico; `AppShell`/`Topbar` reciben solo props serializables saneadas
+- fijar la frontera completa con `npm run verify:system-metrics-backend-policy` y `npm run verify:system-metrics-server-only`
 
 ### `memory.agent_summary`
 Campos esperados:

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -150,6 +150,22 @@ El header global consume `GET /api/v1/system/metrics` desde Phase 36.2 mediante 
 4. Si la API falta, falla o devuelve payload inválido, el header muestra métricas `—` y estado degradado/sin datos sin URL backend, errores crudos, stack traces, paths host ni detalles de configuración.
 5. Este primer corte no añade polling, cache/TTL ni refresh cliente. Si se introduce refresco posterior, requiere diseño y review Franky + Chopper.
 
+Antes de cerrar cambios que toquen el header de métricas de sistema, ejecutar:
+
+```bash
+npm run verify:system-metrics-server-only
+```
+
+Este check confirma que el header mantiene:
+
+- adapter `server-only`;
+- env privada `MUGIWARA_CONTROL_PANEL_API_URL`;
+- endpoint fijo `/api/v1/system/metrics`;
+- root layout dinámico;
+- ausencia de `NEXT_PUBLIC_*`;
+- ausencia de fetch/env/backend URL en `AppShell`/`Topbar`;
+- fallback saneado sin errores crudos ni rutas host.
+
 ## Decisiones relacionadas
 La planificación inicial vive en `openspec/phase-12-3e-server-only-migration-plan.md`, el diseño específico de Skills BFF vive en `openspec/phase-12-3g-skills-bff-design.md`, la implementación vive en `openspec/phase-12-3h-skills-bff-implementation.md`, Vault vive en `openspec/phase-12-4-vault-readonly-api.md` y Health/Dashboard en `openspec/phase-12-5-health-dashboard-aggregation.md`.
 

--- a/openspec/issue-36-3-system-metrics-closeout-verify-checklist.md
+++ b/openspec/issue-36-3-system-metrics-closeout-verify-checklist.md
@@ -1,0 +1,31 @@
+# Issue #36.3 — Verify checklist
+
+## Preparación
+- [x] `main` actualizado antes de crear rama.
+- [x] Rama `zoro/issue-36-3-system-metrics-closeout`.
+- [x] Issue #36, PR #85, PR #86 y OpenSpec 36.0 revisados.
+
+## Guardrails/canon
+- [x] `npm run verify:system-metrics-server-only`.
+- [x] `npm run verify:system-metrics-backend-policy`.
+- [x] `npm run verify:perimeter-policy`.
+- [x] `npm run verify:healthcheck-source-policy`.
+
+## Frontend/backend verify
+- [x] `npm --prefix apps/web run typecheck`.
+- [x] `npm --prefix apps/web run build`.
+- [x] `npm run verify:visual-baseline`.
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_system_metrics_api.py apps/api/tests/test_perimeter_api.py -q`.
+
+## Smoke anti-fugas
+- [x] Smoke live `/dashboard` sin backend URL/env pública/raw errors.
+- [x] Smoke env inválida sin URL interna ni stack traces.
+- [x] Browser/DOM smoke con consola limpia y sin overflow horizontal.
+
+## Cierre
+- [x] `git diff --check`.
+- [ ] PR abierta y revisada por Chopper + Usopp.
+- [ ] PR mergeada.
+- [ ] Project Summary del vault actualizado y pusheado.
+- [ ] Engram actualizado.
+- [ ] Issue #36 comentada y cerrada.

--- a/openspec/issue-36-3-system-metrics-closeout.md
+++ b/openspec/issue-36-3-system-metrics-closeout.md
@@ -1,0 +1,71 @@
+# Issue #36.3 — System metrics guardrails, canon and closeout
+
+## Estado
+- **Fase:** 36.3 — guardrails/canon/closeout final.
+- **Rama:** `zoro/issue-36-3-system-metrics-closeout`.
+- **Issue:** [#36 Always-visible header system metrics](https://github.com/asistentes-mugiwara/mugiwara-control-panel/issues/36).
+- **Base previa:**
+  - 36.0 / PR #84 planificó la feature.
+  - 36.1 / PR #85 cerró backend read model/API.
+  - 36.2 / PR #86 cerró adapter frontend server-only + header integration.
+
+## Objetivo
+Cerrar #36 fijando por guardrail y canon que las métricas RAM/disco/uptime quedan como una superficie host-adjacent pequeña, backend-owned y consumida por el header solo desde frontera server-only de Next.js.
+
+## Alcance
+- Añadir `npm run verify:system-metrics-server-only`.
+- Fijar invariantes frontend:
+  - adapter `server-only`;
+  - env privada `MUGIWARA_CONTROL_PANEL_API_URL`;
+  - endpoint fijo `/api/v1/system/metrics`;
+  - `RootLayout` dinámico;
+  - `AppShell`/`Topbar` sin fetch, sin `process.env`, sin backend URL y sin `NEXT_PUBLIC_*`;
+  - fallback a snapshot saneado con valores `—`;
+  - labels de header cortos/estables para responsive (`RAM`, `Disco`, `Uptime`).
+- Actualizar docs vivas (`runtime-config`, `read-models`) para el estado final.
+- Mantener el guardrail backend 36.1 separado: `verify:system-metrics-backend-policy`.
+- Dejar checklist y closeout de la fase.
+
+## Fuera de alcance
+- No añadir polling, cache/TTL, refresh cliente ni rutas BFF nuevas.
+- No tocar el backend de métricas salvo regresión detectada por verify.
+- No cerrar #40 ni abrir Git control page.
+- No cambiar la semántica operativa revisada por Franky en 36.1.
+- No introducir Playwright/visual regression pesada.
+
+## Verify esperado
+- `npm run verify:system-metrics-server-only`.
+- `npm run verify:system-metrics-backend-policy`.
+- `npm run verify:perimeter-policy`.
+- `npm run verify:healthcheck-source-policy`.
+- `npm --prefix apps/web run typecheck`.
+- `npm --prefix apps/web run build`.
+- `npm run verify:visual-baseline`.
+- `PYTHONPATH=. pytest apps/api/tests/test_system_metrics_api.py apps/api/tests/test_perimeter_api.py -q`.
+- Smoke HTML/DOM contra fugas:
+  - backend URL;
+  - `MUGIWARA_CONTROL_PANEL_API_URL`;
+  - `NEXT_PUBLIC`;
+  - `SystemMetricsApiError`;
+  - `Traceback` / `Stack trace`;
+  - `/proc/meminfo` / `/proc/uptime`.
+- `git diff --check`.
+
+## Review
+- **Chopper:** obligatorio por guardrail de no-leakage y frontera server-only/host-adjacent.
+- **Usopp:** obligatorio porque el closeout fija el responsive y la semántica visual de header de la feature completa.
+- **Franky:** no obligatorio salvo que se introduzca polling/cache/TTL, cambio de fuente runtime o cambio operativo; esta fase solo fija guardrails/canon sobre decisiones ya aprobadas por Franky en 36.1.
+
+## Criterio de cierre de #36
+#36 se puede cerrar solo cuando:
+- PR 36.3 esté mergeada;
+- todos los verify pasen;
+- Chopper y Usopp hayan aprobado o declarado mergeable;
+- Project Summary del vault quede actualizado;
+- Engram registre el cierre final;
+- el issue tenga comentario final con 36.0/36.1/36.2/36.3 y riesgos residuales.
+
+## Riesgos residuales
+- Si el control panel se expone fuera del perímetro privado, el endpoint host-adjacent requiere auth/sesión/rate-limit antes de considerarse seguro.
+- Si se añade polling/refresh posterior, debe abrirse fase propia con coste/frecuencia/cache y review Franky + Chopper.
+- El visual verify sigue siendo baseline manual; no sustituye visual regression automatizada futura si el producto lo requiere.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "verify:backup-health-status-producer": "node scripts/check-backup-health-status-producer.mjs",
     "verify:backup-health-status-runner": "node scripts/check-backup-health-status-runner.mjs",
     "write:backup-health-status": "python3 scripts/write-backup-health-status.py",
-    "verify:system-metrics-backend-policy": "node scripts/check-system-metrics-backend-policy.mjs"
+    "verify:system-metrics-backend-policy": "node scripts/check-system-metrics-backend-policy.mjs",
+    "verify:system-metrics-server-only": "node scripts/check-system-metrics-server-only.mjs"
   },
   "overrides": {
     "postcss": "8.5.10"

--- a/scripts/check-system-metrics-server-only.mjs
+++ b/scripts/check-system-metrics-server-only.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * Static guardrail for Issue #36.3 system metrics server-only header integration.
+ *
+ * Keeps RAM/disk/uptime consumption in the Next.js server boundary and prevents
+ * regressions to browser-side backend fetches, public backend env vars or raw errors.
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = process.cwd()
+const paths = {
+  packageJson: join(repoRoot, 'package.json'),
+  systemHttp: join(repoRoot, 'apps/web/src/modules/system/api/system-metrics-http.ts'),
+  systemViewModel: join(repoRoot, 'apps/web/src/modules/system/view-models/system-metrics-summary.ts'),
+  layout: join(repoRoot, 'apps/web/src/app/layout.tsx'),
+  appShell: join(repoRoot, 'apps/web/src/shared/ui/app-shell/AppShell.tsx'),
+  topbar: join(repoRoot, 'apps/web/src/shared/ui/app-shell/Topbar.tsx'),
+  shellMetricTypes: join(repoRoot, 'apps/web/src/shared/ui/app-shell/system-metrics.ts'),
+  runtimeConfig: join(repoRoot, 'docs/runtime-config.md'),
+  readModels: join(repoRoot, 'docs/read-models.md'),
+  openspec: join(repoRoot, 'openspec/issue-36-3-system-metrics-closeout.md'),
+}
+
+const failures = []
+
+function read(pathName, label) {
+  if (!existsSync(pathName)) {
+    failures.push(`missing ${label}: ${pathName}`)
+    return ''
+  }
+  return readFileSync(pathName, 'utf8')
+}
+
+function mustInclude(text, snippet, label) {
+  if (!text.includes(snippet)) failures.push(`${label} must include: ${snippet}`)
+}
+
+function mustNotInclude(text, snippet, label) {
+  if (text.includes(snippet)) failures.push(`${label} must not include: ${snippet}`)
+}
+
+function mustMatch(text, pattern, label, message) {
+  if (!pattern.test(text)) failures.push(`${label} must ${message}`)
+}
+
+const packageJsonText = read(paths.packageJson, 'package.json')
+const systemHttp = read(paths.systemHttp, 'system metrics server-only adapter')
+const systemViewModel = read(paths.systemViewModel, 'system metrics header view-model')
+const layout = read(paths.layout, 'root layout')
+const appShell = read(paths.appShell, 'AppShell')
+const topbar = read(paths.topbar, 'Topbar')
+const shellMetricTypes = read(paths.shellMetricTypes, 'header metrics prop types')
+const runtimeConfig = read(paths.runtimeConfig, 'runtime config docs')
+const readModels = read(paths.readModels, 'read models docs')
+const openspec = read(paths.openspec, 'Issue 36.3 OpenSpec')
+
+let packageJson
+try {
+  packageJson = JSON.parse(packageJsonText)
+} catch {
+  failures.push('package.json must be valid JSON')
+}
+
+if (packageJson?.scripts?.['verify:system-metrics-server-only'] !== 'node scripts/check-system-metrics-server-only.mjs') {
+  failures.push('package.json must expose verify:system-metrics-server-only')
+}
+
+mustInclude(systemHttp, "import 'server-only'", 'system metrics adapter')
+mustInclude(systemHttp, "SYSTEM_METRICS_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'", 'system metrics adapter')
+mustInclude(systemHttp, '/api/v1/system/metrics', 'system metrics adapter')
+mustInclude(systemHttp, "cache: 'no-store'", 'system metrics adapter')
+mustInclude(systemHttp, "parsed.protocol !== 'http:'", 'system metrics adapter')
+mustInclude(systemHttp, "parsed.protocol !== 'https:'", 'system metrics adapter')
+mustInclude(systemHttp, 'SystemMetricsResponse', 'system metrics adapter')
+mustInclude(systemHttp, 'throw new SystemMetricsApiError', 'system metrics adapter')
+
+for (const forbidden of [
+  'NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL',
+  'process.env.NEXT_PUBLIC',
+  'path=',
+  'target=',
+  'mount=',
+  'device=',
+  'command=',
+  'method=',
+]) {
+  mustNotInclude(systemHttp, forbidden, 'system metrics adapter')
+}
+
+mustInclude(layout, "export const dynamic = 'force-dynamic'", 'root layout')
+mustInclude(layout, 'fetchSystemMetrics()', 'root layout')
+mustInclude(layout, 'createHeaderSystemMetricsSnapshot(response.data)', 'root layout')
+mustInclude(layout, "createUnavailableHeaderSystemMetrics('not_configured')", 'root layout')
+mustInclude(layout, "createUnavailableHeaderSystemMetrics('unavailable')", 'root layout')
+mustInclude(layout, '<AppShell systemMetrics={headerSystemMetrics}>', 'root layout')
+mustNotInclude(layout, 'NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL', 'root layout')
+
+mustInclude(systemViewModel, 'createUnavailableHeaderSystemMetrics', 'system metrics view-model')
+mustInclude(systemViewModel, "source_state: 'unknown'", 'system metrics view-model')
+mustInclude(systemViewModel, "sourceState: metrics.source_state === 'live' ? 'live' : 'degraded'", 'system metrics view-model')
+mustInclude(shellMetricTypes, 'HeaderSystemMetrics', 'header metrics prop types')
+mustInclude(appShell, 'systemMetrics: HeaderSystemMetrics', 'AppShell')
+mustInclude(appShell, 'systemMetrics={systemMetrics}', 'AppShell')
+
+for (const [label, text] of [['AppShell', appShell], ['Topbar', topbar]]) {
+  mustNotInclude(text, 'fetch(', label)
+  mustNotInclude(text, 'process.env', label)
+  mustNotInclude(text, 'MUGIWARA_CONTROL_PANEL_API_URL', label)
+  mustNotInclude(text, 'NEXT_PUBLIC', label)
+  mustNotInclude(text, '/api/v1/system/metrics', label)
+  mustNotInclude(text, 'SystemMetricsApiError', label)
+  mustNotInclude(text, 'Traceback', label)
+  mustNotInclude(text, 'Stack trace', label)
+  mustNotInclude(text, '/proc/meminfo', label)
+  mustNotInclude(text, '/proc/uptime', label)
+}
+
+for (const snippet of [
+  'RAM',
+  'Disco',
+  'Uptime',
+  'topbar__metrics-strip',
+  'topbar__metric-chip',
+  'formatCapacityValue',
+  'formatUptimeValue',
+]) {
+  mustInclude(topbar, snippet, 'Topbar')
+}
+
+mustMatch(topbar, /function\s+metricLabel\([^)]*\)\s*{\s*return label\s*}/s, 'Topbar', 'keep stable short metric labels')
+
+for (const snippet of [
+  'System metrics header',
+  'verify:system-metrics-server-only',
+  'sin `NEXT_PUBLIC_*`',
+  'no hacen fetch',
+  'no leen `process.env`',
+]) {
+  mustInclude(runtimeConfig, snippet, 'runtime config docs')
+}
+
+for (const snippet of [
+  'header global siempre visible',
+  'server-only',
+  'sin `NEXT_PUBLIC_*`',
+  'sin fetch browser directo',
+]) {
+  mustInclude(readModels, snippet, 'read models docs')
+}
+
+for (const snippet of [
+  'Issue #36.3',
+  'verify:system-metrics-server-only',
+  '36.1',
+  '36.2',
+  'closeout',
+]) {
+  mustInclude(openspec, snippet, 'Issue 36.3 OpenSpec')
+}
+
+if (failures.length > 0) {
+  console.error('System metrics server-only check failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log('System metrics server-only check passed.')


### PR DESCRIPTION
## Resumen

Cierra la fase 36.3 de #36: guardrail server-only frontend, docs/canon y closeout final de la feature de métricas RAM/disco/uptime siempre visibles.

## Cambios

- Nuevo guardrail `npm run verify:system-metrics-server-only`.
- Nuevo script `scripts/check-system-metrics-server-only.mjs` que fija:
  - adapter `server-only`;
  - env privada `MUGIWARA_CONTROL_PANEL_API_URL`;
  - endpoint fijo `/api/v1/system/metrics`;
  - `RootLayout` dinámico;
  - `AppShell`/`Topbar` sin fetch, sin `process.env`, sin backend URL, sin `NEXT_PUBLIC_*`;
  - labels estables `RAM`, `Disco`, `Uptime` y fallback saneado.
- Docs actualizadas:
  - `docs/runtime-config.md`
  - `docs/read-models.md`
- OpenSpec/checklist/Engram de 36.3 añadidos.

## Seguridad / frontera

- No añade polling/cache/TTL/refresh cliente.
- No toca fuente runtime ni backend de métricas.
- Mantiene separado el guardrail backend 36.1: `verify:system-metrics-backend-policy`.
- No cierra #40 ni cambia otras superficies.

## Verify ejecutado

- `npm run verify:system-metrics-server-only`
- `npm run verify:system-metrics-backend-policy`
- `npm run verify:perimeter-policy`
- `npm run verify:healthcheck-source-policy`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build`
- `npm run verify:visual-baseline`
- `PYTHONPATH=. pytest apps/api/tests/test_system_metrics_api.py apps/api/tests/test_perimeter_api.py -q` → 6 passed
- Smoke HTML live `/dashboard`: sin backend URL, env privada, `NEXT_PUBLIC`, raw errors ni `/proc/*`; contiene RAM/Disco/Uptime.
- Smoke HTML con env inválida `file:///tmp/private-backend`: sin URL interna, `NEXT_PUBLIC`, stack trace ni raw system errors; header degrada con `—`.
- Browser/DOM smoke `/dashboard`: consola limpia, sin overflow horizontal, métricas visibles.
- `git diff --check`

## Review solicitada

- Chopper: no-leakage, server-only boundary y guardrail de seguridad frontend/host-adjacent.
- Usopp: confirma que el closeout fija correctamente la semántica visual/responsive aprobada en 36.2.

Franky no está solicitado porque no hay polling/cache/TTL ni cambio operativo/runtime nuevo.

## Cierre previsto

Si Chopper + Usopp aprueban, esta PR debe permitir:
- mergear 36.3;
- actualizar Project Summary del vault;
- comentar y cerrar #36.
