### PR TITLE
feat: add controlled git selector

### DIFF
--- a/.engram/issue-40-5-git-controlled-selector-planning-closeout.md
+++ b/.engram/issue-40-5-git-controlled-selector-planning-closeout.md
@@ -1,4 +1,4 @@
-# Issue #40.5 planning closeout — Git controlled selector
+# Issue #40.5 planning closeout — Git controlled selector (`Repos Git`)
 
 ## Contexto
 Tras mergear PR #92, `/git` existe como página server-only/read-only pero selecciona automáticamente el primer repo y primer commit devueltos por backend.
@@ -6,7 +6,7 @@ Tras mergear PR #92, `/git` existe como página server-only/read-only pero selec
 Pablo pidió planificar 40.5 y decidir primero cómo dividirlo. La decisión técnica es no dividir 40.5 en varias PRs salvo que aparezca necesidad de backend nuevo o superficie Git adicional.
 
 ## Decisión
-40.5 será una microfase única de frontend server-only para selector controlado de repo/commit.
+40.5 será una microfase única de frontend server-only para `Selección controlada` de repo/commit.
 
 Corte interno:
 1. contrato server-side de `searchParams` saneados;
@@ -28,6 +28,13 @@ Corte interno:
 - `git diff --check`
 - smoke HTML/DOM con query válida e inválida
 - browser smoke `/git`
+
+## Implementación 40.5
+- `/git` lee `searchParams` en Server Component y valida `repo_id` contra `repoIndex.repos`.
+- La página carga commits/branches solo del repo seleccionado saneado.
+- `sha` se acepta solo si existe en `commits.commits` del repo seleccionado; detail/diff solo se invocan con ese SHA validado.
+- Repo cards y commits son enlaces server-side; no se añadieron inputs, forms, búsqueda libre, refs/rangos/revspecs, acciones Git, working-tree diff ni client-side fetch.
+- Para evitar eco de query maliciosa en HTML/RSC, parámetros no soportados o `repo_id`/`sha` inválidos se redirigen a URL canónica saneada antes de renderizar la página final.
 
 ## Review
 Usopp + Chopper. Franky solo si se introduce backend/runtime/cache/polling o endpoint nuevo.

--- a/.engram/issue-40-5-git-controlled-selector-planning-closeout.md
+++ b/.engram/issue-40-5-git-controlled-selector-planning-closeout.md
@@ -35,6 +35,7 @@ Corte interno:
 - `sha` se acepta solo si existe en `commits.commits` del repo seleccionado; detail/diff solo se invocan con ese SHA validado.
 - Repo cards y commits son enlaces server-side; no se añadieron inputs, forms, búsqueda libre, refs/rangos/revspecs, acciones Git, working-tree diff ni client-side fetch.
 - Para evitar eco de query maliciosa en HTML/RSC, parámetros no soportados o `repo_id`/`sha` inválidos se redirigen a URL canónica saneada antes de renderizar la página final.
+- Tras review de Chopper, la canonicalización se extendió también a fallback/degradación: con API no disponible, cualquier `repo_id`/`sha` o clave no soportada redirige a `/git` antes de renderizar fallback, evitando reflejo de query maliciosa en `__next_f`.
 
 ## Review
 Usopp + Chopper. Franky solo si se introduce backend/runtime/cache/polling o endpoint nuevo.

--- a/.engram/issue-40-5-git-controlled-selector-planning-closeout.md
+++ b/.engram/issue-40-5-git-controlled-selector-planning-closeout.md
@@ -1,0 +1,33 @@
+# Issue #40.5 planning closeout — Git controlled selector
+
+## Contexto
+Tras mergear PR #92, `/git` existe como página server-only/read-only pero selecciona automáticamente el primer repo y primer commit devueltos por backend.
+
+Pablo pidió planificar 40.5 y decidir primero cómo dividirlo. La decisión técnica es no dividir 40.5 en varias PRs salvo que aparezca necesidad de backend nuevo o superficie Git adicional.
+
+## Decisión
+40.5 será una microfase única de frontend server-only para selector controlado de repo/commit.
+
+Corte interno:
+1. contrato server-side de `searchParams` saneados;
+2. UI con enlaces controlados para repos y commits;
+3. guardrail/smokes/canon mínimo.
+
+## Restricciones clave
+- `repo_id` solo se acepta si está en `repoIndex.repos`.
+- `sha` solo se acepta si está en `commits.commits` del repo seleccionado.
+- Nunca llamar detail/diff con SHA no listado por backend en esa renderización.
+- No paths cliente, refs, rangos, revspecs, branches arbitrarias, remotes, URLs, comandos, búsqueda libre ni acciones Git.
+- No renderizar líneas de diff en HTML/DOM.
+
+## Verify esperado
+- `npm run verify:git-server-only`
+- `npm --prefix apps/web run typecheck`
+- `npm --prefix apps/web run build`
+- `npm run verify:visual-baseline`
+- `git diff --check`
+- smoke HTML/DOM con query válida e inválida
+- browser smoke `/git`
+
+## Review
+Usopp + Chopper. Franky solo si se introduce backend/runtime/cache/polling o endpoint nuevo.

--- a/apps/web/src/app/git/page.tsx
+++ b/apps/web/src/app/git/page.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react'
 
