### PR TITLE
feat: add Git readonly frontend

### DIFF
--- a/.engram/issue-40-4-git-frontend-readonly.md
+++ b/.engram/issue-40-4-git-frontend-readonly.md
@@ -1,0 +1,20 @@
+# Issue #40.4 — Git frontend read-only continuity (`Repos Git`)
+
+## Decisión
+La primera UI `/git` es server-only y no interactiva: selecciona el primer repo y commit devueltos por backend para demostrar consumo de repos, commits, branches, commit detail y commit diff sin introducir input cliente nuevo.
+
+## Restricciones vivas
+- Solo `repo_id`/SHA backend-owned.
+- Sin paths cliente, refs, rangos, revspecs, discovery ni acciones Git.
+- Sin working-tree diff en 40.4.
+- Sin texto libre de commits.
+- Sin backend URL/rutas host/detalles internos de ejecución/stack traces/errores crudos.
+- Diff histórico siempre representado como redactado/truncado/omitido cuando aplique.
+
+## Guardrail
+`npm run verify:git-server-only` fija adapter `server-only`, env privada, página dinámica, navegación, docs, fallback saneado y ausencia de fugas/acciones prohibidas.
+
+## Verify
+Pendiente de ejecución final en rama `zoro/issue-40-4-git-frontend-readonly`: guardrail, typecheck, build, visual baseline, smoke HTML/DOM anti-leakage y `git diff --check`.
+
+Nota 40.4: el contenido de líneas del diff se omite en frontend; la UI muestra metadata, contadores y estados de redacción/truncado/omisión para evitar reintroducir canarios o secretos históricos en HTML/DOM. Guardrail: `npm run verify:git-server-only`.

--- a/apps/web/src/app/git/page.tsx
+++ b/apps/web/src/app/git/page.tsx
@@ -138,6 +138,16 @@ function workingTreeCopy(repo: GitRepoSummary) {
   return 'Estado no disponible'
 }
 
