### PR TITLE
feat: add safe git commit diff endpoints

### DIFF
--- a/.engram/issue-40-3-closeout.md
+++ b/.engram/issue-40-3-closeout.md
@@ -1,0 +1,24 @@
+# Issue #40.3 closeout — commit detail + safe diff backend
+
+## Resultado
+Microfase backend-only 40.3 implementada en rama `zoro/issue-40-3-commit-detail-safe-diff`.
+
+## Alcance decidido
+No se dividió más: commit detail y safe diff comparten validación de SHA, lectura `git show`, stats por fichero y política de saneado. Quedan fuera UI, working-tree diff, refs/rangos arbitrarios y cualquier acción Git destructiva/remota.
+
+## Decisiones técnicas
+- El cliente solo puede enviar `repo_id` allowlisteado y SHA completo hex SHA-1/SHA-256 devuelto por el backend.
+- El cuerpo libre del commit sigue sin ser público; `%B` se usa solo internamente para trailers `Mugiwara-Agent` y `Signed-off-by`.
+- `git show` se permite como subcomando read-only bajo hardening 40.1: `shell=False`, cwd fijo, timeout, env mínimo, `GIT_CONFIG_*`, `core.fsmonitor=false`, `core.hooksPath=/dev/null` y `--no-ext-diff`.
+- Los diffs omiten paths sensibles y binarios, redactan tokens/rutas host en líneas permitidas y truncan por fichero/total con indicadores explícitos.
+
+## Verify
+- `python3 -m py_compile ...` módulos Git control + tests.
+- `PYTHONPATH=. pytest apps/api/tests/test_git_control_api.py -q` -> 17 passed.
+- `npm run verify:git-control-backend-policy` -> passed.
+- `npm run verify:perimeter-policy` -> passed.
+- `git diff --check` -> OK.
+
+## Riesgos/follow-ups
+- 40.4 puede consumir estos endpoints desde UI server-only; debe mantener copy visible de solo lectura/redacción/truncado.
+- 40.5 working-tree diff sigue siendo más sensible que commit history y debe tratarse como microfase propia, probablemente summary-first.

--- a/apps/api/src/modules/git_control/AGENTS.md
+++ b/apps/api/src/modules/git_control/AGENTS.md
@@ -9,6 +9,8 @@ Módulo backend read-only para consultar repositorios Git locales allowlisteados
 - Sin discovery arbitrario de filesystem ni selección dinámica de repos desde request.
 - Sin acciones Git destructivas o remotas: no checkout/reset/commit/push/pull/fetch/stash/merge/rebase.
 - Si se invoca Git, usar `subprocess.run` con lista de argumentos, `shell=False`, `cwd` fijo, timeout y entorno mínimo.
-- Serializar solo estado resumido, commits recientes y ramas locales: clean/dirty, conteos, rama actual saneada, hashes/fechas/autores saneados y trailers `Mugiwara-Agent`/`Signed-off-by`. Sin diffs, filenames de status, rutas host, remotes, stdout/stderr, stack traces ni errores crudos.
-- Para commits, aceptar solo `limit` `1..50` y cursor opaco `offset:<n>` generado por backend; no aceptar SHA/ref/revspec cliente ni revsets arbitrarios.
+- Serializar solo estado resumido, commits recientes, ramas locales, detalle de commit y diff seguro: clean/dirty, conteos, rama actual saneada, hashes/fechas/autores saneados, trailers `Mugiwara-Agent`/`Signed-off-by`, stats por fichero saneado y líneas de diff truncadas/redactadas. Sin cuerpo libre de commit, filenames de status, rutas host, remotes, stdout/stderr, stack traces ni errores crudos.
+- Para commits, aceptar solo `limit` `1..50` y cursor opaco `offset:<n>` generado por backend; para detalle/diff aceptar solo SHA completo hex SHA-1/SHA-256. No aceptar refs, rangos ni revspecs arbitrarios.
 - Degradar repos ausentes, corruptos o ilegibles a estados explícitos y saneados.
+
+- Para diffs de commit, omitir paths sensibles (`.env`, credenciales, logs, dumps, DBs), omitir binarios, redactar contenido con tokens/rutas host, truncar por fichero/total y exponer solo contadores/razones genéricas (`sensitive_path`, `binary`).

--- a/apps/api/src/modules/git_control/domain.py
+++ b/apps/api/src/modules/git_control/domain.py
@@ -8,6 +8,10 @@ GIT_CONTROL_SOURCE_LABEL = 'backend-owned-git-registry'
 GIT_COMMAND_TIMEOUT_SECONDS = 2.0
 GIT_COMMITS_DEFAULT_LIMIT = 25
 GIT_COMMITS_MAX_LIMIT = 50