+import { redirect } from 'next/navigation'
+
 import type { GitBranchList, GitCommitDetail, GitCommitDiff, GitCommitList, GitCommitSummary, GitRepoIndex, GitRepoSummary } from '@contracts/read-models'
 
 import {
@@ -41,9 +43,24 @@ type GitPageData = {
   commitDetail: GitCommitDetail
   commitDiff: GitCommitDiff
   notice: GitPageNotice | null
+  selection: {
+    repoId: string | null
+    sha: string | null
+    requestedRepoAccepted: boolean
+    requestedShaAccepted: boolean
+  }
+}
+
+type GitPageSearchParams = Promise<Record<string, string | string[] | undefined>>
+
+type GitPageProps = {
+  searchParams?: GitPageSearchParams
 }
 
 function getFallbackData(notice: GitPageNotice): GitPageData {
+  const fallbackRepo = gitRepoIndexFixture.repos[0] ?? null
+  const fallbackCommit = gitCommitListFixture.commits[0] ?? null
+
   return {
     repoIndex: gitRepoIndexFixture,
     commits: gitCommitListFixture,
@@ -51,14 +68,45 @@ function getFallbackData(notice: GitPageNotice): GitPageData {
     commitDetail: gitCommitDetailFixture,
     commitDiff: gitCommitDiffFixture,
     notice,
+    selection: {
+      repoId: fallbackRepo?.repo_id ?? null,
+      sha: fallbackCommit?.sha ?? null,
+      requestedRepoAccepted: false,
+      requestedShaAccepted: false,
+    },
   }
 }
 
-async function getGitPageData(): Promise<GitPageData> {
+function getSingleSearchParam(searchParams: Record<string, string | string[] | undefined>, key: 'repo_id' | 'sha') {
+  const value = searchParams[key]
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) return value[0]
+  return undefined
+}
+
+function hasUnsupportedGitSearchParams(searchParams: Record<string, string | string[] | undefined>) {
+  return Object.keys(searchParams).some((key) => key !== 'repo_id' && key !== 'sha')
+}
+
+function isNextRedirectError(error: unknown) {
+  return Boolean(
+    error &&
+    typeof error === 'object' &&
+    'digest' in error &&
+    String((error as { digest?: unknown }).digest).startsWith('NEXT_REDIRECT'),
+  )
+}
+
+async function getGitPageData(searchParams: Record<string, string | string[] | undefined>): Promise<GitPageData> {
+  const requestedRepoId = getSingleSearchParam(searchParams, 'repo_id')
+  const requestedSha = getSingleSearchParam(searchParams, 'sha')
+  const unsupportedSearchParams = hasUnsupportedGitSearchParams(searchParams)
+
   try {
     const reposResponse = await fetchGitRepos()
     const repoIndex = reposResponse.data
-    const selectedRepo = repoIndex.repos[0]
+    const selectedRepo = repoIndex.repos.find((repo) => repo.repo_id === requestedRepoId) ?? repoIndex.repos[0]
+    const requestedRepoAccepted = Boolean(requestedRepoId && selectedRepo?.repo_id === requestedRepoId)
 
     if (reposResponse.status !== 'ready' || !selectedRepo) {
       return getFallbackData({
@@ -69,9 +117,14 @@ async function getGitPageData(): Promise<GitPageData> {
       })
     }
 
+    if (requestedRepoId && !requestedRepoAccepted) {
+      redirect(gitRepoHref(selectedRepo.repo_id))
+    }
+
     const commitsResponse = await fetchGitCommits(selectedRepo.repo_id)
     const branchesResponse = await fetchGitBranches(selectedRepo.repo_id)
-    const selectedCommit = commitsResponse.data.commits[0]
+    const selectedCommit = commitsResponse.data.commits.find((commit) => commit.sha === requestedSha) ?? commitsResponse.data.commits[0]
+    const requestedShaAccepted = Boolean(requestedSha && selectedCommit?.sha === requestedSha)
 
     if (!selectedCommit || commitsResponse.status !== 'ready') {
       return {
@@ -86,7 +139,21 @@ async function getGitPageData(): Promise<GitPageData> {
           description: 'La página mantiene índice y ramas saneadas, pero no muestra detalle ni diff porque el backend no devolvió commits listos.',
           detail: `Estado técnico: ${commitsResponse.status}`,
         },
+        selection: {
+          repoId: selectedRepo.repo_id,
+          sha: null,
+          requestedRepoAccepted,
+          requestedShaAccepted: false,
+        },
       }
+    }
+
+    if (unsupportedSearchParams) {
+      redirect(gitCommitHref(selectedRepo.repo_id, selectedCommit.sha))
+    }
+
+    if (requestedSha && !requestedShaAccepted) {
+      redirect(gitRepoHref(selectedRepo.repo_id))
     }
 
     const detailResponse = await fetchGitCommitDetail(selectedRepo.repo_id, selectedCommit.sha)
@@ -99,8 +166,16 @@ async function getGitPageData(): Promise<GitPageData> {
       commitDetail: detailResponse.data,
       commitDiff: diffResponse.data,
       notice: null,
+      selection: {
+        repoId: selectedRepo.repo_id,
+        sha: selectedCommit.sha,
+        requestedRepoAccepted,
+        requestedShaAccepted,
+      },
     }
   } catch (error) {
+    if (isNextRedirectError(error)) throw error
+
     const apiError = error instanceof GitApiError ? error : null
     return getFallbackData({
       status: apiError?.code === 'not_configured' ? 'revision' : 'incidencia',
@@ -117,6 +192,16 @@ async function getGitPageData(): Promise<GitPageData> {
       detail: apiError?.code ? `Estado técnico: ${apiError.code}` : undefined,
     })
   }
+}
+
+function gitRepoHref(repoId: string) {
+  const params = new URLSearchParams({ repo_id: repoId })
+  return `/git?${params.toString()}`
+}
+
+function gitCommitHref(repoId: string, sha: string) {
+  const params = new URLSearchParams({ repo_id: repoId, sha })
+  return `/git?${params.toString()}`
 }
 
 function formatTimestamp(value: string | null | undefined) {
@@ -170,57 +255,64 @@ function Pill({ children }: { children: ReactNode }) {
 
 function RepoCard({ repo, selected }: { repo: GitRepoSummary; selected: boolean }) {
   return (
-    <SurfaceCard title={repo.label} eyebrow={selected ? 'Repo seleccionado por backend' : 'Repo allowlisteado'} accent={selected ? 'sky' : undefined}>
-      <div style={{ display: 'grid', gap: '12px', minWidth: 0 }}>
-        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-          <StatusBadge status={statusForRepo(repo)} label={workingTreeCopy(repo)} />
-          <Pill>{repo.scope}</Pill>
-          <Pill>repo_id: {repo.repo_id}</Pill>
+    <a className="git-selector-link" href={gitRepoHref(repo.repo_id)} aria-current={selected ? 'true' : undefined}>
+      <SurfaceCard title={repo.label} eyebrow={selected ? 'Repo seleccionado' : 'Repo allowlisteado'} accent={selected ? 'sky' : undefined}>
+        <div style={{ display: 'grid', gap: '12px', minWidth: 0 }}>
+          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+            {selected ? <StatusBadge status="operativo" label="Seleccionado" /> : null}
+            <StatusBadge status={statusForRepo(repo)} label={workingTreeCopy(repo)} />
+            <Pill>{repo.scope}</Pill>
+            <Pill>repo_id: {repo.repo_id}</Pill>
+          </div>
+          <p className="text-break" style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
+            Solo lectura. La UI no conoce rutas del host ni remotes; usa únicamente el identificador lógico devuelto por backend.
+          </p>
+          <dl className="git-metric-list">
+            <div>
+              <dt>Rama actual</dt>
+              <dd>{repo.status.current_branch ?? 'No disponible'}</dd>
+            </div>
+            <div>
+              <dt>Cambios</dt>
+              <dd>{repo.status.changed_files_count ?? '—'}</dd>
+            </div>
+            <div>
+              <dt>No trackeados</dt>
+              <dd>{repo.status.untracked_files_count ?? '—'}</dd>
+            </div>
+          </dl>
         </div>
-        <p className="text-break" style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
-          Solo lectura. La UI no conoce rutas del host ni remotes; usa únicamente el identificador lógico devuelto por backend.
-        </p>
-        <dl className="git-metric-list">
-          <div>
-            <dt>Rama actual</dt>
-            <dd>{repo.status.current_branch ?? 'No disponible'}</dd>
-          </div>
-          <div>
-            <dt>Cambios</dt>
-            <dd>{repo.status.changed_files_count ?? '—'}</dd>
-          </div>
-          <div>
-            <dt>No trackeados</dt>
-            <dd>{repo.status.untracked_files_count ?? '—'}</dd>
-          </div>
-        </dl>
-      </div>
-    </SurfaceCard>
+      </SurfaceCard>
+    </a>
   )
 }
 
-function CommitItem({ commit, selected }: { commit: GitCommitSummary; selected: boolean }) {
+function CommitItem({ commit, selected, repoId }: { commit: GitCommitSummary; selected: boolean; repoId: string }) {
   return (
     <li className={`git-commit-row${selected ? ' git-commit-row--selected' : ''}`}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap', minWidth: 0 }}>
-        <strong className="text-break" style={{ color: appTheme.colors.textPrimary }}>{commit.subject}</strong>
-        <code className="git-inline-code">{commit.short_sha}</code>
-      </div>
-      <p className="text-break" style={{ margin: '8px 0 0', color: appTheme.colors.textSecondary }}>
-        {commit.author_name} · {formatTimestamp(commit.committed_at)}
-      </p>
-      <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginTop: '10px' }}>
-        <Pill>Mugiwara-Agent: {commit.trailers.mugiwara_agent ?? 'sin trailer'}</Pill>
-        <Pill>Signed-off-by: {commit.trailers.signed_off_by ? 'presente' : 'sin trailer'}</Pill>
-      </div>
+      <a className="git-selector-link git-commit-link" href={gitCommitHref(repoId, commit.sha)} aria-current={selected ? 'true' : undefined}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap', minWidth: 0 }}>
+          <strong className="text-break" style={{ color: appTheme.colors.textPrimary }}>{commit.subject}</strong>
+          <code className="git-inline-code">{commit.short_sha}</code>
+        </div>
+        <p className="text-break" style={{ margin: '8px 0 0', color: appTheme.colors.textSecondary }}>
+          {commit.author_name} · {formatTimestamp(commit.committed_at)}
+        </p>
+        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginTop: '10px' }}>
+          {selected ? <StatusBadge status="operativo" label="Commit seleccionado" /> : null}
+          <Pill>Mugiwara-Agent: {commit.trailers.mugiwara_agent ?? 'sin trailer'}</Pill>
+          <Pill>Signed-off-by: {commit.trailers.signed_off_by ? 'presente' : 'sin trailer'}</Pill>
+        </div>
+      </a>
     </li>
   )
 }
 
-export default async function GitPage() {
-  const { repoIndex, commits, branches, commitDetail, commitDiff, notice } = await getGitPageData()
-  const selectedRepo = repoIndex.repos[0]
-  const selectedCommit = commitDetail.commit ?? commits.commits[0] ?? null
+export default async function GitPage({ searchParams }: GitPageProps) {
+  const resolvedSearchParams = searchParams ? await searchParams : {}
+  const { repoIndex, commits, branches, commitDetail, commitDiff, notice, selection } = await getGitPageData(resolvedSearchParams)
+  const selectedRepo = repoIndex.repos.find((repo) => repo.repo_id === selection.repoId) ?? repoIndex.repos[0]
+  const selectedCommit = commitDetail.commit ?? commits.commits.find((commit) => commit.sha === selection.sha) ?? commits.commits[0] ?? null
   const isSnapshotMode = Boolean(notice)
   const hasDenseBranches = branches.branches.length > 8
 
@@ -229,9 +321,9 @@ export default async function GitPage() {
       <PageHeader
         eyebrow="Repos Git"
         title="Repos Git"
-        subtitle="Lectura server-only de repositorios allowlisteados: historial, ramas locales, detalle de commit y diff histórico saneado. Sin operaciones mutables ni rutas cliente."
+        subtitle="Lectura server-only de repositorios allowlisteados con selección controlada por enlaces: historial, ramas locales, detalle de commit y diff histórico saneado. Sin operaciones mutables ni rutas cliente."
         mugiwaraSlug="zoro"
-        detailPills={['Solo lectura', 'repo_id/SHA backend-owned', 'Diff redactado/truncado/omitido']}
+        detailPills={['Solo lectura', 'repo_id/SHA backend-owned', 'Selección controlada', 'Diff redactado/truncado/omitido']}
       />
 
       {notice ? (
@@ -257,7 +349,24 @@ export default async function GitPage() {
             { label: 'Sin operaciones mutables', tone: 'connected' },
             { label: 'Sin rutas host', tone: 'connected' },
             { label: 'Sin texto libre de commits', tone: 'connected' },
+            { label: 'Solo repos allowlisteados', tone: 'connected' },
+            { label: 'Solo SHAs listados por backend', tone: 'connected' },
             { label: 'Diff histórico saneado', tone: 'fallback' },
+          ]}
+        />
+      </StatePanel>
+
+      <StatePanel
+        status="operativo"
+        title="Selección controlada"
+        description="Repo y commit se eligen con enlaces server-side. La página solo acepta repo_id existentes en el índice backend-owned y SHA presentes en el historial cargado del repo seleccionado; cualquier parámetro inválido se ignora sin eco en la UI."
+        detail={`Repo seleccionado: ${selectedRepo?.label ?? 'sin repo'} · Commit seleccionado: ${selectedCommit?.short_sha ?? 'sin commit'}`}
+        eyebrow="Selector server-only"
+      >
+        <SourceStatePills
+          items={[
+            { label: selection.requestedRepoAccepted ? 'repo_id aceptado' : 'repo_id por defecto saneado', tone: 'connected' },
+            { label: selection.requestedShaAccepted ? 'SHA aceptado' : 'SHA por defecto saneado', tone: 'connected' },
           ]}
         />
       </StatePanel>
@@ -271,8 +380,8 @@ export default async function GitPage() {
       <section className="section-block layout-grid layout-grid--content-aside" aria-label="Historial y ramas Git">
         <SurfaceCard title="Historial reciente" eyebrow={isSnapshotMode ? 'Commits del snapshot' : 'Commits backend-owned'} accent="gold">
           <ol className="git-commit-list">
-            {commits.commits.map((commit, index) => (
-              <CommitItem key={commit.sha} commit={commit} selected={index === 0} />
+            {commits.commits.map((commit) => (
+              <CommitItem key={commit.sha} commit={commit} repoId={selectedRepo?.repo_id ?? commits.repo_id} selected={commit.sha === selectedCommit?.sha} />
             ))}
           </ol>
           <p style={{ margin: '14px 0 0', color: appTheme.colors.textMuted, fontSize: '13px', lineHeight: 1.6 }}>

--- a/apps/web/src/app/git/page.tsx
+++ b/apps/web/src/app/git/page.tsx
@@ -102,6 +102,10 @@ async function getGitPageData(searchParams: Record<string, string | string[] | u
   const requestedSha = getSingleSearchParam(searchParams, 'sha')
   const unsupportedSearchParams = hasUnsupportedGitSearchParams(searchParams)
 
+  if (unsupportedSearchParams) {
+    redirect('/git')
+  }
+
   try {
     const reposResponse = await fetchGitRepos()
     const repoIndex = reposResponse.data
@@ -109,6 +113,10 @@ async function getGitPageData(searchParams: Record<string, string | string[] | u
     const requestedRepoAccepted = Boolean(requestedRepoId && selectedRepo?.repo_id === requestedRepoId)
 
     if (reposResponse.status !== 'ready' || !selectedRepo) {
+      if (requestedRepoId || requestedSha) {
+        redirect('/git')
+      }
+
       return getFallbackData({
         status: 'revision',
         title: 'Repos Git en modo fallback local',
@@ -127,6 +135,10 @@ async function getGitPageData(searchParams: Record<string, string | string[] | u
     const requestedShaAccepted = Boolean(requestedSha && selectedCommit?.sha === requestedSha)
 
     if (!selectedCommit || commitsResponse.status !== 'ready') {
+      if (requestedSha) {
+        redirect(gitRepoHref(selectedRepo.repo_id))
+      }
+
       return {
         repoIndex,
         commits: commitsResponse.data,
@@ -175,6 +187,10 @@ async function getGitPageData(searchParams: Record<string, string | string[] | u
     }
   } catch (error) {
     if (isNextRedirectError(error)) throw error
+
+    if (requestedRepoId || requestedSha) {
+      redirect('/git')
+    }
 
     const apiError = error instanceof GitApiError ? error : null
     return getFallbackData({

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -559,6 +559,23 @@ button {
 }
 
 
+.git-selector-link {
+  display: block;
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+}
+
+.git-selector-link:focus-visible {
+  outline: 2px solid rgba(100, 181, 246, 0.95);
+  outline-offset: 4px;
+  border-radius: 18px;
+}
+
+.git-selector-link:hover {
+  text-decoration: none;
+}
+
 .git-metric-list {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,150 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const GIT_CANONICAL_PATH = '/git'
+const GIT_ALLOWED_SEARCH_PARAMS = new Set(['repo_id', 'sha'])
+const GIT_REPO_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/i
+const GIT_FULL_SHA_PATTERN = /^[a-f0-9]{40}$|^[a-f0-9]{64}$/i
+const GIT_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'
+
+type GitRepoIndex = {
+  repos?: Array<{ repo_id?: unknown }>
+}
+
+type GitCommitList = {
+  commits?: Array<{ sha?: unknown }>
+}
+
+type GitEnvelope<T> = {
+  status?: unknown
+  data?: T
+}
+
+function hasDuplicateParam(request: NextRequest, key: string) {
+  return request.nextUrl.searchParams.getAll(key).length > 1
+}
+
+function hasUnsafeGitSearchParams(request: NextRequest) {
+  for (const key of Array.from(request.nextUrl.searchParams.keys())) {
+    if (!GIT_ALLOWED_SEARCH_PARAMS.has(key)) return true
+    if (hasDuplicateParam(request, key)) return true
+  }
+
+  const repoId = request.nextUrl.searchParams.get('repo_id')
+  if (repoId && !GIT_REPO_ID_PATTERN.test(repoId)) return true
+
+  const sha = request.nextUrl.searchParams.get('sha')
+  if (sha && !GIT_FULL_SHA_PATTERN.test(sha)) return true
+
+  return false
+}
+
+function trimTrailingSlash(value: string) {
+  return value.replace(/\/$/, '')
+}
+
+function getGitApiBaseUrl() {
+  const value = process.env[GIT_API_BASE_URL_ENV]
+  if (!value) return null
+
+  let parsed: URL
+  try {
+    parsed = new URL(value)
+  } catch {
+    return null
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+  return trimTrailingSlash(value)
+}
+
+function isReadyEnvelope<T>(payload: unknown): payload is GitEnvelope<T> {
+  return payload !== null && typeof payload === 'object' && 'status' in payload && 'data' in payload
+}
+
+async function fetchGitEnvelope<T>(baseUrl: string, path: string): Promise<GitEnvelope<T> | null> {
+  try {
+    const response = await fetch(`${baseUrl}${path}`, {
+      cache: 'no-store',
+      headers: {
+        Accept: 'application/json',
+      },
+    })
+
+    if (!response.ok) return null
+
+    const payload: unknown = await response.json()
+    if (!isReadyEnvelope<T>(payload)) return null
+    return payload
+  } catch {
+    return null
+  }
+}
+
+function getRepoIds(repoIndex: GitRepoIndex | undefined) {
+  return (repoIndex?.repos ?? [])
+    .map((repo) => repo.repo_id)
+    .filter((repoId): repoId is string => typeof repoId === 'string' && repoId.length > 0)
+}
+
+function getCommitShas(commits: GitCommitList | undefined) {
+  return (commits?.commits ?? [])
+    .map((commit) => commit.sha)
+    .filter((sha): sha is string => typeof sha === 'string' && sha.length > 0)
+}
+
+function gitRepoHref(request: NextRequest, repoId: string) {
+  const canonicalUrl = request.nextUrl.clone()
+  canonicalUrl.pathname = GIT_CANONICAL_PATH
+  canonicalUrl.search = new URLSearchParams({ repo_id: repoId }).toString()
+  return canonicalUrl
+}
+
+function redirectToCanonicalGit(request: NextRequest) {
+  const canonicalUrl = request.nextUrl.clone()
+  canonicalUrl.pathname = GIT_CANONICAL_PATH
+  canonicalUrl.search = ''
+  return NextResponse.redirect(canonicalUrl)
+}
+
+async function validateGitSelection(request: NextRequest) {
+  const requestedRepoId = request.nextUrl.searchParams.get('repo_id')
+  const requestedSha = request.nextUrl.searchParams.get('sha')
+
+  if (!requestedRepoId && !requestedSha) return NextResponse.next()
+  if (hasUnsafeGitSearchParams(request)) return redirectToCanonicalGit(request)
+
+  const baseUrl = getGitApiBaseUrl()
+  if (!baseUrl) return redirectToCanonicalGit(request)
+
+  const reposEnvelope = await fetchGitEnvelope<GitRepoIndex>(baseUrl, '/api/v1/git/repos')
+  const repoIds = getRepoIds(reposEnvelope?.data)
+  const selectedRepoId = requestedRepoId && repoIds.includes(requestedRepoId) ? requestedRepoId : repoIds[0]
+
+  if (reposEnvelope?.status !== 'ready' || !selectedRepoId) return redirectToCanonicalGit(request)
+  if (requestedRepoId && selectedRepoId !== requestedRepoId) return NextResponse.redirect(gitRepoHref(request, selectedRepoId))
+  if (!requestedSha) return NextResponse.next()
+
+  const commitsEnvelope = await fetchGitEnvelope<GitCommitList>(
+    baseUrl,
+    `/api/v1/git/repos/${encodeURIComponent(selectedRepoId)}/commits?limit=12`,
+  )
+  const commitShas = getCommitShas(commitsEnvelope?.data)
+
+  if (commitsEnvelope?.status !== 'ready' || !commitShas.includes(requestedSha)) {
+    return NextResponse.redirect(gitRepoHref(request, selectedRepoId))
+  }
+
+  return NextResponse.next()
+}
+
+export async function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname === GIT_CANONICAL_PATH) {
+    return validateGitSelection(request)
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/git'],
+}

--- a/apps/web/src/modules/git/AGENTS.md
+++ b/apps/web/src/modules/git/AGENTS.md
@@ -5,7 +5,7 @@ Módulo frontend read-only para la página `/git` (`Repos Git`).
 
 ## Reglas
 - El adapter HTTP debe ser `server-only` y usar únicamente `MUGIWARA_CONTROL_PANEL_API_URL` en servidor.
-- El cliente/UI solo puede operar con `repo_id` y SHA completo devueltos por backend; no paths, refs, rangos, revspecs ni discovery arbitrario.
+- El cliente/UI solo puede operar con `repo_id` y SHA completo devueltos por backend; no paths, refs, rangos, revspecs ni discovery arbitrario. En 40.5, la `Selección controlada` acepta `searchParams.repo_id` solo si existe en `repoIndex.repos` y `searchParams.sha` solo si existe en `commits.commits` del repo seleccionado.
 - No introducir acciones Git: checkout/reset/commit/push/pull/fetch/stash/merge/rebase.
 - 40.4 no muestra working-tree diff; solo índice, commits, ramas, detalle y diff histórico ya saneado por backend.
 - No renderizar backend URL, rutas host, stdout/stderr, stack traces, errores crudos, cuerpo libre de commits ni paths omitidos por seguridad.

--- a/docs/frontend-implementation-handoff.md
+++ b/docs/frontend-implementation-handoff.md
@@ -701,6 +701,7 @@ Regla del bloque:
 - Fixture/fallback: `apps/web/src/modules/git/view-models/git-surface.fixture.ts`, sin rutas host, secretos, detalles internos de ejecución ni errores crudos.
 - CSS/responsive: clases `git-*` en `globals.css` para listas/cards/diff con `min-width: 0`, wrap y scroll interno del diff.
 - Seguridad de presentación: la página no lee `process.env`, no hace fetch browser, no conoce backend URL, no acepta input de paths/refs/revspecs y solo encadena `repo_id`/SHA que vienen de respuestas backend.
+- Selector 40.5: `Selección controlada` repo/commit mediante enlaces server-side; `searchParams.repo_id` se acepta solo si existe en `repoIndex.repos` y `searchParams.sha` solo si existe en `commits.commits` del repo seleccionado. No hay inputs, forms, búsqueda libre ni selector de refs/rangos.
 - Verificación obligatoria: `npm run verify:git-server-only`, typecheck, build, `npm run verify:visual-baseline`, `git diff --check` y smoke HTML/DOM anti-leakage.
 
 Nota 40.4: el contenido de líneas del diff se omite en frontend; la UI muestra metadata, contadores y estados de redacción/truncado/omisión para evitar reintroducir canarios o secretos históricos en HTML/DOM. Guardrail: `npm run verify:git-server-only`.

--- a/docs/frontend-ui-spec.md
+++ b/docs/frontend-ui-spec.md
@@ -937,8 +937,9 @@ Ese equilibrio debe mantenerse en todas las decisiones de frontend del MVP.
 ## Ruta `/git` — Repos Git
 - Navegación principal: añadir `Repos Git` como superficie read-only de Zoro.
 - Propósito: consultar repositorios Git allowlisteados desde backend, historial reciente, ramas locales, detalle de commit y diff histórico ya saneado.
-- Copy obligatorio: dejar visible `Solo lectura`, `repo_id/SHA backend-owned` y `Diff redactado/truncado/omitido`.
-- Restricciones UI: sin paths cliente, sin discovery arbitrario, sin refs/rangos/revspecs, sin acciones Git y sin working-tree diff en Issue #40.4.
+- Copy obligatorio: dejar visible `Solo lectura`, `repo_id/SHA backend-owned`, `Selección controlada`, `Solo repos allowlisteados`, `Solo SHAs listados por backend` y `Diff redactado/truncado/omitido`.
+- Restricciones UI: sin paths cliente, sin discovery arbitrario, sin refs/rangos/revspecs, sin acciones Git y sin working-tree diff en Issue #40.4/40.5.
+- Selector 40.5: repo cards y commits son enlaces server-side; `repo_id` solo se acepta si existe en `repoIndex.repos` y `sha` solo si existe en `commits.commits` del repo seleccionado. Parámetros inválidos se ignoran sin eco ni error crudo.
 - Layout: cards/listas responsive, no tablas anchas; el panel de diff usa scroll interno/controlado y `pre` con wrap para evitar overflow horizontal.
 - Estados: API real, fallback local saneado, fuente no configurada/degradada; nunca mostrar backend URL, rutas host, detalles internos de ejecución y errores crudos ni errores crudos.
 - Guardrail: `npm run verify:git-server-only`.

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -197,14 +197,15 @@ Resumen de la decisión:
 - El cuerpo libre de commit no forma parte del contrato público; solo se lee internamente para trailers allowlisteados.
 
 ## Git control frontend / Repos Git
-Issue #40.4 añade la ruta frontend `/git` con etiqueta visible `Repos Git`. La página es una Server Component dinámica y consume el backend solo desde `apps/web/src/modules/git/api/git-http.ts` con `import 'server-only'` y `MUGIWARA_CONTROL_PANEL_API_URL`.
+Issue #40.4 añade la ruta frontend `/git` con etiqueta visible `Repos Git`. La página es una Server Component dinámica y consume el backend solo desde `apps/web/src/modules/git/api/git-http.ts` con `import 'server-only'` y `MUGIWARA_CONTROL_PANEL_API_URL`. Issue #40.5 añade `Selección controlada` repo/commit mediante enlaces server-side y validación estricta de `searchParams`.
 
 Reglas de runtime:
 1. El navegador no recibe ni usa `MUGIWARA_CONTROL_PANEL_API_URL`, `NEXT_PUBLIC_*` ni backend URL absoluta.
 2. La UI no acepta paths, URLs, remotes, refs, rangos, revspecs ni comandos Git desde cliente; usa solo `repo_id` y SHA completo devueltos por backend.
-3. La página muestra índice de repos, commits, ramas locales, detalle de commit y diff histórico saneado. No muestra working-tree diff en 40.4.
-4. El fallback local está saneado y no renderiza rutas host, detalles internos de ejecución y errores crudos, errores crudos, tokens ni secretos.
-5. Antes de cerrar cambios sobre esta frontera ejecutar:
+3. `repo_id` solo se acepta si existe en `repoIndex.repos`, y `sha` solo si existe en `commits.commits` del repo seleccionado; query params inválidos se ignoran sin eco ni error crudo.
+4. La página muestra índice de repos, commits, ramas locales, detalle de commit y diff histórico saneado. No muestra working-tree diff en 40.4/40.5.
+5. El fallback local está saneado y no renderiza rutas host, detalles internos de ejecución y errores crudos, errores crudos, tokens ni secretos.
+6. Antes de cerrar cambios sobre esta frontera ejecutar:
 
 ```bash
 npm run verify:git-server-only

--- a/openspec/issue-40-5-git-controlled-selector-plan.md
+++ b/openspec/issue-40-5-git-controlled-selector-plan.md
@@ -1,4 +1,4 @@
-# Issue #40.5 — Selector controlado repo/commit para `/git`
+# Issue #40.5 — Selector controlado repo/commit para `/git` (`Repos Git`)
 
 ## Decisión de división
 
@@ -14,7 +14,7 @@ Si durante implementación aparece necesidad de nuevos endpoints, paginación, b
 
 ## Objetivo
 
-Permitir elegir repo y commit en `/git` sin abrir superficie Git arbitraria.
+Permitir `Selección controlada` de repo y commit en `/git` sin abrir superficie Git arbitraria.
 
 La UI debe dejar de depender solo de “primer repo + primer commit” y permitir navegación controlada entre:
 - repos ya devueltos por `GET /api/v1/git/repos`;

--- a/openspec/issue-40-5-git-controlled-selector-plan.md
+++ b/openspec/issue-40-5-git-controlled-selector-plan.md
@@ -1,0 +1,110 @@
+# Issue #40.5 — Selector controlado repo/commit para `/git`
+
+## Decisión de división
+
+40.5 debe ser **una microfase única de frontend server-only** con pasos internos, no varias PRs.
+
+Motivo:
+- El backend 40.1–40.3 ya expone repos, commits, branches, detail y safe diff.
+- 40.4 ya tiene `/git` server-only/read-only y guardrail `verify:git-server-only`.
+- El selector propuesto no requiere endpoints nuevos ni cambios de contrato backend.
+- Dividirlo en backend/frontend/closeout añadiría burocracia sin reducir riesgo real si mantenemos validación server-side estricta.
+
+Si durante implementación aparece necesidad de nuevos endpoints, paginación, búsqueda, refs, rangos, remotes, working-tree diff o acciones Git, la microfase debe parar y abrir planificación nueva.
+
+## Objetivo
+
+Permitir elegir repo y commit en `/git` sin abrir superficie Git arbitraria.
+
+La UI debe dejar de depender solo de “primer repo + primer commit” y permitir navegación controlada entre:
+- repos ya devueltos por `GET /api/v1/git/repos`;
+- commits ya devueltos por `GET /api/v1/git/repos/{repo_id}/commits` para el repo seleccionado.
+
+## Principio de seguridad
+
+El navegador puede enviar query params, pero la página server-side solo los acepta si coinciden con valores ya devueltos por backend en esa misma renderización.
+
+Contrato:
+- `repo_id` seleccionado debe existir en `repoIndex.repos`.
+- `sha` seleccionado debe existir en `commits.commits` del repo seleccionado.
+- Si `repo_id` o `sha` son inválidos, se ignoran y se cae a selección saneada por defecto.
+- Nunca llamar a `fetchGitCommitDetail` ni `fetchGitCommitDiff` con un SHA que no esté en la lista de commits del repo seleccionado.
+- No aceptar paths, refs, rangos, revspecs, branches arbitrarias, remotes, comandos, URLs ni texto libre.
+
+## Alcance incluido
+
+### Paso A — Contrato de selección server-side
+- Extender `/git` para leer `searchParams` de Next.js.
+- Validar `repo_id` contra repos backend-owned.
+- Tras seleccionar repo, cargar commits y branches de ese repo.
+- Validar `sha` contra la lista de commits cargada.
+- Mantener fallback saneado para repo sin commits o API degradada.
+
+### Paso B — UI de selección sin client component
+- Repo cards como enlaces server-side a `/git?repo_id=<repo_id>`.
+- Commits del historial como enlaces server-side a `/git?repo_id=<repo_id>&sha=<sha>`.
+- Estado visual claro de repo/commit seleccionado.
+- Copy explícito: `Selección controlada`, `Solo repos allowlisteados`, `Solo SHAs listados por backend`.
+- No añadir inputs de texto, selects libres, búsqueda, filtros, botones de acción ni client-side fetch.
+
+### Paso C — Guardrail, smokes y canon mínimo
+- Endurecer `verify:git-server-only` para fijar:
+  - `searchParams` server-side permitido solo con validación contra repos/commits cargados;
+  - ausencia de inputs libres (`input`, `textarea`, `form` para Git) en `/git`;
+  - ausencia de refs/rangos/revspecs/paths/acciones Git en UI;
+  - no render de líneas de diff.
+- Smoke HTML/DOM con parámetros válidos e inválidos:
+  - `/git?repo_id=<válido>&sha=<válido>` renderiza selección esperada;
+  - `/git?repo_id=../../secret&sha=HEAD..main` no ecoa input ni llama a detalle/diff con esos valores;
+  - fallback no expone backend URL, env, rutas host, `.env`, tokens, stdout/stderr, stack traces ni errores crudos.
+- Actualizar OpenSpec/Engram/docs vivas si cambia el contrato visible.
+
+## Fuera de alcance
+
+- Paginación o “cargar más commits”.
+- Búsqueda/filtros por texto.
+- Refs, branches como selector de historial, rangos, revspecs o comparación entre commits.
+- Working-tree diff.
+- Acciones Git mutables o remotas.
+- Client components para Git, fetch desde navegador o BFF nuevo.
+- Renderizar líneas de diff en HTML/DOM.
+- Tooltips/copy buttons/interacciones nuevas sobre SHA.
+
+## Definition of Done
+
+- `/git` permite seleccionar repo y commit mediante enlaces controlados.
+- La selección solo usa `repo_id` y SHA ya devueltos por backend.
+- Query params inválidos se ignoran sin eco ni error crudo.
+- No hay inputs libres ni selectors arbitrarios.
+- No se renderizan líneas de diff en HTML/DOM.
+- Server-only/read-only y fallback saneado siguen intactos.
+- Usopp valida UX/responsive del selector.
+- Chopper valida no-leakage y frontera Git.
+
+## Verify esperado
+
+```bash
+npm run verify:git-server-only
+npm --prefix apps/web run typecheck
+npm --prefix apps/web run build
+npm run verify:visual-baseline
+git diff --check
+# smoke HTML/DOM anti-leakage con API válida e inválida
+# browser smoke /git con repo/commit válido e inválido
+```
+
+## Review routing
+
+- **Usopp**: UI/UX, jerarquía, responsive, claridad del selector y estados seleccionados.
+- **Chopper**: server-only/no-leakage, validación de query params, ausencia de refs/revspecs/paths/acciones Git y no render de diff lines.
+- **Franky**: no necesario salvo que aparezca backend/runtime/cache/polling/endpoints nuevos.
+
+## Riesgos
+
+- Query params son controlables por el usuario: mitigación obligatoria con validación server-side contra datos backend ya cargados.
+- `sha` completo sigue siendo dato Git sensible moderado pero ya backend-owned y aceptado en 40.4; no añadir truncado funcional ni copiar acciones.
+- Si el usuario espera paginación, no incluirla en 40.5: debe quedar para una fase posterior solo si 12 commits no bastan en uso real.
+
+## Siguiente paso
+
+Implementar 40.5 como una única PR pequeña: selector server-side repo/commit, guardrail reforzado y smokes anti-leakage. Después, si pasa review Usopp + Chopper, cerrar Issue #40 con una fase de cierre/canon ligera o comentario final si no hace falta más código.

--- a/openspec/issue-40-5-git-controlled-selector-verify-checklist.md
+++ b/openspec/issue-40-5-git-controlled-selector-verify-checklist.md
@@ -1,0 +1,35 @@
+# Issue #40.5 — Planning verify checklist
+
+## Repo/context
+- [x] Repo inspeccionado desde `/srv/crew-core/projects/mugiwara-control-panel`.
+- [x] `main` estaba limpio y alineado con `origin/main` antes de crear rama de planificación.
+- [x] Issue #40 sigue abierta.
+- [x] PR #92 / 40.4 está mergeada en `main`.
+- [x] OpenSpec 40 inicial y 40.4 revisados.
+- [x] Código actual de `/git` revisado.
+
+## Decisión de división
+- [x] 40.5 se decide como microfase única de frontend server-only.
+- [x] No se planifican endpoints backend nuevos.
+- [x] No se planifica paginación/navegación de historial amplia.
+- [x] La implementación se divide solo en pasos internos: contrato server-side, UI de enlaces, guardrail/smokes/canon.
+
+## Seguridad/alcance
+- [x] Query params solo permitidos si validan contra repos/commits ya devueltos por backend.
+- [x] Sin paths cliente.
+- [x] Sin refs/rangos/revspecs.
+- [x] Sin acciones Git.
+- [x] Sin working-tree diff.
+- [x] Sin líneas de diff en HTML/DOM.
+- [x] Sin inputs libres, forms o client-side Git fetch.
+
+## Verify planificado
+- [x] `verify:git-server-only` sigue siendo gate obligatorio.
+- [x] Typecheck/build/visual baseline incluidos.
+- [x] Smokes HTML/DOM para query params válidos e inválidos incluidos.
+- [x] Review Usopp + Chopper prevista.
+
+## Verify ejecutado en planificación
+- [x] `git diff --check`
+- [ ] commit semántico con trailers
+- [ ] push de rama de planificación

--- a/scripts/check-git-server-only.mjs
+++ b/scripts/check-git-server-only.mjs
@@ -17,7 +17,9 @@ const paths = {
   frontendSpec: join(repoRoot, 'docs/frontend-ui-spec.md'),
   handoff: join(repoRoot, 'docs/frontend-implementation-handoff.md'),
   openspec: join(repoRoot, 'openspec/issue-40-4-git-frontend-readonly.md'),
+  openspecSelector: join(repoRoot, 'openspec/issue-40-5-git-controlled-selector-plan.md'),
   engram: join(repoRoot, '.engram/issue-40-4-git-frontend-readonly.md'),
+  engramSelector: join(repoRoot, '.engram/issue-40-5-git-controlled-selector-planning-closeout.md'),
 }
 const failures = []
 function read(pathName, label) {
@@ -42,7 +44,9 @@ const runtimeConfig = read(paths.runtimeConfig, 'runtime config docs')
 const frontendSpec = read(paths.frontendSpec, 'frontend UI spec')
 const handoff = read(paths.handoff, 'frontend implementation handoff')
 const openspec = read(paths.openspec, 'Issue 40.4 OpenSpec')
+const openspecSelector = read(paths.openspecSelector, 'Issue 40.5 OpenSpec')
 const engram = read(paths.engram, 'Issue 40.4 Engram note')
+const engramSelector = read(paths.engramSelector, 'Issue 40.5 Engram note')
 
 let packageJson
 try { packageJson = JSON.parse(packageJsonText) } catch { failures.push('package.json must be valid JSON') }
@@ -82,11 +86,24 @@ for (const forbidden of [
 
 for (const snippet of [
   "export const dynamic = 'force-dynamic'",
+  "type GitPageSearchParams = Promise<Record<string, string | string[] | undefined>>",
+  "getSingleSearchParam(searchParams, 'repo_id')",
+  "getSingleSearchParam(searchParams, 'sha')",
+  'repoIndex.repos.find((repo) => repo.repo_id === requestedRepoId)',
+  'commitsResponse.data.commits.find((commit) => commit.sha === requestedSha)',
+  'hasUnsupportedGitSearchParams(searchParams)',
+  'redirect(gitRepoHref(selectedRepo.repo_id))',
+  'redirect(gitCommitHref(selectedRepo.repo_id, selectedCommit.sha))',
   'fetchGitRepos()',
   'fetchGitCommits(selectedRepo.repo_id)',
   'fetchGitBranches(selectedRepo.repo_id)',
   'fetchGitCommitDetail(selectedRepo.repo_id, selectedCommit.sha)',
   'fetchGitCommitDiff(selectedRepo.repo_id, selectedCommit.sha)',
+  'href={gitRepoHref(repo.repo_id)}',
+  'href={gitCommitHref(repoId, commit.sha)}',
+  'Selección controlada',
+  'Solo repos allowlisteados',
+  'Solo SHAs listados por backend',
   'Repos Git',
   'Solo lectura',
   'repo_id/SHA backend-owned',
@@ -118,6 +135,13 @@ for (const forbidden of [
   'stash',
   'merge',
   'rebase',
+  '<input',
+  '<textarea',
+  '<form',
+  'name="path"',
+  'name="ref"',
+  'name="branch"',
+  'name="revspec"',
 ]) mustNotInclude(page, forbidden, 'git page')
 
 for (const forbidden of ['Traceback', 'Stack trace', 'stdout', 'stderr', '/srv/', '/home/', 'token', 'secret', 'password']) {
@@ -132,10 +156,16 @@ mustInclude(moduleAgents, 'server-only', 'git module AGENTS')
 mustInclude(moduleAgents, 'sin paths', 'git module AGENTS')
 mustInclude(modulesAgents, 'git', 'modules AGENTS')
 
-for (const doc of [runtimeConfig, frontendSpec, handoff, openspec, engram]) {
+for (const doc of [runtimeConfig, frontendSpec, handoff, openspec, openspecSelector, engram, engramSelector]) {
   mustInclude(doc, 'verify:git-server-only', 'Git docs/OpenSpec/Engram')
   mustInclude(doc, 'Repos Git', 'Git docs/OpenSpec/Engram')
   mustInclude(doc, 'server-only', 'Git docs/OpenSpec/Engram')
+}
+
+for (const doc of [runtimeConfig, frontendSpec, handoff, openspecSelector, engramSelector]) {
+  mustInclude(doc, 'Selección controlada', 'Git selector docs/OpenSpec/Engram')
+  mustInclude(doc, 'repo_id', 'Git selector docs/OpenSpec/Engram')
+  mustInclude(doc, 'SHA', 'Git selector docs/OpenSpec/Engram')
 }
 
 if (failures.length > 0) {

--- a/scripts/check-git-server-only.mjs
+++ b/scripts/check-git-server-only.mjs
@@ -8,6 +8,7 @@ const paths = {
   packageJson: join(repoRoot, 'package.json'),
   adapter: join(repoRoot, 'apps/web/src/modules/git/api/git-http.ts'),
   page: join(repoRoot, 'apps/web/src/app/git/page.tsx'),
+  middleware: join(repoRoot, 'apps/web/src/middleware.ts'),
   fixture: join(repoRoot, 'apps/web/src/modules/git/view-models/git-surface.fixture.ts'),
   moduleAgents: join(repoRoot, 'apps/web/src/modules/git/AGENTS.md'),
   modulesAgents: join(repoRoot, 'apps/web/src/modules/AGENTS.md'),
@@ -35,6 +36,7 @@ function mustNotInclude(text, snippet, label) { if (text.includes(snippet)) fail
 const packageJsonText = read(paths.packageJson, 'package.json')
 const adapter = read(paths.adapter, 'git server-only adapter')
 const page = read(paths.page, 'git page')
+const middleware = read(paths.middleware, 'Git route middleware')
 const fixture = read(paths.fixture, 'git fallback fixture')
 const moduleAgents = read(paths.moduleAgents, 'git module AGENTS')
 const modulesAgents = read(paths.modulesAgents, 'modules AGENTS')
@@ -143,6 +145,27 @@ for (const forbidden of [
   'name="branch"',
   'name="revspec"',
 ]) mustNotInclude(page, forbidden, 'git page')
+
+for (const snippet of [
+  'NextResponse.redirect(canonicalUrl)',
+  "matcher: ['/git']",
+  "GIT_CANONICAL_PATH = '/git'",
+  "GIT_ALLOWED_SEARCH_PARAMS = new Set(['repo_id', 'sha'])",
+  "GIT_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'",
+  'GIT_REPO_ID_PATTERN',
+  'GIT_FULL_SHA_PATTERN',
+  'hasDuplicateParam(request, key)',
+  'hasUnsafeGitSearchParams(request)',
+  'process.env[GIT_API_BASE_URL_ENV]',
+  "fetch(`${baseUrl}${path}`",
+  '/api/v1/git/repos',
+  '/commits?limit=12',
+  "canonicalUrl.search = ''",
+]) mustInclude(middleware, snippet, 'Git route middleware')
+
+for (const forbidden of ['path=', 'ref=', 'branch=', 'revspec=', 'command=', 'url=', 'NEXT_PUBLIC']) {
+  mustNotInclude(middleware, forbidden, 'Git route middleware')
+}
 
 for (const forbidden of ['Traceback', 'Stack trace', 'stdout', 'stderr', '/srv/', '/home/', 'token', 'secret', 'password']) {
   mustNotInclude(fixture.toLowerCase(), forbidden.toLowerCase(), 'git fallback fixture')


### PR DESCRIPTION
## Objetivo
Implementar Issue #40.5 como una microfase frontend server-only para selección controlada repo/commit en `/git`.

## Cambios
- `/git` lee `searchParams` en Server Component.
- `repo_id` solo se acepta si existe en `repoIndex.repos`.
- `sha` solo se acepta si existe en `commits.commits` del repo seleccionado.
- Repo cards y commits son enlaces server-side.
- Estado visual explícito de repo/commit seleccionado y labels de selección controlada.
- Guardrail `verify:git-server-only` endurecido para fijar validación, enlaces server-side, ausencia de inputs/forms y redirección a URL saneada ante query no soportada o maliciosa.
- Docs/OpenSpec/.engram actualizados.

## Restricciones preservadas
- Sin client paths ni paths arbitrarios.
- Sin refs/rangos/revspecs.
- Sin acciones Git.
- Sin working-tree diff.
- Sin inputs libres/búsqueda/forms.
- Sin client-side fetch.
- No se renderizan líneas de diff en HTML/DOM.

## Verify de Zoro
- ✅ `npm run verify:git-server-only`
- ✅ `npm --prefix apps/web run typecheck`
- ✅ `npm --prefix apps/web run build`
- ✅ `npm run verify:visual-baseline`
- ✅ `git diff --check`
- ✅ Smoke HTML/DOM producción con API live:
  - query válida `/git?repo_id=mugiwara-control-panel&sha=<sha-backend>` muestra repo/commit seleccionados y labels aceptados.
  - query inválida `repo_id=../../secret&sha=HEAD..main&path=/srv/private&ref=main` redirige a URL saneada, no ecoa valores maliciosos, no renderiza inputs/forms, no renderiza líneas de diff ni filtra env/backend URL/errores crudos.

## Riesgos / notas
- Query params son controlables por el navegador; la mitigación implementada valida contra datos backend ya cargados y redirige inputs inválidos/no soportados para evitar eco en HTML/RSC.
- No se añade paginación ni búsqueda; quedan fuera de alcance.

## Review solicitado
- Usopp: claridad UI/UX del selector, jerarquía visual, estados seleccionados, responsive.
- Chopper: validación server-side/no-leakage, ausencia de paths/refs/revspecs/acciones Git, no render de líneas de diff.
