### PR TITLE
feat: add git commits branches backend

### DIFF
--- a/.engram/issue-40-2-closeout.md
+++ b/.engram/issue-40-2-closeout.md
@@ -1,0 +1,36 @@
+# Issue #40.2 closeout — Git commits/branches backend
+
+## Resultado
+Se implementó la microfase 40.2 backend-only para Git control: endpoints read-only de commits recientes y ramas locales sobre la registry allowlisteada existente de 40.1.
+
+## Artefactos
+- `apps/api/src/modules/git_control/`
+- `apps/api/tests/test_git_control_api.py`
+- `scripts/check-git-control-backend-policy.mjs`
+- `docs/api-modules.md`
+- `docs/read-models.md`
+- `docs/runtime-config.md`
+- `openspec/issue-40-2-git-commits-branches-verify-checklist.md`
+
+## Decisiones técnicas
+- El cliente sigue operando solo con `repo_id`; no hay paths, URLs, remotes, comandos, refs, branch selector ni revspecs desde cliente.
+- `GET /api/v1/git/repos/{repo_id}/commits` acepta `limit` `1..50` y cursor opaco `offset:<n>` generado por backend. No acepta SHAs ni revsets como cursor.
+- `GET /api/v1/git/repos/{repo_id}/branches` lista solo ramas locales mediante formato fijo de Git; no lista remotes.
+- Commits exponen metadata acotada y trailers `Mugiwara-Agent`/`Signed-off-by`; no exponen diffs ni nombres de ficheros.
+- Git amplía la allowlist read-only a `status`, `log` y `branch`, manteniendo hardening de 40.1: `shell=False`, cwd fijo, timeout, env mínimo, `GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_SYSTEM=/dev/null`, `GIT_CONFIG_NOSYSTEM=1`, `-c core.fsmonitor=false`, `-c core.hooksPath=/dev/null`.
+- Repos desconocidos, no Git o ilegibles degradan con payload saneado y sin filtrar rutas/stdout/stderr.
+
+## Verify
+Ejecutado al cierre:
+- `PYTHONPATH=. pytest apps/api/tests/test_git_control_api.py -q` — pasa (`11 passed`).
+- `npm run verify:git-control-backend-policy` — pasa.
+- `npm run verify:perimeter-policy` — pasa.
+- `git diff --check` — pasa.
+
+## Review requerido
+- Franky + Chopper en PR de implementación.
+- Franky debe validar operabilidad de `git log`/`git branch`, timeout/cwd/env, no red y guardrail.
+- Chopper debe validar seguridad de cursor/límites, no refs/revspecs cliente, no leakage y frontera host.
+
+## Continuidad
+Siguiente microfase de #40 recomendada: 40.3 backend commit detail + safe diff, con redacción/omisión/truncado deny-by-default y nueva revisión Franky + Chopper. No reutilizar la aprobación de 40.2 para diffs.

--- a/.engram/issue-40-2-closeout.md
+++ b/.engram/issue-40-2-closeout.md
@@ -16,7 +16,7 @@ Se implementó la microfase 40.2 backend-only para Git control: endpoints read-o
 - El cliente sigue operando solo con `repo_id`; no hay paths, URLs, remotes, comandos, refs, branch selector ni revspecs desde cliente.
 - `GET /api/v1/git/repos/{repo_id}/commits` acepta `limit` `1..50` y cursor opaco `offset:<n>` generado por backend. No acepta SHAs ni revsets como cursor.
 - `GET /api/v1/git/repos/{repo_id}/branches` lista solo ramas locales mediante formato fijo de Git; no lista remotes.
-- Commits exponen metadata acotada y trailers `Mugiwara-Agent`/`Signed-off-by`; no exponen diffs ni nombres de ficheros.
+- Commits exponen metadata acotada y trailers `Mugiwara-Agent`/`Signed-off-by`; no exponen diffs, nombres de ficheros ni cuerpo libre del commit.
 - Git amplía la allowlist read-only a `status`, `log` y `branch`, manteniendo hardening de 40.1: `shell=False`, cwd fijo, timeout, env mínimo, `GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_SYSTEM=/dev/null`, `GIT_CONFIG_NOSYSTEM=1`, `-c core.fsmonitor=false`, `-c core.hooksPath=/dev/null`.
 - Repos desconocidos, no Git o ilegibles degradan con payload saneado y sin filtrar rutas/stdout/stderr.
 

--- a/apps/api/src/modules/git_control/AGENTS.md
+++ b/apps/api/src/modules/git_control/AGENTS.md
@@ -9,5 +9,6 @@ Módulo backend read-only para consultar repositorios Git locales allowlisteados
 - Sin discovery arbitrario de filesystem ni selección dinámica de repos desde request.
 - Sin acciones Git destructivas o remotas: no checkout/reset/commit/push/pull/fetch/stash/merge/rebase.
 - Si se invoca Git, usar `subprocess.run` con lista de argumentos, `shell=False`, `cwd` fijo, timeout y entorno mínimo.
-- Serializar solo estado resumido: clean/dirty, conteos y rama actual saneada. Sin diffs, filenames, rutas host, remotes, stdout/stderr, stack traces ni errores crudos.
+- Serializar solo estado resumido, commits recientes y ramas locales: clean/dirty, conteos, rama actual saneada, hashes/fechas/autores saneados y trailers `Mugiwara-Agent`/`Signed-off-by`. Sin diffs, filenames de status, rutas host, remotes, stdout/stderr, stack traces ni errores crudos.
+- Para commits, aceptar solo `limit` `1..50` y cursor opaco `offset:<n>` generado por backend; no aceptar SHA/ref/revspec cliente ni revsets arbitrarios.
 - Degradar repos ausentes, corruptos o ilegibles a estados explícitos y saneados.

--- a/apps/api/src/modules/git_control/domain.py
+++ b/apps/api/src/modules/git_control/domain.py
@@ -78,7 +78,6 @@ class GitCommitSummary:
     authored_at: str
     committed_at: str
     subject: str
-    body: str
     mugiwara_agent: str | None
     signed_off_by: str | None
 
@@ -91,7 +90,6 @@ class GitCommitSummary:
             'authored_at': self.authored_at,
             'committed_at': self.committed_at,
             'subject': self.subject,