+GIT_DIFF_MAX_FILES = 25
+GIT_DIFF_MAX_LINES_PER_FILE = 120
+GIT_DIFF_MAX_TOTAL_LINES = 400
+GIT_DIFF_MAX_LINE_LENGTH = 240
 GIT_CURSOR_PATTERN = re.compile(r'^offset:(0|[1-9][0-9]{0,5})$')
 GIT_SHA_PATTERN = re.compile(r'^[0-9a-f]{40}$|^[0-9a-f]{64}$')
 GIT_MINIMAL_ENV = {
@@ -24,7 +28,7 @@ GIT_SAFE_CONFIG_ARGS = (
     '-c',
     'core.hooksPath=/dev/null',
 )
-READ_ONLY_GIT_COMMANDS = frozenset({'status', 'log', 'branch'})
+READ_ONLY_GIT_COMMANDS = frozenset({'status', 'log', 'branch', 'show'})
 FORBIDDEN_GIT_COMMANDS = frozenset(
     {
         'checkout',
@@ -111,3 +115,44 @@ class GitBranchSummary:
             'sha': self.sha,
             'short_sha': self.short_sha,
         }
+
+
+@dataclass(frozen=True)
+class GitCommitFileSummary:
+    path: str | None
+    change_type: str
+    additions: int | None
+    deletions: int | None
+    binary: bool
+    omitted: bool
+    omitted_reason: str | None
+
+    def to_public(self) -> dict:
+        return {
+            'path': self.path,
+            'change_type': self.change_type,
+            'additions': self.additions,
+            'deletions': self.deletions,
+            'binary': self.binary,
+            'omitted': self.omitted,
+            'omitted_reason': self.omitted_reason,
+        }
+
+
+@dataclass(frozen=True)
+class GitCommitDiffFile:
+    summary: GitCommitFileSummary
+    truncated: bool
+    redacted: bool
+    lines: tuple[dict[str, str], ...]
+
+    def to_public(self) -> dict:
+        payload = self.summary.to_public()
+        payload.update(
+            {
+                'truncated': self.truncated,
+                'redacted': self.redacted,
+                'lines': list(self.lines),
+            }
+        )
+        return payload

--- a/apps/api/src/modules/git_control/git_adapter.py
+++ b/apps/api/src/modules/git_control/git_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 import subprocess
 
 from .domain import (
@@ -9,10 +10,16 @@ from .domain import (
     GIT_COMMITS_DEFAULT_LIMIT,
     GIT_COMMITS_MAX_LIMIT,
     GIT_CURSOR_PATTERN,
+    GIT_DIFF_MAX_FILES,
+    GIT_DIFF_MAX_LINE_LENGTH,
+    GIT_DIFF_MAX_LINES_PER_FILE,
+    GIT_DIFF_MAX_TOTAL_LINES,
     GIT_MINIMAL_ENV,
     GIT_SAFE_CONFIG_ARGS,
     GIT_SHA_PATTERN,
     GitBranchSummary,
+    GitCommitDiffFile,
+    GitCommitFileSummary,
     GitCommitSummary,
     GitRepoStatus,
     READ_ONLY_GIT_COMMANDS,
@@ -25,6 +32,10 @@ class GitInvalidCursor(ValueError):
 
 
 class GitInvalidLimit(ValueError):
+    pass
+
+
+class GitInvalidSha(ValueError):
     pass
 
 
@@ -62,6 +73,29 @@ class GitReadAdapter:
             return [], None, 'unknown'
         current = next((branch.name for branch in branches if branch.current), None)
         return branches, current, 'live'
+
+    def get_commit_detail(self, repo: GitRepoDefinition, *, sha: str) -> tuple[GitCommitSummary | None, list[GitCommitFileSummary], str]:
+        _validate_sha(sha)
+        try:
+            commit_output = _run_git_commit_detail(repo.path, sha=sha)
+            stats_output = _run_git_commit_numstat(repo.path, sha=sha)
+            commits = _parse_git_log(commit_output)
+            if not commits:
+                return None, [], 'unknown'
+            return commits[0], _parse_numstat(stats_output), 'live'
+        except Exception:
+            return None, [], 'unknown'
+
+    def get_commit_diff(self, repo: GitRepoDefinition, *, sha: str) -> tuple[list[GitCommitDiffFile], bool, bool, int, str]:
+        _validate_sha(sha)
+        try:
+            stats_output = _run_git_commit_numstat(repo.path, sha=sha)
+            patch_output = _run_git_commit_patch(repo.path, sha=sha)
+            summaries = _parse_numstat(stats_output)
+            files, truncated, redacted, omitted_count = _build_safe_diff(summaries, patch_output)
+            return files, truncated, redacted, omitted_count, 'live'
+        except Exception:
+            return [], False, False, 0, 'unknown'
 
 
 class GitStatusAdapter(GitReadAdapter):
@@ -108,6 +142,63 @@ def _run_git_branches(repo_path: Path) -> str:
             *GIT_SAFE_CONFIG_ARGS,
             'branch',
             '--format=%(refname:short)%00%(HEAD)%00%(objectname)',
+        ],
+    )
+
+
+def _run_git_commit_detail(repo_path: Path, *, sha: str) -> str:
+    return _run_allowlisted_git(
+        repo_path,
+        [
+            'git',
+            '--no-optional-locks',
+            *GIT_SAFE_CONFIG_ARGS,
+            'show',
+            '--no-ext-diff',
+            '--no-renames',
+            '-s',
+            '--format=%H%x1f%h%x1f%an%x1f%ae%x1f%aI%x1f%cI%x1f%s%x1f%B%x1e',
+            sha,
+            '--',
+        ],
+    )
+
+
+def _run_git_commit_numstat(repo_path: Path, *, sha: str) -> str:
+    return _run_allowlisted_git(
+        repo_path,
+        [
+            'git',
+            '--no-optional-locks',
+            *GIT_SAFE_CONFIG_ARGS,
+            'show',
+            '--no-ext-diff',
+            '--no-renames',
+            '--format=',
+            '--numstat',
+            '--diff-filter=ACDMRT',
+            sha,
+            '--',
+        ],
+    )
+
+
+def _run_git_commit_patch(repo_path: Path, *, sha: str) -> str:
+    return _run_allowlisted_git(
+        repo_path,
+        [
+            'git',
+            '--no-optional-locks',
+            *GIT_SAFE_CONFIG_ARGS,
+            'show',
+            '--no-ext-diff',
+            '--no-renames',
+            '--format=',
+            '--patch',
+            '--unified=3',
+            '--diff-filter=ACDMRT',
+            sha,
+            '--',
         ],
     )
 
@@ -203,6 +294,11 @@ def _parse_cursor(cursor: str | None) -> int:
     return int(match.group(1))
 
 
+def _validate_sha(sha: str) -> None:
+    if not GIT_SHA_PATTERN.fullmatch(sha):
+        raise GitInvalidSha('invalid commit identifier')
+
+
 def _parse_git_log(output: str) -> list[GitCommitSummary]:
     commits: list[GitCommitSummary] = []
     for record in output.split('\x1e'):
@@ -251,6 +347,194 @@ def _parse_git_branches(output: str) -> list[GitBranchSummary]:
             )
         )
     return branches