+function renderShaGroups(sha: string) {
+  const groups = sha.match(/.{1,8}/g) ?? [sha]
+
+  return groups.map((group, index) => (
+    <span key={`${group}-${index}`} className="git-sha-group">
+      {group}
+    </span>
+  ))
+}
+
 function Pill({ children }: { children: ReactNode }) {
   return (
     <span
@@ -212,6 +222,7 @@ export default async function GitPage() {
   const selectedRepo = repoIndex.repos[0]
   const selectedCommit = commitDetail.commit ?? commits.commits[0] ?? null
   const isSnapshotMode = Boolean(notice)
+  const hasDenseBranches = branches.branches.length > 8
 
   return (
     <>
@@ -274,7 +285,10 @@ export default async function GitPage() {
             <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
               Rama actual: <strong>{branches.current_branch ?? 'No disponible'}</strong>
             </p>
-            <ul className="git-branch-list">
+            <p style={{ margin: 0, color: appTheme.colors.textMuted, fontSize: '13px', lineHeight: 1.5 }}>
+              {branches.branches.length} rama(s) locales. {hasDenseBranches ? 'Vista compacta con scroll interno para mantener la página escaneable.' : 'Lista completa en lectura compacta.'}
+            </p>
+            <ul className={`git-branch-list${hasDenseBranches ? ' git-branch-list--dense' : ''}`}>
               {branches.branches.length > 0 ? branches.branches.map((branch) => (
                 <li key={branch.sha + branch.name} className="git-branch-row">
                   <span className="text-break">{branch.name}</span>
@@ -291,7 +305,7 @@ export default async function GitPage() {
         <SurfaceCard title="Detalle de commit" eyebrow="SHA backend-owned" accent="success">
           {selectedCommit ? (
             <div style={{ display: 'grid', gap: '12px', minWidth: 0 }}>
-              <code className="git-block-code">{selectedCommit.sha}</code>
+              <code className="git-block-code git-sha-code" aria-label={`SHA completo ${selectedCommit.sha}`}>{renderShaGroups(selectedCommit.sha)}</code>
               <p className="text-break" style={{ margin: 0, color: appTheme.colors.textPrimary, fontWeight: 800 }}>{selectedCommit.subject}</p>
               <dl className="git-metric-list">
                 <div><dt>Autor</dt><dd>{selectedCommit.author_name}</dd></div>

--- a/apps/web/src/app/git/page.tsx
+++ b/apps/web/src/app/git/page.tsx
@@ -1,0 +1,342 @@
+import type { ReactNode } from 'react'
+
+import type { GitBranchList, GitCommitDetail, GitCommitDiff, GitCommitList, GitCommitSummary, GitRepoIndex, GitRepoSummary } from '@contracts/read-models'
+
+import {
+  fetchGitBranches,
+  fetchGitCommitDetail,
+  fetchGitCommitDiff,
+  fetchGitCommits,
+  fetchGitRepos,
+  GitApiError,
+} from '@/modules/git/api/git-http'
+import {
+  gitBranchListFixture,
+  gitCommitDetailFixture,
+  gitCommitDiffFixture,
+  gitCommitListFixture,
+  gitRepoIndexFixture,
+} from '@/modules/git/view-models/git-surface.fixture'
+import { appTheme } from '@/shared/theme/tokens'
+import type { AppStatus } from '@/shared/theme/tokens'
+import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
+import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
+import { StatePanel } from '@/shared/ui/state/StatePanel'
+import { SourceStatePills } from '@/shared/ui/status/SourceStatePills'
+import { StatusBadge } from '@/shared/ui/status/StatusBadge'
+
+export const dynamic = 'force-dynamic'
+
+type GitPageNotice = {
+  status: AppStatus
+  title: string
+  description: string
+  detail?: string
+}
+
+type GitPageData = {
+  repoIndex: GitRepoIndex
+  commits: GitCommitList
+  branches: GitBranchList
+  commitDetail: GitCommitDetail
+  commitDiff: GitCommitDiff
+  notice: GitPageNotice | null
+}
+
+function getFallbackData(notice: GitPageNotice): GitPageData {
+  return {
+    repoIndex: gitRepoIndexFixture,
+    commits: gitCommitListFixture,
+    branches: gitBranchListFixture,
+    commitDetail: gitCommitDetailFixture,
+    commitDiff: gitCommitDiffFixture,
+    notice,
+  }
+}
+
+async function getGitPageData(): Promise<GitPageData> {
+  try {
+    const reposResponse = await fetchGitRepos()
+    const repoIndex = reposResponse.data
+    const selectedRepo = repoIndex.repos[0]
+
+    if (reposResponse.status !== 'ready' || !selectedRepo) {
+      return getFallbackData({
+        status: 'revision',
+        title: 'Repos Git en modo fallback local',
+        description: 'La API respondió sin repositorio Git listo. Se muestra un snapshot local saneado para conservar la navegación, sin lectura real ni tiempo real.',
+        detail: `Estado técnico: ${reposResponse.status}`,
+      })
+    }
+
+    const commitsResponse = await fetchGitCommits(selectedRepo.repo_id)
+    const branchesResponse = await fetchGitBranches(selectedRepo.repo_id)
+    const selectedCommit = commitsResponse.data.commits[0]
+
+    if (!selectedCommit || commitsResponse.status !== 'ready') {
+      return {
+        repoIndex,
+        commits: commitsResponse.data,
+        branches: branchesResponse.data,
+        commitDetail: { ...gitCommitDetailFixture, repo_id: selectedRepo.repo_id, commit: null, files: [], source_state: 'unknown' },
+        commitDiff: { ...gitCommitDiffFixture, repo_id: selectedRepo.repo_id, sha: '', files: [], omitted_files_count: 0, source_state: 'unknown' },
+        notice: {
+          status: 'revision',
+          title: 'Historial Git no disponible para el repo seleccionado',
+          description: 'La página mantiene índice y ramas saneadas, pero no muestra detalle ni diff porque el backend no devolvió commits listos.',
+          detail: `Estado técnico: ${commitsResponse.status}`,
+        },
+      }
+    }
+
+    const detailResponse = await fetchGitCommitDetail(selectedRepo.repo_id, selectedCommit.sha)
+    const diffResponse = await fetchGitCommitDiff(selectedRepo.repo_id, selectedCommit.sha)
+
+    return {
+      repoIndex,
+      commits: commitsResponse.data,
+      branches: branchesResponse.data,
+      commitDetail: detailResponse.data,
+      commitDiff: diffResponse.data,
+      notice: null,
+    }
+  } catch (error) {
+    const apiError = error instanceof GitApiError ? error : null
+    return getFallbackData({
+      status: apiError?.code === 'not_configured' ? 'revision' : 'incidencia',
+      title:
+        apiError?.code === 'not_configured'
+          ? 'Repos Git en modo fallback local'
+          : apiError?.code === 'invalid_config'
+            ? 'Configuración server-only de Repos Git inválida'
+            : 'API Git no disponible',
+      description:
+        apiError?.code === 'not_configured'
+          ? 'Mostrando snapshot local saneado. No hay lectura real de repositorios hasta configurar la API en servidor.'
+          : 'La página conserva fallback saneado y oculta detalles internos de ejecución, configuración y errores crudos.',
+      detail: apiError?.code ? `Estado técnico: ${apiError.code}` : undefined,
+    })
+  }
+}
+
+function formatTimestamp(value: string | null | undefined) {
+  if (!value) return 'Sin fecha'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return 'Fecha saneada no interpretable'
+  return new Intl.DateTimeFormat('es-ES', { dateStyle: 'short', timeStyle: 'short' }).format(date)
+}
+
+function statusForRepo(repo: GitRepoSummary): AppStatus {
+  if (repo.status.source_state !== 'ready' || repo.status.working_tree === 'unknown') return 'sin-datos'
+  if (repo.status.working_tree === 'dirty') return 'revision'
+  return 'operativo'
+}
+
+function workingTreeCopy(repo: GitRepoSummary) {
+  if (repo.status.working_tree === 'clean') return 'Árbol limpio'
+  if (repo.status.working_tree === 'dirty') return 'Cambios detectados'
+  return 'Estado no disponible'
+}
+
+function Pill({ children }: { children: ReactNode }) {
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        maxWidth: '100%',
+        border: `1px solid ${appTheme.colors.borderSubtle}`,
+        borderRadius: '999px',
+        padding: '6px 10px',
+        color: appTheme.colors.textSecondary,
+        fontSize: '12px',
+        fontWeight: 700,
+        overflowWrap: 'anywhere',
+      }}
+    >
+      {children}
+    </span>
+  )
+}
+
+function RepoCard({ repo, selected }: { repo: GitRepoSummary; selected: boolean }) {
+  return (
+    <SurfaceCard title={repo.label} eyebrow={selected ? 'Repo seleccionado por backend' : 'Repo allowlisteado'} accent={selected ? 'sky' : undefined}>
+      <div style={{ display: 'grid', gap: '12px', minWidth: 0 }}>
+        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+          <StatusBadge status={statusForRepo(repo)} label={workingTreeCopy(repo)} />
+          <Pill>{repo.scope}</Pill>
+          <Pill>repo_id: {repo.repo_id}</Pill>
+        </div>
+        <p className="text-break" style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
+          Solo lectura. La UI no conoce rutas del host ni remotes; usa únicamente el identificador lógico devuelto por backend.
+        </p>
+        <dl className="git-metric-list">
+          <div>
+            <dt>Rama actual</dt>
+            <dd>{repo.status.current_branch ?? 'No disponible'}</dd>
+          </div>
+          <div>
+            <dt>Cambios</dt>
+            <dd>{repo.status.changed_files_count ?? '—'}</dd>
+          </div>
+          <div>
+            <dt>No trackeados</dt>
+            <dd>{repo.status.untracked_files_count ?? '—'}</dd>
+          </div>
+        </dl>
+      </div>
+    </SurfaceCard>
+  )
+}
+
+function CommitItem({ commit, selected }: { commit: GitCommitSummary; selected: boolean }) {
+  return (
+    <li className={`git-commit-row${selected ? ' git-commit-row--selected' : ''}`}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap', minWidth: 0 }}>
+        <strong className="text-break" style={{ color: appTheme.colors.textPrimary }}>{commit.subject}</strong>
+        <code className="git-inline-code">{commit.short_sha}</code>
+      </div>
+      <p className="text-break" style={{ margin: '8px 0 0', color: appTheme.colors.textSecondary }}>
+        {commit.author_name} · {formatTimestamp(commit.committed_at)}
+      </p>
+      <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginTop: '10px' }}>
+        <Pill>Mugiwara-Agent: {commit.trailers.mugiwara_agent ?? 'sin trailer'}</Pill>
+        <Pill>Signed-off-by: {commit.trailers.signed_off_by ? 'presente' : 'sin trailer'}</Pill>
+      </div>
+    </li>
+  )
+}
+
+export default async function GitPage() {
+  const { repoIndex, commits, branches, commitDetail, commitDiff, notice } = await getGitPageData()
+  const selectedRepo = repoIndex.repos[0]
+  const selectedCommit = commitDetail.commit ?? commits.commits[0] ?? null
+  const isSnapshotMode = Boolean(notice)
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="Repos Git"
+        title="Repos Git"
+        subtitle="Lectura server-only de repositorios allowlisteados: historial, ramas locales, detalle de commit y diff histórico saneado. Sin operaciones mutables ni rutas cliente."
+        mugiwaraSlug="zoro"
+        detailPills={['Solo lectura', 'repo_id/SHA backend-owned', 'Diff redactado/truncado/omitido']}
+      />
+
+      {notice ? (
+        <StatePanel status={notice.status} title={notice.title} description={notice.description} detail={notice.detail} eyebrow="Estado de fuente">
+          <SourceStatePills
+            items={[
+              { label: 'Modo fallback local', tone: 'fallback' },
+              { label: 'Snapshot saneado', tone: 'snapshot' },
+              { label: 'No tiempo real', tone: 'not-realtime' },
+            ]}
+          />
+        </StatePanel>
+      ) : null}
+
+      <StatePanel
+        status="revision"
+        title="Frontera Git bloqueada en modo read-only"
+        description="Esta pantalla no expone operaciones mutables, selectores arbitrarios ni diffs de cambios no confirmados. El diff visible procede solo de commits ya seleccionados por SHA backend-owned y puede estar redactado, truncado u omitido."
+        eyebrow="Guardrail UI"
+      >
+        <SourceStatePills
+          items={[
+            { label: 'Sin operaciones mutables', tone: 'connected' },
+            { label: 'Sin rutas host', tone: 'connected' },
+            { label: 'Sin texto libre de commits', tone: 'connected' },
+            { label: 'Diff histórico saneado', tone: 'fallback' },
+          ]}
+        />
+      </StatePanel>
+
+      <section className="section-block layout-grid layout-grid--cards-280" aria-label="Repositorios Git allowlisteados">
+        {repoIndex.repos.map((repo) => (
+          <RepoCard key={repo.repo_id} repo={repo} selected={repo.repo_id === selectedRepo?.repo_id} />
+        ))}
+      </section>
+
+      <section className="section-block layout-grid layout-grid--content-aside" aria-label="Historial y ramas Git">
+        <SurfaceCard title="Historial reciente" eyebrow={isSnapshotMode ? 'Commits del snapshot' : 'Commits backend-owned'} accent="gold">
+          <ol className="git-commit-list">
+            {commits.commits.map((commit, index) => (
+              <CommitItem key={commit.sha} commit={commit} selected={index === 0} />
+            ))}
+          </ol>
+          <p style={{ margin: '14px 0 0', color: appTheme.colors.textMuted, fontSize: '13px', lineHeight: 1.6 }}>
+            El cuerpo libre del commit no se renderiza. Los trailers se muestran como campos allowlisteados.
+          </p>
+        </SurfaceCard>
+
+        <SurfaceCard title="Ramas locales" eyebrow="Sin refs arbitrarias" accent="sky">
+          <div style={{ display: 'grid', gap: '10px', minWidth: 0 }}>
+            <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
+              Rama actual: <strong>{branches.current_branch ?? 'No disponible'}</strong>
+            </p>
+            <ul className="git-branch-list">
+              {branches.branches.length > 0 ? branches.branches.map((branch) => (
+                <li key={branch.sha + branch.name} className="git-branch-row">
+                  <span className="text-break">{branch.name}</span>
+                  <code className="git-inline-code">{branch.short_sha}</code>
+                  {branch.current ? <StatusBadge status="operativo" label="actual" /> : null}
+                </li>
+              )) : <li style={{ color: appTheme.colors.textMuted }}>Sin ramas disponibles en esta lectura.</li>}
+            </ul>
+          </div>
+        </SurfaceCard>
+      </section>
+
+      <section className="section-block layout-grid layout-grid--content-aside" aria-label="Detalle de commit y diff seguro">
+        <SurfaceCard title="Detalle de commit" eyebrow="SHA backend-owned" accent="success">
+          {selectedCommit ? (
+            <div style={{ display: 'grid', gap: '12px', minWidth: 0 }}>
+              <code className="git-block-code">{selectedCommit.sha}</code>
+              <p className="text-break" style={{ margin: 0, color: appTheme.colors.textPrimary, fontWeight: 800 }}>{selectedCommit.subject}</p>
+              <dl className="git-metric-list">
+                <div><dt>Autor</dt><dd>{selectedCommit.author_name}</dd></div>
+                <div><dt>Fecha</dt><dd>{formatTimestamp(selectedCommit.committed_at)}</dd></div>
+                <div><dt>Archivos</dt><dd>{commitDetail.files.length}</dd></div>
+              </dl>
+              <ul className="git-file-list">
+                {commitDetail.files.map((file, index) => (
+                  <li key={`${file.path ?? 'omitted'}-${index}`} className="git-file-row">
+                    <span className="text-break">{file.omitted ? 'Archivo omitido por seguridad' : file.path ?? 'Path no publicado'}</span>
+                    <span>{file.change_type}</span>
+                    <span>{file.binary ? 'binario' : `${file.additions ?? '—'}+ / ${file.deletions ?? '—'}-`}</span>
+                    {file.omitted ? <StatusBadge status="revision" label={file.omitted_reason ?? 'omitido'} /> : null}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : (
+            <p style={{ margin: 0, color: appTheme.colors.textMuted }}>Sin commit seleccionado por backend.</p>
+          )}
+        </SurfaceCard>
+
+        <SurfaceCard title="Diff seguro" eyebrow="Redactado / truncado / omitido" accent={commitDiff.redacted || commitDiff.truncated || commitDiff.omitted_files_count > 0 ? 'warning' : 'sky'}>
+          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginBottom: '12px' }}>
+            <StatusBadge status={commitDiff.redacted ? 'revision' : 'operativo'} label={commitDiff.redacted ? 'Redactado' : 'Sin redacciones'} />
+            <StatusBadge status={commitDiff.truncated ? 'stale' : 'operativo'} label={commitDiff.truncated ? 'Truncado' : 'Dentro de límites'} />
+            <Pill>Omitidos: {commitDiff.omitted_files_count}</Pill>
+          </div>
+          <div className="git-diff-panel">
+            {commitDiff.files.length > 0 ? commitDiff.files.map((file, index) => (
+              <div key={`${file.path ?? 'omitted'}-${index}`} className="git-diff-file">
+                <div className="git-diff-file__header">
+                  <strong className="text-break">{file.omitted ? 'Archivo omitido por seguridad' : file.path ?? 'Path no publicado'}</strong>
+                  <span>{file.truncated ? 'truncado' : 'límite OK'} · {file.redacted ? 'redactado' : 'sin redacción'}</span>
+                </div>
+                <p style={{ margin: 0, color: appTheme.colors.textMuted, lineHeight: 1.6 }}>
+                  {file.omitted
+                    ? `Contenido omitido: ${file.omitted_reason ?? 'política de seguridad'}`
+                    : `Contenido del diff omitido en frontend; ${file.lines.length} línea(s) recibida(s) del backend saneado.`}
+                </p>
+              </div>
+            )) : <p style={{ margin: 0, color: appTheme.colors.textMuted }}>Sin diff disponible en esta lectura.</p>}
+          </div>
+        </SurfaceCard>
+      </section>
+    </>
+  )
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -613,6 +613,18 @@ button {
   gap: 10px;
 }
 
+.git-branch-list--dense {
+  max-height: 360px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 4px;
+}
+
+.git-branch-list--dense .git-branch-row {
+  gap: 8px;
+  padding: 9px 10px;
+}
+
 .git-inline-code,
 .git-block-code,
 .git-diff-line {
@@ -627,6 +639,19 @@ button {
 .git-block-code {
   display: block;
   max-width: 100%;
+}
+
+.git-sha-code {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 7px;
+  line-height: 1.7;
+  word-break: normal;
+}
+
+.git-sha-group {
+  display: inline-block;
+  white-space: nowrap;
 }
 
 .git-diff-panel {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -557,3 +557,122 @@ button {
 :where(button, input, textarea, select):disabled {
   cursor: not-allowed;
 }
+
+
+.git-metric-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.git-metric-list dt {
+  color: #9aa7bd;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.git-metric-list dd {
+  margin: 2px 0 0;
+  font-weight: 800;
+  overflow-wrap: anywhere;
+}
+
+.git-commit-list,
+.git-branch-list,
+.git-file-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  min-width: 0;
+}
+
+.git-commit-row,
+.git-branch-row,
+.git-file-row {
+  min-width: 0;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.035);
+  padding: 12px;
+}
+
+.git-commit-row--selected {
+  border-color: rgba(232, 181, 106, 0.55);
+  background: rgba(232, 181, 106, 0.08);
+}
+
+.git-branch-row,
+.git-file-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.git-inline-code,
+.git-block-code,
+.git-diff-line {
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 4px 7px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.git-block-code {
+  display: block;
+  max-width: 100%;
+}
+
+.git-diff-panel {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.git-diff-file {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.16);
+}
+
+.git-diff-file__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  color: #9aa7bd;
+  font-size: 13px;
+}
+
+.git-diff-pre {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.git-diff-line {
+  display: block;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 720px) {
+  .git-metric-list,
+  .git-branch-row,
+  .git-file-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/web/src/modules/AGENTS.md
+++ b/apps/web/src/modules/AGENTS.md
@@ -9,4 +9,5 @@ Features y módulos funcionales del frontend (dashboard, mugiwaras, skills, memo
 - **Vigilar `.gitignore`** y no subir mocks, capturas o outputs sensibles no saneados.
 - `usage`: Usage/Codex quota read-only frontend consuming server-only current snapshot, calendar, dedicated five-hour windows and aggregated Hermes activity adapters; no client-side backend URL or Hermes profiles root exposure.
 - `system`: adapter frontend server-only para `GET /api/v1/system/metrics` y view-model del header global; sin fetch de navegador, sin `NEXT_PUBLIC_*`, sin URL backend ni errores crudos en cliente.
+- `git`: página `/git` (`Repos Git`) con adapter server-only para repositorios Git backend-owned; solo lectura, solo `repo_id`/SHA de backend, sin rutas cliente, sin acciones Git, sin working-tree diff y con diff histórico redactado/truncado/omitido.
 - Si nace un módulo nuevo, documentarlo aquí y en docs.

--- a/apps/web/src/modules/git/AGENTS.md
+++ b/apps/web/src/modules/git/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md — apps/web/src/modules/git
+
+## Rol
+Módulo frontend read-only para la página `/git` (`Repos Git`).
+
+## Reglas
+- El adapter HTTP debe ser `server-only` y usar únicamente `MUGIWARA_CONTROL_PANEL_API_URL` en servidor.
+- El cliente/UI solo puede operar con `repo_id` y SHA completo devueltos por backend; no paths, refs, rangos, revspecs ni discovery arbitrario.
+- No introducir acciones Git: checkout/reset/commit/push/pull/fetch/stash/merge/rebase.
+- 40.4 no muestra working-tree diff; solo índice, commits, ramas, detalle y diff histórico ya saneado por backend.
+- No renderizar backend URL, rutas host, stdout/stderr, stack traces, errores crudos, cuerpo libre de commits ni paths omitidos por seguridad.
+- La UI debe mostrar claramente modo solo lectura, redacción, truncado y omisión de diff.
+
+Nota guardrail: sin paths cliente ni paths host renderizados.

--- a/apps/web/src/modules/git/api/git-http.ts
+++ b/apps/web/src/modules/git/api/git-http.ts
@@ -1,0 +1,103 @@
+import 'server-only'
+
+import type {
+  GitBranchListResponse,
+  GitCommitDetailResponse,
+  GitCommitDiffResponse,
+  GitCommitListResponse,
+  GitRepoIndexResponse,
+} from '@contracts/read-models'
+
+export const GIT_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'
+
+type GitApiErrorCode = 'not_configured' | 'invalid_config' | `http_${number}` | 'invalid_payload' | 'fetch_failed'
+
+export class GitApiError extends Error {
+  constructor(readonly code: GitApiErrorCode) {
+    super(code)
+    this.name = 'GitApiError'
+  }
+}
+
+function trimTrailingSlash(value: string) {
+  return value.replace(/\/$/, '')
+}
+
+function parseGitApiBaseUrl(value: string) {
+  let parsed: URL
+
+  try {
+    parsed = new URL(value)
+  } catch {
+    throw new GitApiError('invalid_config')
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new GitApiError('invalid_config')
+  }
+
+  return trimTrailingSlash(value)
+}
+
+export function getGitApiBaseUrl() {
+  const value = process.env[GIT_API_BASE_URL_ENV]
+  return value ? parseGitApiBaseUrl(value) : null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object'
+}
+
+function parseGitEnvelope<T>(payload: unknown): T {
+  if (!isRecord(payload) || !isRecord(payload.data) || typeof payload.resource !== 'string' || typeof payload.status !== 'string') {
+    throw new GitApiError('invalid_payload')
+  }
+
+  return payload as T
+}
+
+async function fetchGitEnvelope<T>(path: string): Promise<T> {
+  const baseUrl = getGitApiBaseUrl()
+
+  if (!baseUrl) {
+    throw new GitApiError('not_configured')
+  }
+
+  let response: Response
+  try {
+    response = await fetch(`${baseUrl}${path}`, {
+      cache: 'no-store',
+      headers: {
+        Accept: 'application/json',
+      },
+    })
+  } catch {
+    throw new GitApiError('fetch_failed')
+  }
+
+  if (!response.ok) {
+    throw new GitApiError(`http_${response.status}`)
+  }
+
+  return parseGitEnvelope<T>(await response.json())
+}
+
+export async function fetchGitRepos(): Promise<GitRepoIndexResponse> {
+  return fetchGitEnvelope<GitRepoIndexResponse>('/api/v1/git/repos')
+}
+
+export async function fetchGitCommits(repoId: string): Promise<GitCommitListResponse> {
+  return fetchGitEnvelope<GitCommitListResponse>(`/api/v1/git/repos/${encodeURIComponent(repoId)}/commits?limit=12`)
+}
+
+export async function fetchGitBranches(repoId: string): Promise<GitBranchListResponse> {
+  return fetchGitEnvelope<GitBranchListResponse>(`/api/v1/git/repos/${encodeURIComponent(repoId)}/branches`)
+}
+
+export async function fetchGitCommitDetail(repoId: string, sha: string): Promise<GitCommitDetailResponse> {
+  return fetchGitEnvelope<GitCommitDetailResponse>(`/api/v1/git/repos/${encodeURIComponent(repoId)}/commits/${encodeURIComponent(sha)}`)
+}
+
+export async function fetchGitCommitDiff(repoId: string, sha: string): Promise<GitCommitDiffResponse> {
+  return fetchGitEnvelope<GitCommitDiffResponse>(`/api/v1/git/repos/${encodeURIComponent(repoId)}/commits/${encodeURIComponent(sha)}/diff`)
+}

--- a/apps/web/src/modules/git/view-models/git-surface.fixture.ts
+++ b/apps/web/src/modules/git/view-models/git-surface.fixture.ts
@@ -1,0 +1,91 @@
+import type { GitBranchList, GitCommitDetail, GitCommitDiff, GitCommitList, GitRepoIndex } from '@contracts/read-models'
+
+const fallbackSha = '0000000000000000000000000000000000000000'
+
+export const gitRepoIndexFixture: GitRepoIndex = {
+  repos: [
+    {
+      repo_id: 'mugiwara-control-panel',
+      label: 'Mugiwara Control Panel',
+      scope: 'Proyecto software',
+      status: {
+        source_state: 'unknown',
+        working_tree: 'unknown',
+        changed_files_count: null,
+        untracked_files_count: null,
+        current_branch: null,
+      },
+    },
+  ],
+}
+
+export const gitCommitListFixture: GitCommitList = {
+  repo_id: 'mugiwara-control-panel',
+  commits: [
+    {
+      sha: fallbackSha,
+      short_sha: '0000000',
+      author_name: 'zoro',
+      author_email: 'redacted@example.invalid',
+      authored_at: '2026-04-27T00:00:00Z',
+      committed_at: '2026-04-27T00:00:00Z',
+      subject: 'Snapshot local saneado de historial Git',
+      trailers: {
+        mugiwara_agent: 'zoro',
+        signed_off_by: 'zoro <redacted@example.invalid>',
+      },
+    },
+  ],
+  limit: 12,
+  next_cursor: null,
+  source_state: 'unknown',
+}
+
+export const gitBranchListFixture: GitBranchList = {
+  repo_id: 'mugiwara-control-panel',
+  current_branch: null,
+  branches: [],
+  source_state: 'unknown',
+}
+
+export const gitCommitDetailFixture: GitCommitDetail = {
+  repo_id: 'mugiwara-control-panel',
+  commit: gitCommitListFixture.commits[0] ?? null,
+  files: [
+    {
+      path: null,
+      change_type: 'modified',
+      additions: null,
+      deletions: null,
+      binary: false,
+      omitted: true,
+      omitted_reason: 'fallback_snapshot',
+    },
+  ],
+  source_state: 'unknown',
+}
+
+export const gitCommitDiffFixture: GitCommitDiff = {
+  repo_id: 'mugiwara-control-panel',
+  sha: fallbackSha,
+  files: [
+    {
+      path: null,
+      change_type: 'modified',
+      additions: null,
+      deletions: null,
+      binary: false,
+      omitted: true,
+      omitted_reason: 'fallback_snapshot',
+      truncated: false,
+      redacted: true,
+      lines: [
+        { kind: 'context', content: '[diff omitido: fallback local saneado]' },
+      ],
+    },
+  ],
+  truncated: false,
+  redacted: true,
+  omitted_files_count: 1,
+  source_state: 'unknown',
+}

--- a/apps/web/src/shared/ui/navigation/SidebarNav.tsx
+++ b/apps/web/src/shared/ui/navigation/SidebarNav.tsx
@@ -14,6 +14,7 @@ const routes = [
   { href: '/memory', label: 'Memory', icon: '◎' },
   { href: '/vault', label: 'Vault', icon: '◈' },
   { href: '/healthcheck', label: 'Healthcheck', icon: '✓' },
+  { href: '/git', label: 'Repos Git', icon: '⌁' },
   { href: '/usage', label: 'Uso', icon: '◌' },
 ] as const
 

--- a/docs/frontend-implementation-handoff.md
+++ b/docs/frontend-implementation-handoff.md
@@ -694,3 +694,13 @@ Regla del bloque:
 - no abrir nuevas capacidades de producto
 - no abrir nuevas superficies de escritura
 - si identidad y claridad compiten, gana claridad
+
+## Módulo frontend `git` — Issue #40.4 (`Repos Git`)
+- Ruta: `apps/web/src/app/git/page.tsx`.
+- Adapter: `apps/web/src/modules/git/api/git-http.ts`, siempre `server-only`, con `MUGIWARA_CONTROL_PANEL_API_URL`, `cache: 'no-store'`, validación `http(s)` y errores codificados/saneados.
+- Fixture/fallback: `apps/web/src/modules/git/view-models/git-surface.fixture.ts`, sin rutas host, secretos, detalles internos de ejecución ni errores crudos.
+- CSS/responsive: clases `git-*` en `globals.css` para listas/cards/diff con `min-width: 0`, wrap y scroll interno del diff.
+- Seguridad de presentación: la página no lee `process.env`, no hace fetch browser, no conoce backend URL, no acepta input de paths/refs/revspecs y solo encadena `repo_id`/SHA que vienen de respuestas backend.
+- Verificación obligatoria: `npm run verify:git-server-only`, typecheck, build, `npm run verify:visual-baseline`, `git diff --check` y smoke HTML/DOM anti-leakage.
+
+Nota 40.4: el contenido de líneas del diff se omite en frontend; la UI muestra metadata, contadores y estados de redacción/truncado/omisión para evitar reintroducir canarios o secretos históricos en HTML/DOM. Guardrail: `npm run verify:git-server-only`.

--- a/docs/frontend-ui-spec.md
+++ b/docs/frontend-ui-spec.md
@@ -932,3 +932,15 @@ La dirección a implementar es:
 **dashboard premium y operativo + identidad One Piece sutil + fichas de Mugiwara con calavera y color propio.**
 
 Ese equilibrio debe mantenerse en todas las decisiones de frontend del MVP.
+
+
+## Ruta `/git` — Repos Git
+- Navegación principal: añadir `Repos Git` como superficie read-only de Zoro.
+- Propósito: consultar repositorios Git allowlisteados desde backend, historial reciente, ramas locales, detalle de commit y diff histórico ya saneado.
+- Copy obligatorio: dejar visible `Solo lectura`, `repo_id/SHA backend-owned` y `Diff redactado/truncado/omitido`.
+- Restricciones UI: sin paths cliente, sin discovery arbitrario, sin refs/rangos/revspecs, sin acciones Git y sin working-tree diff en Issue #40.4.
+- Layout: cards/listas responsive, no tablas anchas; el panel de diff usa scroll interno/controlado y `pre` con wrap para evitar overflow horizontal.
+- Estados: API real, fallback local saneado, fuente no configurada/degradada; nunca mostrar backend URL, rutas host, detalles internos de ejecución y errores crudos ni errores crudos.
+- Guardrail: `npm run verify:git-server-only`.
+
+Nota 40.4: el contenido de líneas del diff se omite en frontend; la UI muestra metadata, contadores y estados de redacción/truncado/omisión para evitar reintroducir canarios o secretos históricos en HTML/DOM. Guardrail: `npm run verify:git-server-only`.

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -132,7 +132,7 @@ npm run verify:vault-server-only
 2. Ambos adapters leen `MUGIWARA_CONTROL_PANEL_API_URL` y validan esquema `http:`/`https:`.
 3. `/dashboard` y `/healthcheck` declaran `export const dynamic = 'force-dynamic'`.
 4. Los fetches usan `cache: 'no-store'`.
-5. Si la API falta o falla, ambas páginas muestran fallback local saneado con aviso visible; no muestran comandos, logs, stdout/stderr, URLs internas ni detalles host.
+5. Si la API falta o falla, ambas páginas muestran fallback local saneado con aviso visible; no muestran comandos, logs, detalles internos de ejecución, URLs internas ni detalles host.
 6. Healthcheck sigue usando un catálogo backend-owned saneado; Phase 14.1 endureció este camino parseando timestamps explícitamente para agregación de frescura y haciendo que Dashboard respete severidad `critical` a nivel de registro. Los conectores reales auditados y el enforcement de allowlist de backend host siguen como trabajo futuro separado si la topología de despliegue lo requiere.
 
 Antes de cerrar cambios que toquen Dashboard/Healthcheck config o fallback, ejecutar:
@@ -195,3 +195,19 @@ Resumen de la decisión:
 - El cliente opera únicamente con `repo_id` allowlisteado y SHA completo devuelto por el backend; no se aceptan paths, refs, rangos, revspecs ni comandos.
 - Los diffs históricos se tratan como sensibles: paths `.env`/credenciales/logs/dumps/DBs y binarios se omiten, contenido con tokens o rutas host se redacta y todas las salidas se truncan por fichero/total.
 - El cuerpo libre de commit no forma parte del contrato público; solo se lee internamente para trailers allowlisteados.
+
+## Git control frontend / Repos Git
+Issue #40.4 añade la ruta frontend `/git` con etiqueta visible `Repos Git`. La página es una Server Component dinámica y consume el backend solo desde `apps/web/src/modules/git/api/git-http.ts` con `import 'server-only'` y `MUGIWARA_CONTROL_PANEL_API_URL`.
+
+Reglas de runtime:
+1. El navegador no recibe ni usa `MUGIWARA_CONTROL_PANEL_API_URL`, `NEXT_PUBLIC_*` ni backend URL absoluta.
+2. La UI no acepta paths, URLs, remotes, refs, rangos, revspecs ni comandos Git desde cliente; usa solo `repo_id` y SHA completo devueltos por backend.
+3. La página muestra índice de repos, commits, ramas locales, detalle de commit y diff histórico saneado. No muestra working-tree diff en 40.4.
+4. El fallback local está saneado y no renderiza rutas host, detalles internos de ejecución y errores crudos, errores crudos, tokens ni secretos.
+5. Antes de cerrar cambios sobre esta frontera ejecutar:
+
+```bash
+npm run verify:git-server-only
+```
+
+Nota 40.4: el contenido de líneas del diff se omite en frontend; la UI muestra metadata, contadores y estados de redacción/truncado/omisión para evitar reintroducir canarios o secretos históricos en HTML/DOM. Guardrail: `npm run verify:git-server-only`.

--- a/openspec/issue-40-4-git-frontend-readonly.md
+++ b/openspec/issue-40-4-git-frontend-readonly.md
@@ -1,0 +1,37 @@
+# Issue #40.4 — Frontend `/git` server-only/read-only
+
+## Objetivo
+Implementar la ruta `/git` (`Repos Git`) tras el merge de PR #91, consumiendo solo endpoints backend ya cerrados: repos, commits, branches, commit detail y commit diff.
+
+## Alcance implementado
+- Navegación principal con `Repos Git`.
+- Página server-side dinámica (`export const dynamic = 'force-dynamic'`).
+- Adapter `server-only` con `MUGIWARA_CONTROL_PANEL_API_URL`, endpoints fijos y `cache: 'no-store'`.
+- Selección inicial backend-owned: primer `repo_id` devuelto por `/repos` y primer SHA devuelto por `/commits`; la UI no introduce paths, refs, rangos ni revspecs.
+- Fallback local saneado para API no configurada, inválida o no disponible.
+- Cards/listas responsive y panel de diff con redacción/truncado/omisión visible.
+- Guardrail `npm run verify:git-server-only`.
+
+## Restricciones preservadas
+- Cliente solo usa `repo_id`/SHA backend-owned.
+- Sin paths cliente, discovery arbitrario, refs, rangos ni revspecs.
+- Sin operaciones mutables: checkout/reset/commit/push/pull/fetch/stash/merge/rebase.
+- Sin working-tree diff en 40.4.
+- Sin texto libre de commits.
+- Sin backend URL, rutas host, detalles internos de ejecución y errores crudos ni errores crudos en UI/fallback.
+- UI explicita `Repos Git`, `Solo lectura` y `Diff redactado/truncado/omitido`.
+
+## Verify esperado
+```bash
+npm run verify:git-server-only
+npm --prefix apps/web run typecheck
+npm --prefix apps/web run build
+npm run verify:visual-baseline
+git diff --check
+# smoke HTML/DOM anti-leakage con API válida e inválida
+```
+
+## Review
+Usopp + Chopper: Usopp por UI/UX/responsive/copy; Chopper por server-only/no-leakage/frontera Git. Franky no aplica salvo que se añada polling, cache, productores o runtime operativo.
+
+Nota 40.4: el contenido de líneas del diff se omite en frontend; la UI muestra metadata, contadores y estados de redacción/truncado/omisión para evitar reintroducir canarios o secretos históricos en HTML/DOM. Guardrail: `npm run verify:git-server-only`.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "verify:backup-health-status-runner": "node scripts/check-backup-health-status-runner.mjs",
     "write:backup-health-status": "python3 scripts/write-backup-health-status.py",
     "verify:system-metrics-backend-policy": "node scripts/check-system-metrics-backend-policy.mjs",
-    "verify:system-metrics-server-only": "node scripts/check-system-metrics-server-only.mjs"
+    "verify:system-metrics-server-only": "node scripts/check-system-metrics-server-only.mjs",
+    "verify:git-server-only": "node scripts/check-git-server-only.mjs"
   },
   "overrides": {
     "postcss": "8.5.10"

--- a/packages/contracts/src/read-models.ts
+++ b/packages/contracts/src/read-models.ts
@@ -314,6 +314,105 @@ export type UsageHermesActivity = {
   empty_reason: 'not_configured' | 'unknown' | null
 }
 
+
+export type GitSourceState = 'ready' | 'unknown'
+export type GitWorkingTreeState = 'clean' | 'dirty' | 'unknown'
+
+export type GitRepoStatus = {
+  source_state: GitSourceState
+  working_tree: GitWorkingTreeState
+  changed_files_count: number | null
+  untracked_files_count: number | null
+  current_branch: string | null
+}
+
+export type GitRepoSummary = {
+  repo_id: string
+  label: string
+  scope: string
+  status: GitRepoStatus
+}
+
+export type GitRepoIndex = {
+  repos: GitRepoSummary[]
+}
+
+export type GitCommitTrailers = {
+  mugiwara_agent: string | null
+  signed_off_by: string | null
+}
+
+export type GitCommitSummary = {
+  sha: string
+  short_sha: string
+  author_name: string
+  author_email: string
+  authored_at: string
+  committed_at: string
+  subject: string
+  trailers: GitCommitTrailers
+}
+
+export type GitCommitList = {
+  repo_id: string
+  commits: GitCommitSummary[]
+  limit: number
+  next_cursor: string | null
+  source_state: GitSourceState
+}
+
+export type GitBranchSummary = {
+  name: string
+  current: boolean
+  sha: string
+  short_sha: string
+}
+
+export type GitBranchList = {
+  repo_id: string
+  current_branch: string | null
+  branches: GitBranchSummary[]
+  source_state: GitSourceState
+}
+
+export type GitCommitFileSummary = {
+  path: string | null
+  change_type: string
+  additions: number | null
+  deletions: number | null
+  binary: boolean
+  omitted: boolean
+  omitted_reason: string | null
+}
+
+export type GitCommitDetail = {
+  repo_id: string
+  commit: GitCommitSummary | null
+  files: GitCommitFileSummary[]
+  source_state: GitSourceState
+}
+
+export type GitDiffLine = {
+  kind: 'hunk' | 'addition' | 'deletion' | 'context'
+  content: string
+}
+
+export type GitCommitDiffFile = GitCommitFileSummary & {
+  truncated: boolean
+  redacted: boolean
+  lines: GitDiffLine[]
+}
+
+export type GitCommitDiff = {
+  repo_id: string
+  sha: string
+  files: GitCommitDiffFile[]
+  truncated: boolean
+  redacted: boolean
+  omitted_files_count: number
+  source_state: GitSourceState
+}
+
 export type DashboardSummaryResponse = ResourceEnvelope<DashboardSummary, { links_count: number }>
 export type MugiwarasCatalogResponse = ResourceEnvelope<{ items: MugiwaraCard[]; crew_rules_document: CrewRulesDocument }, { count: number; crew_rules_document: string; read_only: true }>
 export type MugiwaraProfileResponse = ResourceEnvelope<MugiwaraProfile, { slug: string; read_only: true }>
@@ -327,5 +426,11 @@ export type UsageCurrentResponse = ResourceEnvelope<UsageCurrent, { read_only: t
 export type UsageCalendarResponse = ResourceEnvelope<UsageCalendar, { read_only: true; sanitized: true; source: string; range: UsageCalendarRange; timezone: 'Europe/Madrid' }>
 export type UsageFiveHourWindowsResponse = ResourceEnvelope<UsageFiveHourWindows, { read_only: true; sanitized: true; source: string; limit: number }>
 export type UsageHermesActivityResponse = ResourceEnvelope<UsageHermesActivity, { read_only: true; sanitized: true; source: string; range: UsageActivityRange }>
+export type GitMeta = { read_only: true; sanitized: true; source: string }
+export type GitRepoIndexResponse = ResourceEnvelope<GitRepoIndex, GitMeta>
+export type GitCommitListResponse = ResourceEnvelope<GitCommitList, GitMeta>
+export type GitBranchListResponse = ResourceEnvelope<GitBranchList, GitMeta>
+export type GitCommitDetailResponse = ResourceEnvelope<GitCommitDetail, GitMeta>
+export type GitCommitDiffResponse = ResourceEnvelope<GitCommitDiff, GitMeta>
 export type SystemMetricsResponse = ResourceEnvelope<SystemMetrics, { read_only: true; sanitized: true; source: string; disk_target: 'fastapi-visible-root-filesystem' }>
 export type SystemSignalsResponse = ResourceEnvelope<{ items: SystemSignal[] }, { count: number }>

--- a/scripts/check-git-server-only.mjs
+++ b/scripts/check-git-server-only.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/** Static guardrail for Issue #40.4 Git frontend server-only/read-only integration. */
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = process.cwd()
+const paths = {
+  packageJson: join(repoRoot, 'package.json'),
+  adapter: join(repoRoot, 'apps/web/src/modules/git/api/git-http.ts'),
+  page: join(repoRoot, 'apps/web/src/app/git/page.tsx'),
+  fixture: join(repoRoot, 'apps/web/src/modules/git/view-models/git-surface.fixture.ts'),
+  moduleAgents: join(repoRoot, 'apps/web/src/modules/git/AGENTS.md'),
+  modulesAgents: join(repoRoot, 'apps/web/src/modules/AGENTS.md'),
+  nav: join(repoRoot, 'apps/web/src/shared/ui/navigation/SidebarNav.tsx'),
+  css: join(repoRoot, 'apps/web/src/app/globals.css'),
+  runtimeConfig: join(repoRoot, 'docs/runtime-config.md'),
+  frontendSpec: join(repoRoot, 'docs/frontend-ui-spec.md'),
+  handoff: join(repoRoot, 'docs/frontend-implementation-handoff.md'),
+  openspec: join(repoRoot, 'openspec/issue-40-4-git-frontend-readonly.md'),
+  engram: join(repoRoot, '.engram/issue-40-4-git-frontend-readonly.md'),
+}
+const failures = []
+function read(pathName, label) {
+  if (!existsSync(pathName)) {
+    failures.push(`missing ${label}: ${pathName}`)
+    return ''
+  }
+  return readFileSync(pathName, 'utf8')
+}
+function mustInclude(text, snippet, label) { if (!text.includes(snippet)) failures.push(`${label} must include: ${snippet}`) }
+function mustNotInclude(text, snippet, label) { if (text.includes(snippet)) failures.push(`${label} must not include: ${snippet}`) }
+
+const packageJsonText = read(paths.packageJson, 'package.json')
+const adapter = read(paths.adapter, 'git server-only adapter')
+const page = read(paths.page, 'git page')
+const fixture = read(paths.fixture, 'git fallback fixture')
+const moduleAgents = read(paths.moduleAgents, 'git module AGENTS')
+const modulesAgents = read(paths.modulesAgents, 'modules AGENTS')
+const nav = read(paths.nav, 'SidebarNav')
+const css = read(paths.css, 'globals.css')
+const runtimeConfig = read(paths.runtimeConfig, 'runtime config docs')
+const frontendSpec = read(paths.frontendSpec, 'frontend UI spec')
+const handoff = read(paths.handoff, 'frontend implementation handoff')
+const openspec = read(paths.openspec, 'Issue 40.4 OpenSpec')
+const engram = read(paths.engram, 'Issue 40.4 Engram note')
+
+let packageJson
+try { packageJson = JSON.parse(packageJsonText) } catch { failures.push('package.json must be valid JSON') }
+if (packageJson?.scripts?.['verify:git-server-only'] !== 'node scripts/check-git-server-only.mjs') failures.push('package.json must expose verify:git-server-only')
+
+for (const snippet of [
+  "import 'server-only'",
+  "GIT_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'",
+  "parsed.protocol !== 'http:'",
+  "parsed.protocol !== 'https:'",
+  "cache: 'no-store'",
+  '/api/v1/git/repos',
+  '/commits?limit=12',
+  '/branches',
+  '/diff',
+]) mustInclude(adapter, snippet, 'git adapter')
+
+for (const forbidden of [
+  'NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL',
+  'process.env.NEXT_PUBLIC',
+  'path=',
+  'url=',
+  'remote=',
+  'command=',
+  'ref=',
+  'branch=',
+  'revspec=',
+  'checkout',
+  'reset',
+  'commit --',
+  'push',
+  'pull',
+  'stash',
+  'merge',
+  'rebase',
+]) mustNotInclude(adapter, forbidden, 'git adapter')
+
+for (const snippet of [
+  "export const dynamic = 'force-dynamic'",
+  'fetchGitRepos()',
+  'fetchGitCommits(selectedRepo.repo_id)',
+  'fetchGitBranches(selectedRepo.repo_id)',
+  'fetchGitCommitDetail(selectedRepo.repo_id, selectedCommit.sha)',
+  'fetchGitCommitDiff(selectedRepo.repo_id, selectedCommit.sha)',
+  'Repos Git',
+  'Solo lectura',
+  'repo_id/SHA backend-owned',
+  'Diff redactado/truncado/omitido',
+  'Sin operaciones mutables',
+  'Sin rutas host',
+  'Sin texto libre de commits',
+  'Archivo omitido por seguridad',
+]) mustInclude(page, snippet, 'git page')
+
+for (const forbidden of [
+  "'use client'",
+  'process.env',
+  'NEXT_PUBLIC',
+  'MUGIWARA_CONTROL_PANEL_API_URL',
+  '/api/v1/git',
+  'Traceback',
+  'Stack trace',
+  'stdout',
+  'stderr',
+  '/srv/',
+  '/home/',
+  '.env',
+  'checkout',
+  'reset',
+  'push',
+  'pull',
+  ' fetch(',
+  'stash',
+  'merge',
+  'rebase',
+]) mustNotInclude(page, forbidden, 'git page')
+
+for (const forbidden of ['Traceback', 'Stack trace', 'stdout', 'stderr', '/srv/', '/home/', 'token', 'secret', 'password']) {
+  mustNotInclude(fixture.toLowerCase(), forbidden.toLowerCase(), 'git fallback fixture')
+}
+
+mustInclude(nav, "{ href: '/git', label: 'Repos Git'", 'SidebarNav')
+mustInclude(css, '.git-diff-pre', 'globals.css')
+mustInclude(css, 'overflow-x: auto', 'globals.css')
+mustInclude(css, '@media (max-width: 720px)', 'globals.css')
+mustInclude(moduleAgents, 'server-only', 'git module AGENTS')
+mustInclude(moduleAgents, 'sin paths', 'git module AGENTS')
+mustInclude(modulesAgents, 'git', 'modules AGENTS')
+
+for (const doc of [runtimeConfig, frontendSpec, handoff, openspec, engram]) {
+  mustInclude(doc, 'verify:git-server-only', 'Git docs/OpenSpec/Engram')
+  mustInclude(doc, 'Repos Git', 'Git docs/OpenSpec/Engram')
+  mustInclude(doc, 'server-only', 'Git docs/OpenSpec/Engram')
+}
+
+if (failures.length > 0) {
+  console.error('Git server-only frontend check failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+console.log('Git server-only frontend check passed.')


### PR DESCRIPTION
## Objetivo
Implementar Issue #40.4: frontend `/git` (`Repos Git`) server-only/read-only tras merge de PR #91.

## Alcance
- Añade navegación principal `Repos Git` y ruta `/git` dinámica.
- Añade módulo frontend `git` con adapter `server-only` usando `MUGIWARA_CONTROL_PANEL_API_URL`.
- Consume solo endpoints backend cerrados: repos, commits, branches, commit detail y commit diff.
- Encadena solo `repo_id` y SHA devueltos por backend.
- Añade fallback local saneado, copy read-only y UI responsive para diff redactado/truncado/omitido.
- Añade guardrail `npm run verify:git-server-only` y actualiza docs/OpenSpec/.engram.

## Restricciones preservadas
- Sin paths cliente, discovery arbitrario, refs/rangos/revspecs.
- Sin acciones Git: checkout/reset/commit/push/pull/fetch/stash/merge/rebase.
- Sin working-tree diff en 40.4.
- Sin body libre de commits.
- Sin backend URL, rutas host, stdout/stderr, stack traces ni errores crudos en UI/fallback.

## Verify Zoro
- `npm run verify:git-server-only`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build`
- `npm run verify:visual-baseline`
- `git diff --check`
- Smoke HTML/DOM anti-leakage con API live local y config inválida sintética.
- Browser visual smoke `/git`: consola limpia; sin overflow horizontal obvio en viewport actual; copy read-only/diff seguro visible.

## Review solicitada
- Usopp: UI/UX, claridad, responsive, jerarquía visual y copy de solo lectura/diff seguro.
- Chopper: server-only, no-leakage, ausencia de paths/refs/revspecs/acciones Git y fallback saneado.