-            'body': self.body,
             'trailers': {
                 'mugiwara_agent': self.mugiwara_agent,
                 'signed_off_by': self.signed_off_by,

--- a/apps/api/src/modules/git_control/domain.py
+++ b/apps/api/src/modules/git_control/domain.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
 
 
 GIT_CONTROL_SOURCE_LABEL = 'backend-owned-git-registry'
 GIT_COMMAND_TIMEOUT_SECONDS = 2.0
+GIT_COMMITS_DEFAULT_LIMIT = 25
+GIT_COMMITS_MAX_LIMIT = 50
+GIT_CURSOR_PATTERN = re.compile(r'^offset:(0|[1-9][0-9]{0,5})$')
+GIT_SHA_PATTERN = re.compile(r'^[0-9a-f]{40}$|^[0-9a-f]{64}$')
 GIT_MINIMAL_ENV = {
     'PATH': '/usr/bin:/bin',
     'LANG': 'C',
@@ -19,7 +24,7 @@ GIT_SAFE_CONFIG_ARGS = (
     '-c',
     'core.hooksPath=/dev/null',
 )
-READ_ONLY_GIT_COMMANDS = frozenset({'status'})
+READ_ONLY_GIT_COMMANDS = frozenset({'status', 'log', 'branch'})
 FORBIDDEN_GIT_COMMANDS = frozenset(
     {
         'checkout',
@@ -61,4 +66,50 @@ class GitRepoStatus:
             'changed_files_count': self.changed_files_count,
             'untracked_files_count': self.untracked_files_count,
             'current_branch': self.current_branch,
+        }
+
+
+@dataclass(frozen=True)
+class GitCommitSummary:
+    sha: str
+    short_sha: str
+    author_name: str
+    author_email: str
+    authored_at: str
+    committed_at: str
+    subject: str
+    body: str
+    mugiwara_agent: str | None
+    signed_off_by: str | None
+
+    def to_public(self) -> dict:
+        return {
+            'sha': self.sha,
+            'short_sha': self.short_sha,
+            'author_name': self.author_name,
+            'author_email': self.author_email,
+            'authored_at': self.authored_at,
+            'committed_at': self.committed_at,
+            'subject': self.subject,
+            'body': self.body,
+            'trailers': {
+                'mugiwara_agent': self.mugiwara_agent,
+                'signed_off_by': self.signed_off_by,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class GitBranchSummary:
+    name: str
+    current: bool
+    sha: str
+    short_sha: str
+
+    def to_public(self) -> dict:
+        return {
+            'name': self.name,
+            'current': self.current,
+            'sha': self.sha,
+            'short_sha': self.short_sha,
         }

--- a/apps/api/src/modules/git_control/git_adapter.py
+++ b/apps/api/src/modules/git_control/git_adapter.py
@@ -6,21 +6,66 @@ import subprocess
 from .domain import (
     FORBIDDEN_GIT_COMMANDS,
     GIT_COMMAND_TIMEOUT_SECONDS,
+    GIT_COMMITS_DEFAULT_LIMIT,
+    GIT_COMMITS_MAX_LIMIT,
+    GIT_CURSOR_PATTERN,
     GIT_MINIMAL_ENV,
     GIT_SAFE_CONFIG_ARGS,
+    GIT_SHA_PATTERN,
+    GitBranchSummary,
+    GitCommitSummary,
     GitRepoStatus,
     READ_ONLY_GIT_COMMANDS,
 )
 from .registry import GitRepoDefinition
 
 
-class GitStatusAdapter:
+class GitInvalidCursor(ValueError):
+    pass
+
+
+class GitInvalidLimit(ValueError):
+    pass
+
+
+class GitReadAdapter:
     def read_status(self, repo: GitRepoDefinition) -> GitRepoStatus:
         try:
             output = _run_git_status(repo.path)
             return _parse_porcelain_status(output)
         except Exception:
             return GitRepoStatus.unknown()
+
+    def list_commits(
+        self,
+        repo: GitRepoDefinition,
+        *,
+        limit: int = GIT_COMMITS_DEFAULT_LIMIT,
+        cursor: str | None = None,
+    ) -> tuple[list[GitCommitSummary], str | None, str]:
+        offset = _parse_cursor(cursor)
+        _validate_limit(limit)
+        try:
+            output = _run_git_log(repo.path, limit=limit + 1, offset=offset)
+            commits = _parse_git_log(output)
+        except Exception:
+            return [], None, 'unknown'
+        visible = commits[:limit]
+        next_cursor = f'offset:{offset + limit}' if len(commits) > limit else None
+        return visible, next_cursor, 'live'
+
+    def list_branches(self, repo: GitRepoDefinition) -> tuple[list[GitBranchSummary], str | None, str]:
+        try:
+            output = _run_git_branches(repo.path)
+            branches = _parse_git_branches(output)
+        except Exception:
+            return [], None, 'unknown'
+        current = next((branch.name for branch in branches if branch.current), None)
+        return branches, current, 'live'
+
+
+class GitStatusAdapter(GitReadAdapter):
+    pass
 
 
 def _run_git_status(repo_path: Path) -> str:
@@ -35,6 +80,34 @@ def _run_git_status(repo_path: Path) -> str:
             '--branch',
             '--untracked-files=all',
             '--no-renames',
+        ],
+    )
+
+
+def _run_git_log(repo_path: Path, *, limit: int, offset: int) -> str:
+    return _run_allowlisted_git(
+        repo_path,
+        [
+            'git',
+            '--no-optional-locks',
+            *GIT_SAFE_CONFIG_ARGS,
+            'log',
+            f'--max-count={limit}',
+            f'--skip={offset}',
+            '--format=%H%x1f%h%x1f%an%x1f%ae%x1f%aI%x1f%cI%x1f%s%x1f%B%x1e',
+        ],
+    )
+
+
+def _run_git_branches(repo_path: Path) -> str:
+    return _run_allowlisted_git(
+        repo_path,
+        [
+            'git',
+            '--no-optional-locks',
+            *GIT_SAFE_CONFIG_ARGS,
+            'branch',
+            '--format=%(refname:short)%00%(HEAD)%00%(objectname)',
         ],
     )
 
@@ -114,3 +187,105 @@ def _sanitize_branch_name(raw: str) -> str | None:
     if len(sanitized) > 80:
         return None
     return sanitized
+
+
+def _validate_limit(limit: int) -> None:
+    if limit < 1 or limit > GIT_COMMITS_MAX_LIMIT:
+        raise GitInvalidLimit('invalid commit limit')
+
+
+def _parse_cursor(cursor: str | None) -> int:
+    if cursor is None:
+        return 0
+    match = GIT_CURSOR_PATTERN.fullmatch(cursor)
+    if not match:
+        raise GitInvalidCursor('invalid commit cursor')
+    return int(match.group(1))
+
+
+def _parse_git_log(output: str) -> list[GitCommitSummary]:
+    commits: list[GitCommitSummary] = []
+    for record in output.split('\x1e'):
+        record = record.strip('\n')
+        if not record:
+            continue
+        parts = record.split('\x1f', 7)
+        if len(parts) != 8:
+            continue
+        sha, short_sha, author_name, author_email, authored_at, committed_at, subject, body = parts
+        if not GIT_SHA_PATTERN.fullmatch(sha):
+            continue
+        trailers = _extract_trailers(body)
+        commits.append(
+            GitCommitSummary(
+                sha=sha,
+                short_sha=_sanitize_short_sha(short_sha, sha),
+                author_name=_sanitize_text(author_name, max_length=120),
+                author_email=_sanitize_email(author_email),
+                authored_at=_sanitize_text(authored_at, max_length=40),
+                committed_at=_sanitize_text(committed_at, max_length=40),
+                subject=_sanitize_text(subject, max_length=200),
+                body=_sanitize_body(body),
+                mugiwara_agent=trailers.get('mugiwara-agent'),
+                signed_off_by=trailers.get('signed-off-by'),
+            )
+        )
+    return commits
+
+
+def _parse_git_branches(output: str) -> list[GitBranchSummary]:
+    branches: list[GitBranchSummary] = []
+    for line in output.splitlines():
+        parts = line.split('\x00')
+        if len(parts) != 3:
+            continue
+        raw_name, marker, sha = parts
+        name = _sanitize_branch_name(raw_name)
+        if name is None or not GIT_SHA_PATTERN.fullmatch(sha):
+            continue
+        branches.append(
+            GitBranchSummary(
+                name=name,
+                current=marker == '*',
+                sha=sha,
+                short_sha=sha[:12],
+            )
+        )
+    return branches
+
+
+def _extract_trailers(body: str) -> dict[str, str | None]:
+    trailers: dict[str, str | None] = {'mugiwara-agent': None, 'signed-off-by': None}
+    for line in body.splitlines():
+        if ':' not in line:
+            continue
+        key, value = line.split(':', 1)
+        normalized = key.strip().lower()
+        if normalized in trailers:
+            trailers[normalized] = _sanitize_text(value.strip(), max_length=160)
+    return trailers
+
+
+def _sanitize_body(body: str) -> str:
+    lines = []
+    for line in body.splitlines():
+        if line.lower().startswith(('mugiwara-agent:', 'signed-off-by:')):
+            continue
+        lines.append(_sanitize_text(line, max_length=200))
+    return '\n'.join(lines).strip()[:1000]
+
+
+def _sanitize_text(value: str, *, max_length: int) -> str:
+    safe = ''.join(char for char in value if char.isprintable() and char not in {'\x1e', '\x1f', '\x00'})
+    return safe[:max_length]
+
+
+def _sanitize_email(value: str) -> str:
+    safe = _sanitize_text(value, max_length=160)
+    if '@' not in safe or any(marker in safe.lower() for marker in ('token', 'secret', 'password', '/')):
+        return ''
+    return safe
+
+
+def _sanitize_short_sha(value: str, sha: str) -> str:
+    return sha[:12]

--- a/apps/api/src/modules/git_control/git_adapter.py
+++ b/apps/api/src/modules/git_control/git_adapter.py
@@ -225,7 +225,6 @@ def _parse_git_log(output: str) -> list[GitCommitSummary]:
                 authored_at=_sanitize_text(authored_at, max_length=40),
                 committed_at=_sanitize_text(committed_at, max_length=40),
                 subject=_sanitize_text(subject, max_length=200),
-                body=_sanitize_body(body),
                 mugiwara_agent=trailers.get('mugiwara-agent'),
                 signed_off_by=trailers.get('signed-off-by'),
             )
@@ -264,15 +263,6 @@ def _extract_trailers(body: str) -> dict[str, str | None]:
         if normalized in trailers:
             trailers[normalized] = _sanitize_text(value.strip(), max_length=160)
     return trailers
-
-
-def _sanitize_body(body: str) -> str:
-    lines = []
-    for line in body.splitlines():
-        if line.lower().startswith(('mugiwara-agent:', 'signed-off-by:')):
-            continue
-        lines.append(_sanitize_text(line, max_length=200))
-    return '\n'.join(lines).strip()[:1000]
 
 
 def _sanitize_text(value: str, *, max_length: int) -> str:

--- a/apps/api/src/modules/git_control/router.py
+++ b/apps/api/src/modules/git_control/router.py
@@ -4,7 +4,8 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
 from ...shared.contracts import resource_response
-from .domain import GIT_CONTROL_SOURCE_LABEL
+from .domain import GIT_COMMITS_DEFAULT_LIMIT, GIT_CONTROL_SOURCE_LABEL
+from .git_adapter import GitInvalidCursor, GitInvalidLimit
 from .service import GitControlService, GitRepoNotFound
 
 router = APIRouter(prefix='/api/v1/git', tags=['git_control'])
@@ -35,22 +36,79 @@ def get_git_repo_status(repo_id: str, service: GitControlService = Depends(get_g
     try:
         status_payload = service.get_repo_status(repo_id)
     except GitRepoNotFound:
-        return JSONResponse(
-            status_code=404,
-            content={
-                'detail': {
-                    'code': 'git_repo_not_found',
-                    'message': 'Git repository is not configured.',
-                }
-            },
-        )
+        return _git_repo_not_found_response()
     return resource_response(
         resource='git.repo_status',
         status=service.status_for_repo_status(status_payload),
         data=status_payload,
-        meta={
-            'read_only': True,
-            'sanitized': True,
-            'source': GIT_CONTROL_SOURCE_LABEL,
+        meta=_git_meta(),
+    )
+
+
+@router.get('/repos/{repo_id}/commits')
+def list_git_repo_commits(
+    repo_id: str,
+    limit: int = GIT_COMMITS_DEFAULT_LIMIT,
+    cursor: str | None = None,
+    service: GitControlService = Depends(get_git_control_service),
+):
+    try:
+        commits_payload = service.list_commits(repo_id, limit=limit, cursor=cursor)
+    except GitRepoNotFound:
+        return _git_repo_not_found_response()
+    except GitInvalidLimit:
+        return _git_validation_error_response('git_invalid_limit', 'Invalid commit limit.')
+    except GitInvalidCursor:
+        return _git_validation_error_response('git_invalid_cursor', 'Invalid commit cursor.')
+    return resource_response(
+        resource='git.commit_list',
+        status=service.status_for_commit_list(commits_payload),
+        data=commits_payload,
+        meta=_git_meta(),
+    )
+
+
+@router.get('/repos/{repo_id}/branches')
+def list_git_repo_branches(repo_id: str, service: GitControlService = Depends(get_git_control_service)):
+    try:
+        branches_payload = service.list_branches(repo_id)
+    except GitRepoNotFound:
+        return _git_repo_not_found_response()
+    return resource_response(
+        resource='git.branch_list',
+        status=service.status_for_branch_list(branches_payload),
+        data=branches_payload,
+        meta=_git_meta(),
+    )
+
+
+def _git_meta() -> dict:
+    return {
+        'read_only': True,
+        'sanitized': True,
+        'source': GIT_CONTROL_SOURCE_LABEL,
+    }
+
+
+def _git_repo_not_found_response() -> JSONResponse:
+    return JSONResponse(
+        status_code=404,
+        content={
+            'detail': {
+                'code': 'git_repo_not_found',
+                'message': 'Git repository is not configured.',
+            }
+        },
+    )
+
+
+def _git_validation_error_response(code: str, message: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=400,
+        content={
+            'detail': {
+                'code': code,
+                'message': message,
+            }
         },
     )

--- a/apps/api/src/modules/git_control/service.py
+++ b/apps/api/src/modules/git_control/service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from .domain import GitRepoStatus
-from .git_adapter import GitStatusAdapter
+from .domain import GIT_COMMITS_DEFAULT_LIMIT, GitRepoStatus
+from .git_adapter import GitInvalidCursor, GitInvalidLimit, GitReadAdapter
 from .registry import GitRepoDefinition, GitRepoRegistry, default_git_repo_registry
 
 
@@ -14,23 +14,48 @@ class GitControlService:
         self,
         *,
         registry: GitRepoRegistry | None = None,
-        status_adapter: GitStatusAdapter | None = None,
+        status_adapter: GitReadAdapter | None = None,
     ) -> None:
         self._registry = registry or default_git_repo_registry()
-        self._status_adapter = status_adapter or GitStatusAdapter()
+        self._read_adapter = status_adapter or GitReadAdapter()
 
     def list_repos(self) -> dict:
         repos = []
         for repo in self._registry.list_repos():
-            repos.append(_repo_index_entry(repo, self._status_adapter.read_status(repo)))
+            repos.append(_repo_index_entry(repo, self._read_adapter.read_status(repo)))
         return {'repos': repos}
 
     def get_repo_status(self, repo_id: str) -> dict:
         repo = self._registry.get(repo_id)
         if repo is None:
             raise GitRepoNotFound()
-        status = self._status_adapter.read_status(repo)
+        status = self._read_adapter.read_status(repo)
         return {'repo_id': repo.repo_id, 'status': status.to_public()}
+
+    def list_commits(self, repo_id: str, *, limit: int = GIT_COMMITS_DEFAULT_LIMIT, cursor: str | None = None) -> dict:
+        repo = self._registry.get(repo_id)
+        if repo is None:
+            raise GitRepoNotFound()
+        commits, next_cursor, source_state = self._read_adapter.list_commits(repo, limit=limit, cursor=cursor)
+        return {
+            'repo_id': repo.repo_id,
+            'commits': [commit.to_public() for commit in commits],
+            'limit': limit,
+            'next_cursor': next_cursor,
+            'source_state': source_state,
+        }
+
+    def list_branches(self, repo_id: str) -> dict:
+        repo = self._registry.get(repo_id)
+        if repo is None:
+            raise GitRepoNotFound()
+        branches, current_branch, source_state = self._read_adapter.list_branches(repo)
+        return {
+            'repo_id': repo.repo_id,
+            'current_branch': current_branch,
+            'branches': [branch.to_public() for branch in branches],
+            'source_state': source_state,
+        }
 
     @staticmethod
     def status_for_index(index: dict) -> str:
@@ -43,6 +68,18 @@ class GitControlService:
     def status_for_repo_status(status_payload: dict) -> str:
         status = status_payload.get('status') or {}
         if status.get('source_state') == 'live':
+            return 'ready'
+        return 'source_unavailable'
+
+    @staticmethod
+    def status_for_commit_list(commits_payload: dict) -> str:
+        if commits_payload.get('source_state') == 'live':
+            return 'ready'
+        return 'source_unavailable'
+
+    @staticmethod
+    def status_for_branch_list(branches_payload: dict) -> str:
+        if branches_payload.get('source_state') == 'live':
             return 'ready'
         return 'source_unavailable'
 

--- a/apps/api/tests/test_git_control_api.py
+++ b/apps/api/tests/test_git_control_api.py
@@ -308,6 +308,7 @@ def test_git_commits_lists_recent_commits_with_mugiwara_trailers_and_safe_cursor
     assert payload['data']['commits'][0]['short_sha'] == newer_sha[:12]
     assert payload['data']['commits'][0]['subject'] == 'fix: add ops note'
     assert payload['data']['commits'][0]['trailers'] == {'mugiwara_agent': None, 'signed_off_by': None}
+    assert 'body' not in payload['data']['commits'][0]
     assert payload['data']['next_cursor'] == 'offset:1'
     _assert_no_leakage(payload)
 
@@ -321,9 +322,43 @@ def test_git_commits_lists_recent_commits_with_mugiwara_trailers_and_safe_cursor
         'mugiwara_agent': 'zoro',
         'signed_off_by': 'zoro <asistentes.mugiwara@gmail.com>',
     }
-    assert 'Detailed body line.' in trailer_commit['body']
+    assert 'body' not in trailer_commit
+    assert 'Detailed body line.' not in second_page.text
     assert '.git' not in second_page.text
     _assert_no_leakage(second_payload)
+
+
+def test_git_commits_do_not_expose_sensitive_commit_body_while_extracting_trailers(tmp_path: Path) -> None:
+    from apps.api.src.modules.git_control.registry import GitRepoDefinition, GitRepoRegistry
+
+    sensitive_marker = 'SYNTHETIC-SECRET-COMMIT-BODY-MARKER'
+    repo = _make_repo(tmp_path / 'sensitive-body-private-repo')
+    sha = _commit_file(
+        repo,
+        'safe-note.md',
+        'safe note\n',
+        'docs: add safe note',
+        f'Operational context {sensitive_marker}\n\nMugiwara-Agent: zoro\nSigned-off-by: zoro <asistentes.mugiwara@gmail.com>',
+    )
+    registry = GitRepoRegistry(
+        repos=(GitRepoDefinition(repo_id='fixture-sensitive-body', label='Fixture sensitive body repository', scope='test', path=repo),)
+    )
+    _install_git_control_override(registry)
+
+    response = TestClient(app).get('/api/v1/git/repos/fixture-sensitive-body/commits?limit=1')
+
+    assert response.status_code == 200
+    payload = response.json()
+    commit = payload['data']['commits'][0]
+    assert commit['sha'] == sha
+    assert commit['trailers'] == {
+        'mugiwara_agent': 'zoro',
+        'signed_off_by': 'zoro <asistentes.mugiwara@gmail.com>',
+    }
+    assert 'body' not in commit
+    assert sensitive_marker not in response.text
+    assert 'Operational context' not in response.text
+    _assert_no_leakage(payload)
 
 
 def test_git_branches_lists_local_branches_only_without_remotes_or_paths(tmp_path: Path) -> None:

--- a/apps/api/tests/test_git_control_api.py
+++ b/apps/api/tests/test_git_control_api.py
@@ -53,6 +53,24 @@ def _make_repo(path: Path) -> Path:
     return path
 
 
+def _commit_file(repo: Path, filename: str, content: str, subject: str, body: str = '') -> str:
+    (repo / filename).write_text(content, encoding='utf-8')
+    _git(repo, 'add', filename)
+    if body:
+        _git(repo, 'commit', '-m', subject, '-m', body)
+    else:
+        _git(repo, 'commit', '-m', subject)
+    result = subprocess.run(
+        ['git', 'rev-parse', 'HEAD'],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
 def _assert_no_leakage(value: Any) -> None:
     serialized = str(value).lower()
     for marker in FORBIDDEN_LEAKAGE_MARKERS:
@@ -256,3 +274,178 @@ def test_git_repo_status_degrades_safely_for_unreadable_or_non_git_repo(tmp_path
     }
     assert 'not-a-git-repo-private-token' not in response.text
     _assert_no_leakage(payload)
+
+
+def test_git_commits_lists_recent_commits_with_mugiwara_trailers_and_safe_cursor(tmp_path: Path) -> None:
+    from apps.api.src.modules.git_control.registry import GitRepoDefinition, GitRepoRegistry
+
+    repo = _make_repo(tmp_path / 'commits-private-repo')
+    older_sha = _commit_file(
+        repo,
+        'agent-note.md',
+        'agent note\n',
+        'docs: add agent note',
+        'Detailed body line.\n\nMugiwara-Agent: zoro\nSigned-off-by: zoro <asistentes.mugiwara@gmail.com>',
+    )
+    newer_sha = _commit_file(repo, 'ops-note.md', 'ops note\n', 'fix: add ops note')
+    registry = GitRepoRegistry(
+        repos=(GitRepoDefinition(repo_id='fixture-commits', label='Fixture commits repository', scope='test', path=repo),)
+    )
+    _install_git_control_override(registry)
+
+    first_page = TestClient(app).get('/api/v1/git/repos/fixture-commits/commits?limit=1')
+
+    assert first_page.status_code == 200
+    payload = first_page.json()
+    assert payload['resource'] == 'git.commit_list'
+    assert payload['status'] == 'ready'
+    assert payload['meta']['read_only'] is True
+    assert payload['meta']['sanitized'] is True
+    assert payload['data']['repo_id'] == 'fixture-commits'
+    assert payload['data']['limit'] == 1
+    assert len(payload['data']['commits']) == 1
+    assert payload['data']['commits'][0]['sha'] == newer_sha
+    assert payload['data']['commits'][0]['short_sha'] == newer_sha[:12]
+    assert payload['data']['commits'][0]['subject'] == 'fix: add ops note'
+    assert payload['data']['commits'][0]['trailers'] == {'mugiwara_agent': None, 'signed_off_by': None}
+    assert payload['data']['next_cursor'] == 'offset:1'
+    _assert_no_leakage(payload)
+
+    second_page = TestClient(app).get('/api/v1/git/repos/fixture-commits/commits?limit=2&cursor=offset:1')
+    assert second_page.status_code == 200
+    second_payload = second_page.json()
+    returned_shas = [commit['sha'] for commit in second_payload['data']['commits']]
+    assert older_sha in returned_shas
+    trailer_commit = next(commit for commit in second_payload['data']['commits'] if commit['sha'] == older_sha)
+    assert trailer_commit['trailers'] == {
+        'mugiwara_agent': 'zoro',
+        'signed_off_by': 'zoro <asistentes.mugiwara@gmail.com>',
+    }
+    assert 'Detailed body line.' in trailer_commit['body']
+    assert '.git' not in second_page.text
+    _assert_no_leakage(second_payload)
+
+
+def test_git_branches_lists_local_branches_only_without_remotes_or_paths(tmp_path: Path) -> None:
+    from apps.api.src.modules.git_control.registry import GitRepoDefinition, GitRepoRegistry
+
+    repo = _make_repo(tmp_path / 'branches-private-repo')
+    main_sha = _commit_file(repo, 'main.txt', 'main\n', 'feat: main branch note')
+    _git(repo, 'switch', '-c', 'zoro/fixture-safe')
+    branch_sha = _commit_file(repo, 'branch.txt', 'branch\n', 'feat: branch note')
+    _git(repo, 'remote', 'add', 'origin', 'git@github.com:private/secret-repo.git')
+    registry = GitRepoRegistry(
+        repos=(GitRepoDefinition(repo_id='fixture-branches', label='Fixture branches repository', scope='test', path=repo),)
+    )
+    _install_git_control_override(registry)
+
+    response = TestClient(app).get('/api/v1/git/repos/fixture-branches/branches?ref=origin/main&path=/srv/private')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'git.branch_list'
+    assert payload['status'] == 'ready'
+    assert payload['data']['repo_id'] == 'fixture-branches'
+    assert payload['data']['current_branch'] == 'zoro/fixture-safe'
+    branches = {branch['name']: branch for branch in payload['data']['branches']}
+    assert set(branches) == {'main', 'zoro/fixture-safe'}
+    assert branches['main']['sha'] == main_sha
+    assert branches['main']['short_sha'] == main_sha[:12]
+    assert branches['main']['current'] is False
+    assert branches['zoro/fixture-safe']['sha'] == branch_sha
+    assert branches['zoro/fixture-safe']['current'] is True
+    assert 'origin' not in response.text
+    assert 'secret-repo' not in response.text
+    assert '/srv/private' not in response.text
+    _assert_no_leakage(payload)
+
+
+def test_git_commits_reject_invalid_limit_and_malicious_cursor_without_echo(tmp_path: Path) -> None:
+    from apps.api.src.modules.git_control.registry import GitRepoDefinition, GitRepoRegistry
+
+    repo = _make_repo(tmp_path / 'validation-private-repo')
+    registry = GitRepoRegistry(
+        repos=(GitRepoDefinition(repo_id='fixture-validation', label='Fixture validation repository', scope='test', path=repo),)
+    )
+    _install_git_control_override(registry)
+
+    bad_limit = TestClient(app).get('/api/v1/git/repos/fixture-validation/commits?limit=999')
+    bad_cursor = TestClient(app).get('/api/v1/git/repos/fixture-validation/commits?cursor=HEAD..main:/srv/private-token')
+
+    assert bad_limit.status_code == 400
+    assert bad_limit.json()['detail']['code'] == 'git_invalid_limit'
+    assert '999' not in bad_limit.text
+    assert bad_cursor.status_code == 400
+    assert bad_cursor.json()['detail']['code'] == 'git_invalid_cursor'
+    assert 'HEAD' not in bad_cursor.text
+    assert '/srv/private-token' not in bad_cursor.text
+    _assert_no_leakage(bad_limit.json())
+    _assert_no_leakage(bad_cursor.json())
+
+
+def test_git_commits_unknown_repo_and_degraded_repo_are_sanitized(tmp_path: Path) -> None:
+    from apps.api.src.modules.git_control.registry import GitRepoDefinition, GitRepoRegistry
+
+    not_git = tmp_path / 'not-git-private-token'
+    not_git.mkdir()
+    registry = GitRepoRegistry(
+        repos=(GitRepoDefinition(repo_id='fixture-broken-commits', label='Fixture broken repository', scope='test', path=not_git),)
+    )
+    _install_git_control_override(registry)
+
+    unknown = TestClient(app).get('/api/v1/git/repos/unknown-private-token/commits?cursor=offset:0')
+    degraded = TestClient(app).get('/api/v1/git/repos/fixture-broken-commits/commits')
+
+    assert unknown.status_code == 404
+    assert unknown.json()['detail']['code'] == 'git_repo_not_found'
+    assert 'unknown-private-token' not in unknown.text
+    assert degraded.status_code == 200
+    payload = degraded.json()
+    assert payload['resource'] == 'git.commit_list'
+    assert payload['status'] == 'source_unavailable'
+    assert payload['data'] == {
+        'repo_id': 'fixture-broken-commits',
+        'commits': [],
+        'limit': 25,
+        'next_cursor': None,
+        'source_state': 'unknown',
+    }
+    assert 'not-git-private-token' not in degraded.text
+    _assert_no_leakage(unknown.json())
+    _assert_no_leakage(payload)
+
+
+def test_git_read_model_invocations_stay_allowlisted_and_hardened(monkeypatch, tmp_path: Path) -> None:
+    from apps.api.src.modules.git_control.git_adapter import GitReadAdapter
+    from apps.api.src.modules.git_control.registry import GitRepoDefinition
+
+    captured: list[dict[str, Any]] = []
+
+    def fake_run(args, **kwargs):
+        captured.append({'args': args, 'kwargs': kwargs})
+        if 'branch' in args:
+            return SimpleNamespace(stdout='main\x00*\x00aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n')
+        return SimpleNamespace(stdout='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\x1faaaaaaaaaaaa\x1ffixture\x1ffixture@example.invalid\x1f2026-04-27T10:00:00+00:00\x1f2026-04-27T10:00:00+00:00\x1ffeat: safe\x1fbody\x1e')
+
+    monkeypatch.setattr('apps.api.src.modules.git_control.git_adapter.subprocess.run', fake_run)
+    adapter = GitReadAdapter()
+    repo = GitRepoDefinition(repo_id='fixture-policy', label='Fixture policy repository', scope='test', path=tmp_path)
+
+    adapter.list_commits(repo, limit=1, cursor=None)
+    adapter.list_branches(repo)
+
+    assert len(captured) == 2
+    for call in captured:
+        args = call['args']
+        kwargs = call['kwargs']
+        assert args[0] == 'git'
+        assert '--no-optional-locks' in args
+        assert 'core.fsmonitor=false' in args
+        assert 'core.hooksPath=/dev/null' in args
+        assert kwargs['shell'] is False
+        assert kwargs['cwd'] == tmp_path
+        assert kwargs['timeout'] == 2.0
+        assert kwargs['env']['GIT_CONFIG_GLOBAL'] == '/dev/null'
+        assert kwargs['env']['GIT_CONFIG_SYSTEM'] == '/dev/null'
+        assert kwargs['env']['GIT_CONFIG_NOSYSTEM'] == '1'
+        assert not any(command in args for command in ['checkout', 'reset', 'commit', 'push', 'pull', 'fetch', 'stash', 'merge', 'rebase'])

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -106,7 +106,7 @@
 - usar Git solo como lectura host-adjacent acotada para status, commits y ramas locales, con `subprocess.run` en lista de argumentos, `shell=False`, `cwd` fijo, timeout, entorno mínimo, config global/system nula y overrides `core.fsmonitor=false`/`core.hooksPath=/dev/null`
 - no ejecutar acciones destructivas ni remotas (`checkout`, `reset`, `commit`, `push`, `pull`, `fetch`, `stash`, `merge`, `rebase`)
 - no exponer rutas host, nombres de fichero de status, diffs, remotes privados, stdout/stderr, stack traces ni errores crudos
-- commits serializan solo hashes, autor/email saneado, fechas, subject/body acotado y trailers `Mugiwara-Agent`/`Signed-off-by`
+- commits serializan solo hashes, autor/email saneado, fechas, subject y trailers allowlisteados `Mugiwara-Agent`/`Signed-off-by`; el cuerpo libre del commit no se publica y solo se usa internamente para extraer esos trailers
 - branches serializa solo ramas locales con nombre saneado, `current`, sha y short_sha; no remotes ni refs arbitrarias
 - degradar repos ausentes/corruptos/ilegibles a `source_unavailable` con payload saneado
 - bloquear la frontera backend con `npm run verify:git-control-backend-policy`

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -99,10 +99,15 @@
 ### `git_control`
 - exponer `GET /api/v1/git/repos` como índice read-only de repositorios Git locales allowlisteados por una backend-owned registry
 - exponer `GET /api/v1/git/repos/{repo_id}/status` como estado resumido de un repo allowlisteado
+- exponer `GET /api/v1/git/repos/{repo_id}/commits?limit=&cursor=` como historial reciente paginado de commits saneados
+- exponer `GET /api/v1/git/repos/{repo_id}/branches` como listado de ramas locales saneadas
 - aceptar únicamente `repo_id` lógico desde cliente; nunca paths, URLs, remotes, comandos, refs arbitrarias ni revspecs
-- usar Git solo como lectura host-adjacent acotada para status summary, con `subprocess.run` en lista de argumentos, `shell=False`, `cwd` fijo, timeout, entorno mínimo y comandos read-only allowlisteados
+- validar `limit` como entero `1..50` y `cursor` como token opaco `offset:<n>`; no resolver revsets, SHA/ref cliente ni rangos arbitrarios
+- usar Git solo como lectura host-adjacent acotada para status, commits y ramas locales, con `subprocess.run` en lista de argumentos, `shell=False`, `cwd` fijo, timeout, entorno mínimo, config global/system nula y overrides `core.fsmonitor=false`/`core.hooksPath=/dev/null`
 - no ejecutar acciones destructivas ni remotas (`checkout`, `reset`, `commit`, `push`, `pull`, `fetch`, `stash`, `merge`, `rebase`)
-- no exponer rutas host, nombres de fichero, diffs, remotes privados, stdout/stderr, stack traces ni errores crudos
+- no exponer rutas host, nombres de fichero de status, diffs, remotes privados, stdout/stderr, stack traces ni errores crudos
+- commits serializan solo hashes, autor/email saneado, fechas, subject/body acotado y trailers `Mugiwara-Agent`/`Signed-off-by`
+- branches serializa solo ramas locales con nombre saneado, `current`, sha y short_sha; no remotes ni refs arbitrarias
 - degradar repos ausentes/corruptos/ilegibles a `source_unavailable` con payload saneado
 - bloquear la frontera backend con `npm run verify:git-control-backend-policy`
 

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -194,7 +194,37 @@ Uso:
 - estado read-only resumido de un repo allowlisteado
 - `dirty` solo indica conteos; no serializa nombres de archivo ni contenido
 - repos ilegibles/no Git degradan a `source_unavailable` con `unknown` y campos nulos
-- no hay commits, branches, diffs ni working-tree diff en esta microfase
+- no hay diffs ni working-tree diff en esta microfase
+
+### `git.commit_list`
+Campos esperados:
+- `repo_id`
+- `commits[]` con `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`, `committed_at`, `subject`, `body` y `trailers`
+- `trailers.mugiwara_agent`
+- `trailers.signed_off_by`
+- `limit`
+- `next_cursor` opaco `offset:<n>` o `null`
+- `source_state`
+
+Uso:
+- historial reciente paginado de un repo allowlisteado
+- el cliente solo aporta `repo_id`, `limit` y `cursor`; nunca paths, refs, SHA, revsets, remotes ni comandos
+- `limit` se valida como `1..50`; `cursor` se valida estrictamente como token backend-owned `offset:<n>`
+- no serializa diffs, nombres de ficheros tocados, remotes, rutas host, stdout/stderr ni errores crudos
+- repos ilegibles/no Git degradan a `source_unavailable` con lista vacía y `source_state=unknown`
+
+### `git.branch_list`
+Campos esperados:
+- `repo_id`
+- `current_branch` saneada o `null`
+- `branches[]` con `name`, `current`, `sha` y `short_sha`
+- `source_state`
+
+Uso:
+- listar solo ramas locales del repo allowlisteado
+- no acepta `ref`/`branch`/`revspec` cliente; cualquier query ajena no controla la invocación Git ni se ecoa
+- no serializa remotes (`origin/*`), URLs, rutas host, stdout/stderr ni errores crudos
+- nombres de rama no saneables se omiten
 
 ### `memory.agent_summary`
 Campos esperados:

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -199,9 +199,10 @@ Uso:
 ### `git.commit_list`
 Campos esperados:
 - `repo_id`
-- `commits[]` con `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`, `committed_at`, `subject`, `body` y `trailers`
+- `commits[]` con `sha`, `short_sha`, `author_name`, `author_email`, `authored_at`, `committed_at`, `subject` y `trailers`
 - `trailers.mugiwara_agent`
 - `trailers.signed_off_by`
+- El cuerpo libre del commit no forma parte del contrato público; se lee solo internamente para extraer trailers allowlisteados.
 - `limit`
 - `next_cursor` opaco `offset:<n>` o `null`
 - `source_state`

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -167,13 +167,14 @@ Este check confirma que el header mantiene:
 - fallback saneado sin errores crudos ni rutas host.
 
 ## Git control backend
-Issue #40.1 añade solo backend `GET /api/v1/git/repos` y `GET /api/v1/git/repos/{repo_id}/status`.
+Issue #40.1 añade backend `GET /api/v1/git/repos` y `GET /api/v1/git/repos/{repo_id}/status`; Issue #40.2 amplía la misma frontera con `GET /api/v1/git/repos/{repo_id}/commits?limit=&cursor=` y `GET /api/v1/git/repos/{repo_id}/branches`.
 
 1. No requiere variable runtime nueva: la registry Git es backend-owned y deny-by-default.
-2. El cliente opera solo con `repo_id`; no existen parámetros `path`, `url`, `remote`, `command`, `ref` ni `revspec`.
+2. El cliente opera solo con `repo_id`; para commits solo puede aportar `limit` `1..50` y cursor opaco `offset:<n>` generado por backend. No existen parámetros `path`, `url`, `remote`, `command`, `ref`, `branch`, `sha` ni `revspec` controlando Git.
 3. Las rutas reales de la registry pueden existir internamente en backend, pero no se serializan en API, UI, logs públicos, errores ni docs públicas.
-4. La lectura Git es status-only: no hay commits, branches, diffs ni acciones remotas/destructivas en esta microfase.
-5. Antes de cerrar cambios que toquen esta frontera, ejecutar:
+4. La lectura Git de 40.2 es status/commits/branches-locales: no hay diffs, working-tree diff, remotes ni acciones destructivas/remotas.
+5. Toda invocación Git mantiene `shell=False`, cwd fijo, timeout, env mínimo, `GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_SYSTEM=/dev/null`, `GIT_CONFIG_NOSYSTEM=1`, `core.fsmonitor=false` y `core.hooksPath=/dev/null`.
+6. Antes de cerrar cambios que toquen esta frontera, ejecutar:
 
 ```bash
 npm run verify:git-control-backend-policy

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -172,7 +172,7 @@ Issue #40.1 añade backend `GET /api/v1/git/repos` y `GET /api/v1/git/repos/{rep
 1. No requiere variable runtime nueva: la registry Git es backend-owned y deny-by-default.
 2. El cliente opera solo con `repo_id`; para commits solo puede aportar `limit` `1..50` y cursor opaco `offset:<n>` generado por backend. No existen parámetros `path`, `url`, `remote`, `command`, `ref`, `branch`, `sha` ni `revspec` controlando Git.
 3. Las rutas reales de la registry pueden existir internamente en backend, pero no se serializan en API, UI, logs públicos, errores ni docs públicas.
-4. La lectura Git de 40.2 es status/commits/branches-locales: no hay diffs, working-tree diff, remotes ni acciones destructivas/remotas.
+4. La lectura Git de 40.2 es status/commits/branches-locales: no hay diffs, working-tree diff, remotes ni acciones destructivas/remotas. La lista de commits publica metadata mínima y trailers allowlisteados; no publica el cuerpo libre del commit.
 5. Toda invocación Git mantiene `shell=False`, cwd fijo, timeout, env mínimo, `GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_SYSTEM=/dev/null`, `GIT_CONFIG_NOSYSTEM=1`, `core.fsmonitor=false` y `core.hooksPath=/dev/null`.
 6. Antes de cerrar cambios que toquen esta frontera, ejecutar:
 

--- a/openspec/issue-40-2-git-commits-branches-verify-checklist.md
+++ b/openspec/issue-40-2-git-commits-branches-verify-checklist.md
@@ -1,0 +1,42 @@
+# Issue #40.2 — Git commits/branches backend verify checklist
+
+## Scope
+- [x] `main` actualizado antes de empezar.
+- [x] Rama creada: `zoro/issue-40-2-git-commits-branches`.
+- [x] Revisados PR #89, Issue #40, checklist 40.1, `.engram/issue-40-1-closeout.md`, docs API/read-models/runtime, guardrail `verify:git-control-backend-policy` y Project Summary del vault.
+- [x] Confirmado que el Project Summary del vault ya fue actualizado tras 40.1.
+
+## TDD
+- [x] Tests rojos escritos primero en `apps/api/tests/test_git_control_api.py`.
+- [x] Rojo observado: endpoints `/commits` y `/branches` devolvían 404 y `GitReadAdapter` no existía.
+- [x] Implementación añadida después del rojo.
+
+## Implementación
+- [x] Endpoint `GET /api/v1/git/repos/{repo_id}/commits?limit=&cursor=` añadido.
+- [x] Endpoint `GET /api/v1/git/repos/{repo_id}/branches` añadido.
+- [x] Cliente solo usa `repo_id`; commits solo acepta `limit` y cursor opaco `offset:<n>`.
+- [x] Límites inválidos y cursor/revspec malicioso devuelven error saneado sin ecoar input.
+- [x] Commits serializan hashes, autor/email saneado, fechas, subject/body acotado y trailers `Mugiwara-Agent`/`Signed-off-by`.
+- [x] Branches serializa únicamente ramas locales saneadas; sin remotes, refs arbitrarias ni discovery.
+- [x] Sin UI, sin diffs, sin working tree diff y sin commit detail por SHA.
+- [x] Sin checkout/reset/commit/push/pull/fetch/stash/merge/rebase.
+- [x] Git usa `shell=False`, cwd fijo, timeout, env mínimo, `GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_SYSTEM=/dev/null`, `GIT_CONFIG_NOSYSTEM=1`, `-c core.fsmonitor=false`, `-c core.hooksPath=/dev/null`.
+- [x] Payload no serializa rutas host, remotes privados, stdout/stderr, stack traces ni errores crudos.
+- [x] Repos desconocidos o ilegibles degradan con errores/payload saneados.
+
+## Guardrails/docs
+- [x] Actualizado `npm run verify:git-control-backend-policy` para status/commits/branches.
+- [x] Actualizados `docs/api-modules.md`, `docs/read-models.md`, `docs/runtime-config.md`.
+- [x] Actualizado `apps/api/src/modules/git_control/AGENTS.md`.
+- [x] Actualizado `openspec/issue-40-git-control-page-plan.md`.
+- [x] Añadido `.engram/issue-40-2-closeout.md`.
+
+## Verify requerido
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_git_control_api.py -q`
+- [x] `npm run verify:git-control-backend-policy`
+- [x] `npm run verify:perimeter-policy`
+- [x] `git diff --check`
+
+## Review esperado
+- Franky: operabilidad, subprocess Git policy para `log`/`branch`, timeout/cwd/env mínimo, no red en request y mantenibilidad del guardrail.
+- Chopper: seguridad, allowlist, validación estricta de cursor/límites, no leakage, no refs/revspecs cliente y errores saneados.

--- a/openspec/issue-40-2-git-commits-branches-verify-checklist.md
+++ b/openspec/issue-40-2-git-commits-branches-verify-checklist.md
@@ -16,7 +16,7 @@
 - [x] Endpoint `GET /api/v1/git/repos/{repo_id}/branches` añadido.
 - [x] Cliente solo usa `repo_id`; commits solo acepta `limit` y cursor opaco `offset:<n>`.
 - [x] Límites inválidos y cursor/revspec malicioso devuelven error saneado sin ecoar input.
-- [x] Commits serializan hashes, autor/email saneado, fechas, subject/body acotado y trailers `Mugiwara-Agent`/`Signed-off-by`.
+- [x] Commits serializan hashes, autor/email saneado, fechas, subject y trailers `Mugiwara-Agent`/`Signed-off-by`; el cuerpo libre no se publica.
 - [x] Branches serializa únicamente ramas locales saneadas; sin remotes, refs arbitrarias ni discovery.
 - [x] Sin UI, sin diffs, sin working tree diff y sin commit detail por SHA.
 - [x] Sin checkout/reset/commit/push/pull/fetch/stash/merge/rebase.

--- a/openspec/issue-40-git-control-page-plan.md
+++ b/openspec/issue-40-git-control-page-plan.md
@@ -3,7 +3,8 @@
 ## Estado
 - Issue: [#40 Add Git control page for local repository history and diffs](https://github.com/asistentes-mugiwara/mugiwara-control-panel/issues/40)
 - Planificación: PR #88 cerrada.
-- Microfase 40.1: `zoro/issue-40-1-git-registry-status`, backend-only registry/status implementado.
+- Microfase 40.1: PR #89 mergeada; backend-only registry/status implementado.
+- Microfase 40.2: `zoro/issue-40-2-git-commits-branches`, backend-only commits/branches read model en implementación.
 - Tipo de fase: planificación SDD inicial + primera microfase backend runtime.
 - Fecha: 2026-04-27
 
@@ -122,13 +123,15 @@ El API debe indicar `omitted_reason`, `truncated`, `redacted` y contadores; no d
 **Review:** Franky + Chopper.
 
 ### 40.2 — Backend commits + branches read model
+**Estado:** implementado en rama `zoro/issue-40-2-git-commits-branches`.
+
 **Objetivo:** listar commits recientes, trailers y ramas locales seguras.
 
-**Incluye:** `GET /commits`, `GET /branches`, parsing de trailers `Mugiwara-Agent`/`Signed-off-by`, límites de paginación, cursor seguro, validación de SHA/cursor.
+**Incluye:** `GET /api/v1/git/repos/{repo_id}/commits?limit=&cursor=`, `GET /api/v1/git/repos/{repo_id}/branches`, parsing de trailers `Mugiwara-Agent`/`Signed-off-by`, límites de paginación `1..50`, cursor opaco `offset:<n>`, validación estricta de cursor y ausencia de refs/SHA/revspecs cliente. Git mantiene hardening de 40.1 y añade solo subcomandos read-only `log` y `branch`.
 
-**No incluye:** diff content ni working tree diff.
+**No incluye:** diff content, commit detail por SHA, refs/remotes, working tree diff ni UI.
 
-**TDD/verify:** fixtures de repos temporales con trailers, mensajes multilinea, autores, ramas; rechazo de revspecs maliciosas; no leakage de paths/remotes; guardrail actualizado.
+**TDD/verify:** fixtures de repos temporales con trailers, mensajes multilinea, autores, ramas; rechazo de revspecs maliciosas vía cursor; no leakage de paths/remotes; guardrail actualizado.
 
 **Review:** Franky + Chopper.
 

--- a/openspec/issue-40-git-control-page-plan.md
+++ b/openspec/issue-40-git-control-page-plan.md
@@ -65,7 +65,7 @@ La registry puede contener rutas absolutas internamente, pero esas rutas no debe
 - `GET /api/v1/git/repos`
   - Lista repos allowlisteados con rama actual, último commit resumido, estado clean/dirty, ahead/behind saneado si está disponible sin red, y `source_state`.
 - `GET /api/v1/git/repos/{repo_id}/commits?limit=&cursor=`
-  - Historial paginado con límite máximo bajo, hashes, autor/email opcionalmente saneado, fechas, asunto/body resumido y trailers.
+  - Historial paginado con límite máximo bajo, hashes, autor/email opcionalmente saneado, fechas, asunto y trailers; el cuerpo libre del commit se usa solo internamente para extraer trailers y no se publica.
 - `GET /api/v1/git/repos/{repo_id}/branches`
   - Ramas/refs locales allowlisted y rama actual; sin resolver refs arbitrarias desde cliente.
 - `GET /api/v1/git/repos/{repo_id}/commits/{sha}`

--- a/scripts/check-git-control-backend-policy.mjs
+++ b/scripts/check-git-control-backend-policy.mjs
@@ -204,6 +204,9 @@ const requiredTestSnippets = [
   'test_git_unknown_repo_id_returns_sanitized_not_found_without_echoing_input',
   'test_git_repo_status_degrades_safely_for_unreadable_or_non_git_repo',
   'test_git_commits_lists_recent_commits_with_mugiwara_trailers_and_safe_cursor',
+  'test_git_commits_do_not_expose_sensitive_commit_body_while_extracting_trailers',
+  'SYNTHETIC-SECRET-COMMIT-BODY-MARKER',
+  "assert 'body' not in commit",
   'Mugiwara-Agent: zoro',
   'Signed-off-by: zoro <asistentes.mugiwara@gmail.com>',
   'test_git_branches_lists_local_branches_only_without_remotes_or_paths',
@@ -224,6 +227,7 @@ mustInclude(readModelsDoc, 'git.repo_index', 'read models doc')
 mustInclude(readModelsDoc, 'git.repo_status', 'read models doc')
 mustInclude(readModelsDoc, 'git.commit_list', 'read models doc')
 mustInclude(readModelsDoc, 'git.branch_list', 'read models doc')
+mustInclude(readModelsDoc, 'El cuerpo libre del commit no forma parte del contrato público', 'read models doc')
 mustInclude(runtimeConfigDoc, 'Git control backend', 'runtime config doc')
 
 if (failures.length > 0) {

--- a/scripts/check-git-control-backend-policy.mjs
+++ b/scripts/check-git-control-backend-policy.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 /**
- * Static guardrail for Issue #40.1 Git control backend policy.
+ * Static guardrail for Issue #40 Git control backend policy.
  *
- * Keeps Git control as a backend-owned read-only registry/status surface, not a
- * filesystem browser or Git console.
+ * Keeps Git control as a backend-owned read-only registry/status/commits/branches
+ * surface, not a filesystem browser or Git console.
  */
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
@@ -79,8 +79,12 @@ mustInclude(mainPy, 'app.include_router(git_control_router)', 'FastAPI main')
 mustInclude(routerPy, "router = APIRouter(prefix='/api/v1/git', tags=['git_control'])", 'git_control router')
 mustInclude(routerPy, "@router.get('/repos')", 'git_control router')
 mustInclude(routerPy, "@router.get('/repos/{repo_id}/status')", 'git_control router')
+mustInclude(routerPy, "@router.get('/repos/{repo_id}/commits')", 'git_control router')
+mustInclude(routerPy, "@router.get('/repos/{repo_id}/branches')", 'git_control router')
 mustInclude(routerPy, "resource='git.repo_index'", 'git_control router')
 mustInclude(routerPy, "resource='git.repo_status'", 'git_control router')
+mustInclude(routerPy, "resource='git.commit_list'", 'git_control router')
+mustInclude(routerPy, "resource='git.branch_list'", 'git_control router')
 mustInclude(routerPy, "'read_only': True", 'git_control router')
 mustInclude(routerPy, "'sanitized': True", 'git_control router')
 mustInclude(routerPy, "'source': GIT_CONTROL_SOURCE_LABEL", 'git_control router')
@@ -96,7 +100,11 @@ const requiredDomainSnippets = [
   'GIT_SAFE_CONFIG_ARGS',
   'core.fsmonitor=false',
   'core.hooksPath=/dev/null',
-  "READ_ONLY_GIT_COMMANDS = frozenset({'status'})",
+  'GIT_COMMITS_DEFAULT_LIMIT',
+  'GIT_COMMITS_MAX_LIMIT',
+  'GIT_CURSOR_PATTERN',
+  'GIT_SHA_PATTERN',
+  "READ_ONLY_GIT_COMMANDS = frozenset({'status', 'log', 'branch'})",
   'FORBIDDEN_GIT_COMMANDS = frozenset',
   "'checkout'",
   "'reset'",
@@ -133,10 +141,16 @@ const requiredAdapterSnippets = [
   '*GIT_SAFE_CONFIG_ARGS',
   '_extract_git_command',
   "'status'",
+  "'log'",
+  "'branch'",
   "'--porcelain=v1'",
   "'--branch'",
   "'--untracked-files=all'",
   "'--no-renames'",
+  "'--max-count={limit}'",
+  "'--skip={offset}'",
+  "'--format=%H%x1f%h%x1f%an%x1f%ae%x1f%aI%x1f%cI%x1f%s%x1f%B%x1e'",
+  "'--format=%(refname:short)%00%(HEAD)%00%(objectname)'",
   'READ_ONLY_GIT_COMMANDS',
   'FORBIDDEN_GIT_COMMANDS',
 ]
@@ -189,6 +203,14 @@ const requiredTestSnippets = [
   'assert not marker.exists()',
   'test_git_unknown_repo_id_returns_sanitized_not_found_without_echoing_input',
   'test_git_repo_status_degrades_safely_for_unreadable_or_non_git_repo',
+  'test_git_commits_lists_recent_commits_with_mugiwara_trailers_and_safe_cursor',
+  'Mugiwara-Agent: zoro',
+  'Signed-off-by: zoro <asistentes.mugiwara@gmail.com>',
+  'test_git_branches_lists_local_branches_only_without_remotes_or_paths',
+  'test_git_commits_reject_invalid_limit_and_malicious_cursor_without_echo',
+  'HEAD..main:/srv/private-token',
+  'test_git_commits_unknown_repo_and_degraded_repo_are_sanitized',
+  'test_git_read_model_invocations_stay_allowlisted_and_hardened',
   '_assert_no_leakage',
   '.env',
   'super-secret-value',
@@ -200,6 +222,8 @@ mustInclude(apiModulesDoc, 'GET /api/v1/git/repos/{repo_id}/status', 'API module
 mustInclude(apiModulesDoc, 'backend-owned registry', 'API modules doc')
 mustInclude(readModelsDoc, 'git.repo_index', 'read models doc')
 mustInclude(readModelsDoc, 'git.repo_status', 'read models doc')
+mustInclude(readModelsDoc, 'git.commit_list', 'read models doc')
+mustInclude(readModelsDoc, 'git.branch_list', 'read models doc')
 mustInclude(runtimeConfigDoc, 'Git control backend', 'runtime config doc')
 
 if (failures.length > 0) {


### PR DESCRIPTION
## Objetivo
Implementar microfase 40.2 backend-only de Issue #40: read models/endpoints Git read-only para commits recientes y branches locales sobre la registry allowlisteada existente de 40.1.

## Alcance
- Añade `GET /api/v1/git/repos/{repo_id}/commits?limit=&cursor=`.
- Añade `GET /api/v1/git/repos/{repo_id}/branches`.
- Añade `GitReadAdapter` con subcomandos read-only `log` y `branch`, manteniendo status.
- Extrae trailers `Mugiwara-Agent` y `Signed-off-by` de commits.
- Valida `limit` como `1..50` y `cursor` como token opaco `offset:<n>`.
- Añade tests backend para repo desconocido, límites inválidos, cursor/revspec malicioso, trailers, no leakage, ramas locales y degradación segura.
- Actualiza guardrail `verify:git-control-backend-policy`.
- Actualiza docs API/read-models/runtime, OpenSpec/checklist y Engram.
- Actualiza Project Summary del vault en commit separado `0699749` del repo vault.

## Restricciones respetadas
- Sin UI.
- Sin diffs ni working tree diff.
- Cliente solo usa `repo_id`; nunca paths.
- No hay discovery arbitrario.
- No hay refs/SHA/revspecs cliente ni remotes.
- Sin acciones Git destructivas/remotas: no checkout/reset/commit/push/pull/fetch/stash/merge/rebase.
- Mantiene hardening Git de 40.1: `shell=False`, cwd fijo, timeout, env mínimo, `GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_SYSTEM=/dev/null`, `GIT_CONFIG_NOSYSTEM=1`, `-c core.fsmonitor=false`, `-c core.hooksPath=/dev/null`.
- No se serializan rutas host, remotes privados, stdout/stderr, stack traces, errores crudos, filenames de status ni diffs.

## Verify de Zoro
- `PYTHONPATH=. pytest apps/api/tests/test_git_control_api.py -q` ✅ (`11 passed`)
- `npm run verify:git-control-backend-policy` ✅
- `npm run verify:perimeter-policy` ✅
- `git diff --check` ✅

## Review solicitada
- Franky: operabilidad, subprocess Git policy para `log`/`branch`, timeout/cwd/env mínimo, no red en request, mantenibilidad del guardrail.
- Chopper: seguridad, allowlist, validación estricta de cursor/límites, no refs/revspecs cliente, no leakage, errores saneados.

No auto-merge hasta respuesta de Franky + Chopper.