+
+
+def _parse_numstat(output: str) -> list[GitCommitFileSummary]:
+    files: list[GitCommitFileSummary] = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        if '\x1f' in line:
+            parts = line.split('\x1f')
+            if len(parts) != 4:
+                continue
+            raw_path, additions_raw, deletions_raw, change_type_raw = parts
+        else:
+            parts = line.split('\t')
+            if len(parts) < 3:
+                continue
+            additions_raw, deletions_raw, raw_path = parts[0], parts[1], parts[2]
+            change_type_raw = 'modified'
+        binary = additions_raw == '-' or deletions_raw == '-'
+        additions = None if binary else _parse_int(additions_raw)
+        deletions = None if binary else _parse_int(deletions_raw)
+        safe_path = _sanitize_repo_path(raw_path)
+        sensitive = _is_sensitive_path(raw_path)
+        omitted = sensitive or binary
+        omitted_reason = 'sensitive_path' if sensitive else ('binary' if binary else None)
+        files.append(
+            GitCommitFileSummary(
+                path=None if omitted else safe_path,
+                change_type=_sanitize_change_type(change_type_raw, additions, deletions),
+                additions=additions,
+                deletions=deletions,
+                binary=binary,
+                omitted=omitted,
+                omitted_reason=omitted_reason,
+            )
+        )
+        if len(files) >= GIT_DIFF_MAX_FILES:
+            break
+    return files
+
+
+def _parse_int(value: str) -> int | None:
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _sanitize_change_type(raw: str, additions: int | None, deletions: int | None) -> str:
+    value = raw.lower()
+    allowed = {'added', 'modified', 'deleted', 'renamed', 'copied', 'typechange'}
+    if value in allowed and value != 'modified':
+        return value
+    if deletions == 0 and additions and additions > 0:
+        return 'added'
+    if additions == 0 and deletions and deletions > 0:
+        return 'deleted'
+    return 'modified'
+
+
+def _build_safe_diff(summaries: list[GitCommitFileSummary], patch_output: str) -> tuple[list[GitCommitDiffFile], bool, bool, int]:
+    patch_by_path = _split_patch_by_path(patch_output)
+    files: list[GitCommitDiffFile] = []
+    total_lines = 0
+    any_truncated = False
+    any_redacted = False
+    omitted_count = 0
+    for summary in summaries:
+        if summary.omitted or summary.path is None:
+            omitted_count += 1
+            files.append(GitCommitDiffFile(summary=summary, truncated=False, redacted=False, lines=()))
+            continue
+        raw_lines = patch_by_path.get(summary.path, [])
+        safe_lines: list[dict[str, str]] = []
+        file_truncated = False
+        file_redacted = False
+        for raw_line in raw_lines:
+            if total_lines >= GIT_DIFF_MAX_TOTAL_LINES or len(safe_lines) >= GIT_DIFF_MAX_LINES_PER_FILE:
+                file_truncated = True
+                break
+            safe_line, redacted = _sanitize_diff_line(raw_line)
+            if redacted:
+                file_redacted = True
+            safe_lines.append({'kind': _classify_diff_line(raw_line), 'content': safe_line})
+            total_lines += 1
+        if len(raw_lines) > len(safe_lines):
+            file_truncated = True
+        any_truncated = any_truncated or file_truncated
+        any_redacted = any_redacted or file_redacted
+        files.append(
+            GitCommitDiffFile(
+                summary=summary,
+                truncated=file_truncated,
+                redacted=file_redacted,
+                lines=tuple(safe_lines),
+            )
+        )
+    return files, any_truncated, any_redacted, omitted_count
+
+
+def _split_patch_by_path(output: str) -> dict[str, list[str]]:
+    result: dict[str, list[str]] = {}
+    current_path: str | None = None
+    current_lines: list[str] = []
+    for line in output.splitlines():
+        if line.startswith('diff --git '):
+            if current_path is not None:
+                result[current_path] = current_lines
+            current_path = _path_from_diff_header(line)
+            current_lines = []
+            continue
+        if current_path is None:
+            continue
+        if line.startswith(('index ', 'new file mode ', 'deleted file mode ', 'similarity index ', 'rename from ', 'rename to ')):
+            continue
+        if line.startswith('--- ') or line.startswith('+++ '):
+            continue
+        current_lines.append(line)
+    if current_path is not None:
+        result[current_path] = current_lines
+    return result
+
+
+def _path_from_diff_header(line: str) -> str | None:
+    parts = line.split(' ')
+    if len(parts) < 4:
+        return None
+    raw = parts[3]
+    if raw.startswith('b/'):
+        raw = raw[2:]
+    return _sanitize_repo_path(raw)
+
+
+def _sanitize_repo_path(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    value = raw.strip().strip('"')
+    if value.startswith(('a/', 'b/')):
+        value = value[2:]
+    if not value or value.startswith('/') or '..' in value.split('/'):
+        return None
+    if len(value) > 180:
+        return None
+    allowed = []
+    for char in value:
+        if char.isalnum() or char in {'-', '_', '.', '/', '@'}:
+            allowed.append(char)
+        else:
+            return None
+    return ''.join(allowed)
+
+
+SENSITIVE_PATH_RE = re.compile(
+    r'(^|/)(\.env($|\.)|.*(secret|token|password|credential|cookie|private).*|.*\.(key|pem|p12|pfx|sqlite|sqlite3|db|log|dump|bak|backup)$)',
+    re.IGNORECASE,
+)
+SECRET_CONTENT_RE = re.compile(
+    r'(authorization:|bearer\s+|token\s*=|secret\s*=|password\s*=|cookie\s*=|-----begin .*private key-----|ghp_[a-z0-9_]+|sk-[a-z0-9_-]+|xox[a-z]-)',
+    re.IGNORECASE,
+)
+HOST_PATH_RE = re.compile(r'/(srv|home|tmp|var|etc)/[^\s]+', re.IGNORECASE)
+
+
+def _is_sensitive_path(raw_path: str | None) -> bool:
+    sanitized = _sanitize_repo_path(raw_path)
+    if sanitized is None:
+        return True
+    return SENSITIVE_PATH_RE.search(sanitized) is not None
+
+
+def _sanitize_diff_line(value: str) -> tuple[str, bool]:
+    safe = _sanitize_text(value, max_length=GIT_DIFF_MAX_LINE_LENGTH)
+    redacted = False
+    if SECRET_CONTENT_RE.search(safe) or HOST_PATH_RE.search(safe):
+        prefix = safe[:1] if safe[:1] in {'+', '-', ' '} else ''
+        safe = f'{prefix}[redacted]'
+        redacted = True
+    return safe, redacted
+
+
+def _classify_diff_line(value: str) -> str:
+    if value.startswith('@@'):
+        return 'hunk'
+    if value.startswith('+'):
+        return 'addition'
+    if value.startswith('-'):
+        return 'deletion'
+    return 'context'
 
 
 def _extract_trailers(body: str) -> dict[str, str | None]:

--- a/apps/api/src/modules/git_control/router.py
+++ b/apps/api/src/modules/git_control/router.py
@@ -5,7 +5,7 @@ from fastapi.responses import JSONResponse
 
 from ...shared.contracts import resource_response
 from .domain import GIT_COMMITS_DEFAULT_LIMIT, GIT_CONTROL_SOURCE_LABEL
-from .git_adapter import GitInvalidCursor, GitInvalidLimit
+from .git_adapter import GitInvalidCursor, GitInvalidLimit, GitInvalidSha
 from .service import GitControlService, GitRepoNotFound
 
 router = APIRouter(prefix='/api/v1/git', tags=['git_control'])
@@ -67,6 +67,38 @@ def list_git_repo_commits(
         meta=_git_meta(),
     )
 
+
+
+@router.get('/repos/{repo_id}/commits/{sha}/diff')
+def get_git_commit_diff(repo_id: str, sha: str, service: GitControlService = Depends(get_git_control_service)):
+    try:
+        diff_payload = service.get_commit_diff(repo_id, sha=sha)
+    except GitRepoNotFound:
+        return _git_repo_not_found_response()
+    except GitInvalidSha:
+        return _git_validation_error_response('git_invalid_sha', 'Invalid commit identifier.')
+    return resource_response(
+        resource='git.commit_diff',
+        status=service.status_for_commit_diff(diff_payload),
+        data=diff_payload,
+        meta=_git_meta(),
+    )
+
+
+@router.get('/repos/{repo_id}/commits/{sha}')
+def get_git_commit_detail(repo_id: str, sha: str, service: GitControlService = Depends(get_git_control_service)):
+    try:
+        detail_payload = service.get_commit_detail(repo_id, sha=sha)
+    except GitRepoNotFound:
+        return _git_repo_not_found_response()
+    except GitInvalidSha:
+        return _git_validation_error_response('git_invalid_sha', 'Invalid commit identifier.')
+    return resource_response(
+        resource='git.commit_detail',
+        status=service.status_for_commit_detail(detail_payload),
+        data=detail_payload,
+        meta=_git_meta(),
+    )
 
 @router.get('/repos/{repo_id}/branches')
 def list_git_repo_branches(repo_id: str, service: GitControlService = Depends(get_git_control_service)):

--- a/apps/api/src/modules/git_control/service.py
+++ b/apps/api/src/modules/git_control/service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from .domain import GIT_COMMITS_DEFAULT_LIMIT, GitRepoStatus
-from .git_adapter import GitInvalidCursor, GitInvalidLimit, GitReadAdapter
+from .git_adapter import GitInvalidCursor, GitInvalidLimit, GitInvalidSha, GitReadAdapter
 from .registry import GitRepoDefinition, GitRepoRegistry, default_git_repo_registry
 
 
@@ -45,6 +45,34 @@ class GitControlService:
             'source_state': source_state,
         }
 
+
+    def get_commit_detail(self, repo_id: str, *, sha: str) -> dict:
+        repo = self._registry.get(repo_id)
+        if repo is None:
+            raise GitRepoNotFound()
+        commit, files, source_state = self._read_adapter.get_commit_detail(repo, sha=sha)
+        return {
+            'repo_id': repo.repo_id,
+            'commit': commit.to_public() if commit is not None else None,
+            'files': [file.to_public() for file in files],
+            'source_state': source_state,
+        }
+
+    def get_commit_diff(self, repo_id: str, *, sha: str) -> dict:
+        repo = self._registry.get(repo_id)
+        if repo is None:
+            raise GitRepoNotFound()
+        files, truncated, redacted, omitted_files_count, source_state = self._read_adapter.get_commit_diff(repo, sha=sha)
+        return {
+            'repo_id': repo.repo_id,
+            'sha': sha,
+            'files': [file.to_public() for file in files],
+            'truncated': truncated,
+            'redacted': redacted,
+            'omitted_files_count': omitted_files_count,
+            'source_state': source_state,
+        }
+
     def list_branches(self, repo_id: str) -> dict:
         repo = self._registry.get(repo_id)
         if repo is None:
@@ -80,6 +108,18 @@ class GitControlService:
     @staticmethod
     def status_for_branch_list(branches_payload: dict) -> str:
         if branches_payload.get('source_state') == 'live':
+            return 'ready'
+        return 'source_unavailable'
+
+    @staticmethod
+    def status_for_commit_detail(detail_payload: dict) -> str:
+        if detail_payload.get('source_state') == 'live' and detail_payload.get('commit') is not None:
+            return 'ready'
+        return 'source_unavailable'
+
+    @staticmethod
+    def status_for_commit_diff(diff_payload: dict) -> str:
+        if diff_payload.get('source_state') == 'live':
             return 'ready'
         return 'source_unavailable'
 

--- a/apps/api/tests/test_git_control_api.py
+++ b/apps/api/tests/test_git_control_api.py
@@ -484,3 +484,226 @@ def test_git_read_model_invocations_stay_allowlisted_and_hardened(monkeypatch, t
         assert kwargs['env']['GIT_CONFIG_SYSTEM'] == '/dev/null'
         assert kwargs['env']['GIT_CONFIG_NOSYSTEM'] == '1'
         assert not any(command in args for command in ['checkout', 'reset', 'commit', 'push', 'pull', 'fetch', 'stash', 'merge', 'rebase'])
+
+
+
+def test_git_commit_detail_returns_metadata_and_safe_file_stats_without_body_or_sensitive_paths(tmp_path: Path) -> None:
+    from apps.api.src.modules.git_control.registry import GitRepoDefinition, GitRepoRegistry
+
+    repo = _make_repo(tmp_path / 'detail-private-repo')
+    sha = _commit_file(
+        repo,
+        'safe-detail.md',
+        'public line\nsecond line\n',
+        'feat: add safe detail',
+        'Body with SYNTHETIC-SECRET-COMMIT-BODY-MARKER\n\nMugiwara-Agent: zoro\nSigned-off-by: zoro <asistentes.mugiwara@gmail.com>',
+    )
+    _commit_file(repo, '.env', 'TOKEN=super-secret-value\n', 'chore: add sensitive fixture')
+    registry = GitRepoRegistry(
+        repos=(GitRepoDefinition(repo_id='fixture-detail', label='Fixture detail repository', scope='test', path=repo),)
+    )
+    _install_git_control_override(registry)
+
+    response = TestClient(app).get(f'/api/v1/git/repos/fixture-detail/commits/{sha}?path=/srv/private&ref=HEAD')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'git.commit_detail'
+    assert payload['status'] == 'ready'
+    assert payload['meta']['read_only'] is True
+    assert payload['meta']['sanitized'] is True
+    assert payload['data']['repo_id'] == 'fixture-detail'
+    assert payload['data']['source_state'] == 'live'
+    commit = payload['data']['commit']
+    assert commit['sha'] == sha
+    assert commit['subject'] == 'feat: add safe detail'
+    assert commit['trailers'] == {
+        'mugiwara_agent': 'zoro',
+        'signed_off_by': 'zoro <asistentes.mugiwara@gmail.com>',
+    }
+    assert 'body' not in commit
+    assert payload['data']['files'] == [
+        {
+            'path': 'safe-detail.md',
+            'change_type': 'added',
+            'additions': 2,
+            'deletions': 0,
+            'binary': False,
+            'omitted': False,
+            'omitted_reason': None,
+        }
+    ]
+    assert 'SYNTHETIC-SECRET-COMMIT-BODY-MARKER' not in response.text
+    assert '/srv/private' not in response.text
+    assert '.env' not in response.text
+    assert 'super-secret-value' not in response.text
+    _assert_no_leakage(payload)
+
+
+def test_git_commit_detail_rejects_invalid_sha_without_echoing_revspec(tmp_path: Path) -> None:
+    from apps.api.src.modules.git_control.registry import GitRepoDefinition, GitRepoRegistry
+
+    repo = _make_repo(tmp_path / 'invalid-sha-private-repo')
+    registry = GitRepoRegistry(
+        repos=(GitRepoDefinition(repo_id='fixture-invalid-sha', label='Fixture invalid sha repository', scope='test', path=repo),)
+    )
+    _install_git_control_override(registry)
+
+    response = TestClient(app).get('/api/v1/git/repos/fixture-invalid-sha/commits/HEAD..main:private-token')
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload['detail'] == {
+        'code': 'git_invalid_sha',
+        'message': 'Invalid commit identifier.',
+    }
+    assert 'HEAD' not in response.text
+    assert 'private-token' not in response.text
+    _assert_no_leakage(payload)
+
+
+def test_git_commit_diff_redacts_omits_and_truncates_deny_by_default(tmp_path: Path) -> None:
+    from apps.api.src.modules.git_control.registry import GitRepoDefinition, GitRepoRegistry
+
+    repo = _make_repo(tmp_path / 'diff-private-repo')
+    safe_content = '\n'.join(
+        [
+            'visible public line',
+            'Authorization: Bearer SYNTHETIC-TOKEN-MARKER',
+            'host path /srv/crew-core/private should be hidden',
+            *[f'long public line {index}' for index in range(160)],
+        ]
+    ) + '\n'
+    sha = _commit_file(repo, 'safe-diff.md', safe_content, 'feat: add safe diff')
+    _commit_file(repo, '.env', 'TOKEN=super-secret-value\n', 'chore: add env fixture')
+    registry = GitRepoRegistry(
+        repos=(GitRepoDefinition(repo_id='fixture-diff', label='Fixture diff repository', scope='test', path=repo),)
+    )
+    _install_git_control_override(registry)
+
+    response = TestClient(app).get(f'/api/v1/git/repos/fixture-diff/commits/{sha}/diff?path=/srv/private&command=show')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'git.commit_diff'
+    assert payload['status'] == 'ready'
+    assert payload['data']['repo_id'] == 'fixture-diff'
+    assert payload['data']['sha'] == sha
+    assert payload['data']['source_state'] == 'live'
+    assert payload['data']['redacted'] is True
+    assert payload['data']['truncated'] is True
+    assert payload['data']['omitted_files_count'] == 0
+    assert len(payload['data']['files']) == 1
+    diff_file = payload['data']['files'][0]
+    assert diff_file['path'] == 'safe-diff.md'
+    assert diff_file['omitted'] is False
+    assert diff_file['redacted'] is True
+    assert diff_file['truncated'] is True
+    rendered_lines = '\n'.join(line['content'] for line in diff_file['lines'])
+    assert 'visible public line' in rendered_lines
+    assert '[redacted]' in rendered_lines
+    assert 'SYNTHETIC-TOKEN-MARKER' not in response.text
+    assert '/srv/crew-core/private' not in response.text
+    assert 'long public line 159' not in response.text
+    assert '/srv/private' not in response.text
+    _assert_no_leakage(payload)
+
+
+def test_git_commit_diff_omits_sensitive_paths_and_binary_content(tmp_path: Path) -> None:
+    from apps.api.src.modules.git_control.registry import GitRepoDefinition, GitRepoRegistry
+
+    repo = _make_repo(tmp_path / 'sensitive-diff-private-repo')
+    (repo / '.env').write_text('TOKEN=super-secret-value\n', encoding='utf-8')
+    (repo / 'data.sqlite').write_bytes(b'\x00\x01sqlite private bytes')
+    _git(repo, 'add', '.env', 'data.sqlite')
+    _git(repo, 'commit', '-m', 'chore: add sensitive files')
+    sha = subprocess.run(
+        ['git', 'rev-parse', 'HEAD'],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+    registry = GitRepoRegistry(
+        repos=(GitRepoDefinition(repo_id='fixture-sensitive-diff', label='Fixture sensitive diff repository', scope='test', path=repo),)
+    )
+    _install_git_control_override(registry)
+
+    response = TestClient(app).get(f'/api/v1/git/repos/fixture-sensitive-diff/commits/{sha}/diff')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['data']['omitted_files_count'] == 2
+    assert payload['data']['files'] == [
+        {
+            'path': None,
+            'change_type': 'added',
+            'additions': 1,
+            'deletions': 0,
+            'binary': False,
+            'omitted': True,
+            'omitted_reason': 'sensitive_path',
+            'truncated': False,
+            'redacted': False,
+            'lines': [],
+        },
+        {
+            'path': None,
+            'change_type': 'modified',
+            'additions': None,
+            'deletions': None,
+            'binary': True,
+            'omitted': True,
+            'omitted_reason': 'sensitive_path',
+            'truncated': False,
+            'redacted': False,
+            'lines': [],
+        },
+    ]
+    assert '.env' not in response.text
+    assert 'data.sqlite' not in response.text
+    assert 'super-secret-value' not in response.text
+    assert 'sqlite private bytes' not in response.text
+    _assert_no_leakage(payload)
+
+
+def test_git_detail_and_diff_invocations_stay_allowlisted_and_hardened(monkeypatch, tmp_path: Path) -> None:
+    from apps.api.src.modules.git_control.git_adapter import GitReadAdapter
+    from apps.api.src.modules.git_control.registry import GitRepoDefinition
+
+    sha = 'a' * 40
+    captured: list[dict[str, Any]] = []
+
+    def fake_run(args, **kwargs):
+        captured.append({'args': args, 'kwargs': kwargs})
+        if '--numstat' in args:
+            return SimpleNamespace(stdout='safe.md\x1f1\x1f0\x1fadded\x1e')
+        if '--patch' in args:
+            return SimpleNamespace(stdout='diff --git a/safe.md b/safe.md\nnew file mode 100644\n--- /dev/null\n+++ b/safe.md\n@@ -0,0 +1 @@\n+visible\n')
+        return SimpleNamespace(stdout=f'{sha}\x1faaaaaaaaaaaa\x1ffixture\x1ffixture@example.invalid\x1f2026-04-27T10:00:00+00:00\x1f2026-04-27T10:00:00+00:00\x1ffeat: safe\x1fMugiwara-Agent: zoro\n\x1e')
+
+    monkeypatch.setattr('apps.api.src.modules.git_control.git_adapter.subprocess.run', fake_run)
+    adapter = GitReadAdapter()
+    repo = GitRepoDefinition(repo_id='fixture-policy', label='Fixture policy repository', scope='test', path=tmp_path)
+
+    adapter.get_commit_detail(repo, sha=sha)
+    adapter.get_commit_diff(repo, sha=sha)
+
+    assert len(captured) == 4
+    for call in captured:
+        args = call['args']
+        kwargs = call['kwargs']
+        assert args[0] == 'git'
+        assert '--no-optional-locks' in args
+        assert 'core.fsmonitor=false' in args
+        assert 'core.hooksPath=/dev/null' in args
+        assert '--no-ext-diff' in args
+        assert sha in args
+        assert kwargs['shell'] is False
+        assert kwargs['cwd'] == tmp_path
+        assert kwargs['timeout'] == 2.0
+        assert kwargs['env']['GIT_CONFIG_GLOBAL'] == '/dev/null'
+        assert kwargs['env']['GIT_CONFIG_SYSTEM'] == '/dev/null'
+        assert kwargs['env']['GIT_CONFIG_NOSYSTEM'] == '1'
+        assert not any(command in args for command in ['checkout', 'reset', 'commit', 'push', 'pull', 'fetch', 'stash', 'merge', 'rebase'])

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -101,12 +101,16 @@
 - exponer `GET /api/v1/git/repos/{repo_id}/status` como estado resumido de un repo allowlisteado
 - exponer `GET /api/v1/git/repos/{repo_id}/commits?limit=&cursor=` como historial reciente paginado de commits saneados
 - exponer `GET /api/v1/git/repos/{repo_id}/branches` como listado de ramas locales saneadas
+- exponer `GET /api/v1/git/repos/{repo_id}/commits/{sha}` como detalle de commit con metadata saneada y stats por fichero deny-by-default
+- exponer `GET /api/v1/git/repos/{repo_id}/commits/{sha}/diff` como diff histórico seguro, truncado y redactado
 - aceptar únicamente `repo_id` lógico desde cliente; nunca paths, URLs, remotes, comandos, refs arbitrarias ni revspecs
-- validar `limit` como entero `1..50` y `cursor` como token opaco `offset:<n>`; no resolver revsets, SHA/ref cliente ni rangos arbitrarios
-- usar Git solo como lectura host-adjacent acotada para status, commits y ramas locales, con `subprocess.run` en lista de argumentos, `shell=False`, `cwd` fijo, timeout, entorno mínimo, config global/system nula y overrides `core.fsmonitor=false`/`core.hooksPath=/dev/null`
+- validar `limit` como entero `1..50`, `cursor` como token opaco `offset:<n>` y `sha` como SHA completo hex SHA-1/SHA-256; no resolver refs, rangos ni revsets arbitrarios
+- usar Git solo como lectura host-adjacent acotada para status, commits, ramas locales, commit detail y diff de commit, con `subprocess.run` en lista de argumentos, `shell=False`, `cwd` fijo, timeout, entorno mínimo, config global/system nula y overrides `core.fsmonitor=false`/`core.hooksPath=/dev/null`
 - no ejecutar acciones destructivas ni remotas (`checkout`, `reset`, `commit`, `push`, `pull`, `fetch`, `stash`, `merge`, `rebase`)
-- no exponer rutas host, nombres de fichero de status, diffs, remotes privados, stdout/stderr, stack traces ni errores crudos
+- no exponer rutas host, nombres de fichero de status, remotes privados, stdout/stderr, stack traces ni errores crudos
 - commits serializan solo hashes, autor/email saneado, fechas, subject y trailers allowlisteados `Mugiwara-Agent`/`Signed-off-by`; el cuerpo libre del commit no se publica y solo se usa internamente para extraer esos trailers
+- commit detail reutiliza esa metadata y añade stats por fichero con paths repo-relativos solo cuando son seguros; `.env`, credenciales, logs, dumps, DBs y binarios se omiten con razón genérica
+- commit diff serializa líneas saneadas con límites por fichero/total; redacta contenido con tokens/rutas host y nunca devuelve el cuerpo libre del commit, paths sensibles, stdout/stderr ni errores crudos
 - branches serializa solo ramas locales con nombre saneado, `current`, sha y short_sha; no remotes ni refs arbitrarias
 - degradar repos ausentes/corruptos/ilegibles a `source_unavailable` con payload saneado
 - bloquear la frontera backend con `npm run verify:git-control-backend-policy`

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -227,6 +227,35 @@ Uso:
 - no serializa remotes (`origin/*`), URLs, rutas host, stdout/stderr ni errores crudos
 - nombres de rama no saneables se omiten
 
+
+
+### `git.commit_detail`
+Campos esperados:
+- `repo_id`
+- `commit` con el mismo contrato público de `git.commit_list` para `sha`, `short_sha`, autor/email saneado, fechas, `subject` y trailers allowlisteados
+- `files[]` con `path` repo-relativo solo si es seguro, `change_type`, `additions`, `deletions`, `binary`, `omitted` y `omitted_reason`
+- `source_state`
+
+Uso:
+- abrir un commit concreto desde un `sha` completo devuelto por el backend
+- el cliente solo aporta `repo_id` y SHA completo hex; nunca paths, refs, rangos, `HEAD`, revsets, remotes ni comandos
+- no serializa cuerpo libre del commit; `%B` sigue siendo interno para trailers
+- paths sensibles (`.env`, credenciales, logs, dumps, DBs) y binarios se omiten con razón genérica sin revelar el path
+
+### `git.commit_diff`
+Campos esperados:
+- `repo_id`
+- `sha`
+- `files[]` con el contrato de stats anterior más `truncated`, `redacted` y `lines[]` saneadas
+- `lines[].kind` (`hunk`, `addition`, `deletion`, `context`) y `lines[].content`
+- `truncated`, `redacted`, `omitted_files_count` y `source_state`
+
+Uso:
+- mostrar diff histórico de commit solo después de pasar por política deny-by-default del backend
+- omitir paths sensibles y binarios; redactar tokens, credenciales y rutas host si aparecen en líneas permitidas
+- truncar por fichero y total; el payload debe indicar truncado/redacción/omisión sin devolver contenido peligroso ni patrones exactos
+- no hay working-tree diff en 40.3; cambios no commiteados quedan fuera de alcance por mayor riesgo de secretos
+
 ### `memory.agent_summary`
 Campos esperados:
 - `mugiwara_slug`

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -188,3 +188,10 @@ Resumen de la decisión:
 - `/skills` migró en Phase 12.3h con route handlers BFF same-origin porque es client component y contiene preview/update controlados.
 - Ese BFF usa `MUGIWARA_CONTROL_PANEL_API_URL` solo en servidor, no es proxy abierto, valida entradas críticas, usa `cache: no-store` y devuelve errores saneados.
 - FastAPI sigue siendo la fuente de verdad para allowlist, path safety, stale hash, edición y auditoría.
+
+
+## Git control backend — 40.3 commit detail + safe diff
+- La superficie Git sigue siendo backend-only/read-only y deny-by-default.
+- El cliente opera únicamente con `repo_id` allowlisteado y SHA completo devuelto por el backend; no se aceptan paths, refs, rangos, revspecs ni comandos.
+- Los diffs históricos se tratan como sensibles: paths `.env`/credenciales/logs/dumps/DBs y binarios se omiten, contenido con tokens o rutas host se redacta y todas las salidas se truncan por fichero/total.
+- El cuerpo libre de commit no forma parte del contrato público; solo se lee internamente para trailers allowlisteados.

--- a/openspec/issue-40-3-commit-detail-safe-diff-verify-checklist.md
+++ b/openspec/issue-40-3-commit-detail-safe-diff-verify-checklist.md
@@ -1,0 +1,42 @@
+# Issue #40.3 — Git commit detail + safe diff backend verify checklist
+
+## Scope
+- [x] `main` actualizado tras PR #90.
+- [x] Rama creada: `zoro/issue-40-3-commit-detail-safe-diff`.
+- [x] Rehidratados Issue #40, comentario de cierre 40.2/PR #90, OpenSpec, docs, guardrail, AGENTS y `.engram/issue-40-2-closeout.md`.
+- [x] Decisión de corte: 40.3 no se divide más; commit detail + safe diff forman una unidad backend-only coherente, manteniendo fuera UI y working-tree diff.
+
+## TDD
+- [x] Tests rojos escritos primero en `apps/api/tests/test_git_control_api.py`.
+- [x] Rojo observado: endpoints `/commits/{sha}` y `/commits/{sha}/diff` devolvían 404 y `GitReadAdapter.get_commit_detail` no existía.
+- [x] Implementación añadida después del rojo.
+
+## Implementación
+- [x] Endpoint `GET /api/v1/git/repos/{repo_id}/commits/{sha}` añadido.
+- [x] Endpoint `GET /api/v1/git/repos/{repo_id}/commits/{sha}/diff` añadido.
+- [x] Cliente solo usa `repo_id` allowlisteado y SHA completo hex SHA-1/SHA-256; nunca paths, refs, rangos ni revspecs.
+- [x] SHA inválido devuelve error saneado `git_invalid_sha` sin ecoar input.
+- [x] Commit detail serializa metadata saneada, trailers allowlisteados y stats por fichero; no expone body libre del commit.
+- [x] Diff de commit omite paths sensibles y binarios; redacta contenido con tokens/rutas host; trunca por fichero y total.
+- [x] Payload de diff expone `truncated`, `redacted`, `omitted`, `omitted_reason` y `omitted_files_count` con razones genéricas.
+- [x] Sin UI, sin working-tree diff y sin acciones Git destructivas/remotas.
+- [x] Git usa `shell=False`, cwd fijo, timeout, env mínimo, `GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_SYSTEM=/dev/null`, `GIT_CONFIG_NOSYSTEM=1`, `-c core.fsmonitor=false`, `-c core.hooksPath=/dev/null`, y `--no-ext-diff` para detail/diff.
+- [x] Payload no serializa rutas host, remotes privados, stdout/stderr, stack traces, errores crudos ni cuerpo libre de commits.
+
+## Guardrails/docs
+- [x] Actualizado `npm run verify:git-control-backend-policy` para commit detail + diff.
+- [x] Actualizados `docs/api-modules.md`, `docs/read-models.md`, `docs/runtime-config.md`.
+- [x] Actualizado `apps/api/src/modules/git_control/AGENTS.md`.
+- [x] Actualizado `openspec/issue-40-git-control-page-plan.md`.
+- [x] Añadido `.engram/issue-40-3-closeout.md`.
+
+## Verify requerido
+- [x] `python3 -m py_compile apps/api/src/modules/git_control/domain.py apps/api/src/modules/git_control/git_adapter.py apps/api/src/modules/git_control/service.py apps/api/src/modules/git_control/router.py apps/api/tests/test_git_control_api.py`
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_git_control_api.py -q`
+- [x] `npm run verify:git-control-backend-policy`
+- [x] `npm run verify:perimeter-policy`
+- [x] `git diff --check`
+
+## Review esperado
+- Franky: operabilidad, subprocess Git policy para `show`, timeout/cwd/env mínimo, `--no-ext-diff`, límites de diff y mantenibilidad del guardrail.
+- Chopper: seguridad, validación estricta de SHA, no refs/revspecs cliente, omisión/redacción/truncado deny-by-default y no leakage.

--- a/openspec/issue-40-git-control-page-plan.md
+++ b/openspec/issue-40-git-control-page-plan.md
@@ -4,8 +4,8 @@
 - Issue: [#40 Add Git control page for local repository history and diffs](https://github.com/asistentes-mugiwara/mugiwara-control-panel/issues/40)
 - Planificación: PR #88 cerrada.
 - Microfase 40.1: PR #89 mergeada; backend-only registry/status implementado.
-- Microfase 40.2: `zoro/issue-40-2-git-commits-branches`, backend-only commits/branches read model en implementación.
-- Tipo de fase: planificación SDD inicial + primera microfase backend runtime.
+- Microfase 40.2: PR #90 mergeada; backend-only commits/branches read model implementado.
+- Tipo de fase: planificación SDD inicial + microfases backend runtime.
 - Fecha: 2026-04-27
 
 ## Objetivo
@@ -69,9 +69,9 @@ La registry puede contener rutas absolutas internamente, pero esas rutas no debe
 - `GET /api/v1/git/repos/{repo_id}/branches`
   - Ramas/refs locales allowlisted y rama actual; sin resolver refs arbitrarias desde cliente.
 - `GET /api/v1/git/repos/{repo_id}/commits/{sha}`
-  - Detalle de commit con metadata, trailers y lista de archivos tocados con stats.
+  - Detalle de commit con metadata, trailers y lista de archivos tocados con stats; SHA completo hex validado, sin refs/rangos/revspecs.
 - `GET /api/v1/git/repos/{repo_id}/commits/{sha}/diff`
-  - Diff unificado seguro, truncado por archivo y total, con archivos sensibles omitidos/redactados.
+  - Diff unificado seguro, truncado por archivo y total, con paths sensibles y binarios omitidos, y líneas permitidas redactadas si contienen tokens/rutas host.
 - `GET /api/v1/git/repos/{repo_id}/status`
   - Working tree read-only. Primero summary/status; diff del working tree solo tras cerrar política de redacción equivalente a commit diff.
 
@@ -136,13 +136,15 @@ El API debe indicar `omitted_reason`, `truncated`, `redacted` y contadores; no d
 **Review:** Franky + Chopper.
 
 ### 40.3 — Backend commit detail + safe diff
+**Estado:** implementado en rama `zoro/issue-40-3-commit-detail-safe-diff`.
+
 **Objetivo:** exponer detalle de commit y diff seguro/truncado.
 
-**Incluye:** stats por archivo, binary detection, límites por archivo/total, omisión por path sensible, redacción por contenido, `truncated/redacted/omitted_reason` explícitos.
+**Incluye:** `GET /api/v1/git/repos/{repo_id}/commits/{sha}` y `GET /api/v1/git/repos/{repo_id}/commits/{sha}/diff`, stats por archivo, binary detection, límites por archivo/total, omisión por path sensible, redacción por contenido y `truncated/redacted/omitted_reason` explícitos. El SHA aceptado es completo hex SHA-1/SHA-256 devuelto por backend, no refs ni revspecs.
 
-**No incluye:** working tree diff ni UI completa.
+**No incluye:** working tree diff, UI completa, refs/rangos arbitrarios ni cuerpo libre de commits.
 
-**TDD/verify:** tests con `.env`, DB/log/binario, diff grande, contenido con token sintético, SHA inválido, path traversal/revspec malicioso; scan recursivo del payload público.
+**TDD/verify:** tests con `.env`, DB/binario, diff grande, contenido con token sintético, SHA inválido/revspec malicioso y scan recursivo del payload público; `py_compile`; `PYTHONPATH=. pytest apps/api/tests/test_git_control_api.py -q`; `npm run verify:git-control-backend-policy`; `npm run verify:perimeter-policy`; `git diff --check`.
 
 **Review:** Franky + Chopper obligatorio.
 

--- a/scripts/check-git-control-backend-policy.mjs
+++ b/scripts/check-git-control-backend-policy.mjs
@@ -2,7 +2,7 @@
 /**
  * Static guardrail for Issue #40 Git control backend policy.
  *
- * Keeps Git control as a backend-owned read-only registry/status/commits/branches
+ * Keeps Git control as a backend-owned read-only registry/status/commits/branches/commit-detail/diff
  * surface, not a filesystem browser or Git console.
  */
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
@@ -81,10 +81,14 @@ mustInclude(routerPy, "@router.get('/repos')", 'git_control router')
 mustInclude(routerPy, "@router.get('/repos/{repo_id}/status')", 'git_control router')
 mustInclude(routerPy, "@router.get('/repos/{repo_id}/commits')", 'git_control router')
 mustInclude(routerPy, "@router.get('/repos/{repo_id}/branches')", 'git_control router')
+mustInclude(routerPy, "@router.get('/repos/{repo_id}/commits/{sha}')", 'git_control router')
+mustInclude(routerPy, "@router.get('/repos/{repo_id}/commits/{sha}/diff')", 'git_control router')
 mustInclude(routerPy, "resource='git.repo_index'", 'git_control router')
 mustInclude(routerPy, "resource='git.repo_status'", 'git_control router')
 mustInclude(routerPy, "resource='git.commit_list'", 'git_control router')
 mustInclude(routerPy, "resource='git.branch_list'", 'git_control router')
+mustInclude(routerPy, "resource='git.commit_detail'", 'git_control router')
+mustInclude(routerPy, "resource='git.commit_diff'", 'git_control router')
 mustInclude(routerPy, "'read_only': True", 'git_control router')
 mustInclude(routerPy, "'sanitized': True", 'git_control router')
 mustInclude(routerPy, "'source': GIT_CONTROL_SOURCE_LABEL", 'git_control router')
@@ -104,7 +108,7 @@ const requiredDomainSnippets = [
   'GIT_COMMITS_MAX_LIMIT',
   'GIT_CURSOR_PATTERN',
   'GIT_SHA_PATTERN',
-  "READ_ONLY_GIT_COMMANDS = frozenset({'status', 'log', 'branch'})",
+  "READ_ONLY_GIT_COMMANDS = frozenset({'status', 'log', 'branch', 'show'})",
   'FORBIDDEN_GIT_COMMANDS = frozenset',
   "'checkout'",
   "'reset'",
@@ -143,6 +147,13 @@ const requiredAdapterSnippets = [
   "'status'",
   "'log'",
   "'branch'",
+  "'show'",
+  "'--no-ext-diff'",
+  "'--patch'",
+  "'--numstat'",
+  'GIT_DIFF_MAX_LINES_PER_FILE',
+  'GIT_DIFF_MAX_TOTAL_LINES',
+  'GIT_DIFF_MAX_LINE_LENGTH',
   "'--porcelain=v1'",
   "'--branch'",
   "'--untracked-files=all'",
@@ -214,6 +225,14 @@ const requiredTestSnippets = [
   'HEAD..main:/srv/private-token',
   'test_git_commits_unknown_repo_and_degraded_repo_are_sanitized',
   'test_git_read_model_invocations_stay_allowlisted_and_hardened',
+  'test_git_commit_detail_returns_metadata_and_safe_file_stats_without_body_or_sensitive_paths',
+  'test_git_commit_detail_rejects_invalid_sha_without_echoing_revspec',
+  'test_git_commit_diff_redacts_omits_and_truncates_deny_by_default',
+  'test_git_commit_diff_omits_sensitive_paths_and_binary_content',
+  'test_git_detail_and_diff_invocations_stay_allowlisted_and_hardened',
+  'SYNTHETIC-TOKEN-MARKER',
+  "[redacted]",
+  'sensitive_path',
   '_assert_no_leakage',
   '.env',
   'super-secret-value',
@@ -227,6 +246,8 @@ mustInclude(readModelsDoc, 'git.repo_index', 'read models doc')
 mustInclude(readModelsDoc, 'git.repo_status', 'read models doc')
 mustInclude(readModelsDoc, 'git.commit_list', 'read models doc')
 mustInclude(readModelsDoc, 'git.branch_list', 'read models doc')
+mustInclude(readModelsDoc, 'git.commit_detail', 'read models doc')
+mustInclude(readModelsDoc, 'git.commit_diff', 'read models doc')
 mustInclude(readModelsDoc, 'El cuerpo libre del commit no forma parte del contrato público', 'read models doc')
 mustInclude(runtimeConfigDoc, 'Git control backend', 'runtime config doc')
 


### PR DESCRIPTION
## Objetivo

Implementa la microfase 40.3 de Issue #40: backend-only commit detail + safe diff read-only para repos Git allowlisteados.

## Alcance decidido

No he dividido más 40.3: commit detail y safe diff comparten validación de SHA, lectura Git `show`, stats por fichero y política deny-by-default. Quedan fuera:
- UI `/git` (40.4)
- working-tree diff (40.5)
- refs/rangos/revspecs arbitrarios
- cuerpo libre de commits
- acciones Git destructivas o remotas

## Cambios

- Añade `GET /api/v1/git/repos/{repo_id}/commits/{sha}`.
- Añade `GET /api/v1/git/repos/{repo_id}/commits/{sha}/diff`.
- Valida SHA completo hex SHA-1/SHA-256; no acepta `HEAD`, rangos ni revspecs.
- Mantiene cliente solo por `repo_id` allowlisteado.
- Extiende Git read adapter con `git show` read-only bajo hardening 40.1:
  - `shell=False`
  - `cwd` fijo del repo allowlisteado
  - timeout
  - env mínimo
  - `GIT_CONFIG_GLOBAL=/dev/null`
  - `GIT_CONFIG_SYSTEM=/dev/null`
  - `GIT_CONFIG_NOSYSTEM=1`
  - `core.fsmonitor=false`
  - `core.hooksPath=/dev/null`
  - `--no-ext-diff`
- Safe diff deny-by-default:
  - omite paths sensibles (`.env`, credenciales, logs, dumps, DBs)
  - omite binarios
  - redacta tokens/rutas host en líneas permitidas
  - trunca por fichero y total
  - expone razones genéricas (`sensitive_path`, `binary`) y flags `truncated/redacted/omitted`
- Actualiza tests, guardrail, docs, OpenSpec/checklist, AGENTS y `.engram`.

## Verificación ejecutada

- `python3 -m py_compile apps/api/src/modules/git_control/domain.py apps/api/src/modules/git_control/git_adapter.py apps/api/src/modules/git_control/service.py apps/api/src/modules/git_control/router.py apps/api/tests/test_git_control_api.py`
- `PYTHONPATH=. pytest apps/api/tests/test_git_control_api.py -q` -> 17 passed
- `npm run verify:git-control-backend-policy` -> passed
- `npm run verify:perimeter-policy` -> passed
- `git diff --check` -> OK

## Riesgos y mitigaciones

- Riesgo principal: diffs históricos pueden contener secretos. Mitigado con omisión por path sensible, omisión de binarios, redacción por contenido y truncado explícito.
- El parser de diff es deliberadamente estrecho y no pretende ser visor completo. Si duda, omite/redacta/trunca.
- Working-tree diff queda fuera por mayor riesgo de secretos no commiteados.

## Review solicitado

- Franky: operabilidad/runtime del subprocess Git read-only, límites, timeout/cwd/env mínimo, `--no-ext-diff`, mantenibilidad del guardrail.
- Chopper: seguridad, validación de SHA, ausencia de refs/revspecs cliente, no leakage, omisión/redacción/truncado deny-by-default.

Refs: Issue #40; microfase posterior a PR #90.