### PR TITLE
docs: close out git control block

### DIFF
--- a/.engram/issue-40-6-closeout-canon.md
+++ b/.engram/issue-40-6-closeout-canon.md
@@ -1,0 +1,33 @@
+# Issue #40.6 closeout — Git control page canon
+
+## Contexto
+PR #93 cerró Issue #40.5 con selector controlado repo/commit en `/git`. Chopper aprobó tras mover la canonicalización anti-echo a `apps/web/src/middleware.ts`, porque `redirect()` desde Server Component podía devolver HTML/RSC intermedio con la query original. Usopp dejó `mergeable_with_minor_followups` sin bloquear el merge.
+
+## Decisión
+La siguiente microfase elegida es A) closeout/canon del bloque 40.1–40.5.
+
+Motivo: el bloque Git control ya entrega valor read-only suficiente y seguro. Abrir ahora refs/rangos/revspecs, remotes, acciones Git, working-tree diff o líneas de diff en DOM introduciría capacidad sensible sin necesidad explícita ni review nueva.
+
+## Estado cerrado
+- 40.1: backend registry/status read-only.
+- 40.2: backend commits/branches read-only.
+- 40.3: commit detail + safe diff backend deny-by-default.
+- 40.4: frontend `/git` server-only/read-only.
+- 40.5: selector controlado repo/commit con canonicalización temprana anti-echo RSC.
+
+## Restricciones vivas
+- Cliente solo usa `repo_id` allowlisteado y SHA backend-owned.
+- Sin paths, remotes, refs, rangos, revspecs, comandos Git ni discovery arbitrario desde cliente.
+- Sin acciones Git mutables o remotas.
+- Sin working-tree diff.
+- Sin render de líneas de diff en HTML/DOM.
+- Cualquier nueva capacidad Git requiere fase explícita y review adecuada.
+
+## Verify de esta microfase
+Docs/OpenSpec/.engram-only: `git diff --check`.
+
+## Continuidad
+Si Pablo pide continuar Git control, no implementar directamente. Primero elegir una ruta explícita:
+1. follow-up operativo/performance del middleware `/git` con Franky;
+2. polish UI menor con Usopp;
+3. nueva planificación para capacidad Git concreta con Franky/Chopper/Usopp según riesgo.

--- a/openspec/issue-40-6-closeout-canon-verify-checklist.md
+++ b/openspec/issue-40-6-closeout-canon-verify-checklist.md
@@ -1,0 +1,38 @@
+# Issue #40.6 — Closeout/canon verify checklist
+
+## Estado previo
+- [x] `git status --short --branch` revisado.
+- [x] `git log --oneline --decorate -5` revisado.
+- [x] `gh pr view 93 --json state,mergedAt,mergeCommit,url` revisado.
+- [x] PR #93 confirmada como mergeada en `ab10ba5853bff0109b727831c9ce1f756763fa33`.
+
+## Contexto revisado
+- [x] OpenSpec inicial `openspec/issue-40-git-control-page-plan.md`.
+- [x] OpenSpec 40.4 `openspec/issue-40-4-git-frontend-readonly.md`.
+- [x] OpenSpec 40.5 `openspec/issue-40-5-git-controlled-selector-plan.md`.
+- [x] Checklist 40.5 `openspec/issue-40-5-git-controlled-selector-verify-checklist.md`.
+- [x] Engram 40.4/40.5.
+- [x] Docs vivas `docs/runtime-config.md`, `docs/frontend-ui-spec.md`, `docs/frontend-implementation-handoff.md`, `docs/api-modules.md`, `docs/read-models.md`.
+- [x] Vault `Project Summary - Mugiwara Control Panel`.
+
+## Decisión
+- [x] Opción A elegida: closeout/canon del bloque 40.1–40.5.
+- [x] No se abre capacidad sensible por inercia.
+- [x] No se implementan refs/rangos/revspecs.
+- [x] No se implementan remotes ni acciones Git.
+- [x] No se implementa working-tree diff.
+- [x] No se renderizan líneas de diff en DOM.
+
+## Cambios de esta microfase
+- [x] Añadido OpenSpec 40.6 de closeout/canon.
+- [x] Añadido checklist de verify 40.6.
+- [x] Añadido closeout `.engram` 40.6.
+- [x] Actualizado OpenSpec inicial #40 para reflejar estado real tras 40.5.
+- [x] Sin cambios runtime, backend, frontend, dependencias ni configuración.
+
+## Verify ejecutado
+- [x] `git diff --check`
+- [x] revisión de diff final antes de commit
+- [ ] commit semántico con trailers Mugiwara
+- [ ] push de rama
+- [ ] PR abierta si aplica

--- a/openspec/issue-40-6-closeout-canon-verify-checklist.md
+++ b/openspec/issue-40-6-closeout-canon-verify-checklist.md
@@ -33,6 +33,6 @@
 ## Verify ejecutado
 - [x] `git diff --check`
 - [x] revisión de diff final antes de commit
-- [ ] commit semántico con trailers Mugiwara
-- [ ] push de rama
-- [ ] PR abierta si aplica
+- [x] commit semántico con trailers Mugiwara
+- [x] push de rama
+- [x] PR abierta: #94

--- a/openspec/issue-40-6-closeout-canon.md
+++ b/openspec/issue-40-6-closeout-canon.md
@@ -1,0 +1,77 @@
+# Issue #40.6 — Git control page closeout/canon
+
+## Opción elegida
+A) `closeout/canon` del bloque 40.1–40.5.
+
+## Motivo
+PR #93 / Issue #40.5 ya cerró la última microfase funcional prevista para `/git`: selector controlado repo/commit, canonicalización temprana anti-echo RSC y verify completo con review Chopper + Usopp. Abrir ahora refs/rangos/revspecs, remotes, acciones Git, working-tree diff o líneas de diff en DOM aumentaría superficie sensible por inercia y contradice el estado canónico de seguridad.
+
+El siguiente paso seguro es congelar el bloque como read-only controlado, corregir drift del OpenSpec inicial y dejar explícitas las fronteras futuras.
+
+## Contexto verificado
+- `main` limpio y alineado con `origin/main` tras merge de PR #93.
+- PR #93 está `MERGED`, merge commit `ab10ba5853bff0109b727831c9ce1f756763fa33`.
+- Git control 40.1–40.5 queda cerrado:
+  - 40.1 backend registry/status.
+  - 40.2 backend commits/branches.
+  - 40.3 backend commit detail + safe diff.
+  - 40.4 frontend `/git` server-only/read-only.
+  - 40.5 selector controlado repo/commit con middleware anti-echo antes de RSC.
+- El vault `Project Summary - Mugiwara Control Panel` ya registra PR #93 como hito reciente y recomienda no abrir nueva capacidad sin fase explícita.
+
+## Alcance de esta microfase
+- Actualizar OpenSpec inicial de Issue #40 para reflejar estado real 40.1–40.5.
+- Declarar 40.6 como cierre documental/canónico, no como feature runtime.
+- Añadir checklist de verify de closeout.
+- Añadir closeout `.engram` de continuidad técnica.
+- No tocar runtime, backend, frontend, dependencias, scripts ni configuración operativa.
+
+## Fuera de alcance obligatorio
+- Refs, rangos, revspecs o selector de branches como historial.
+- Remotes, `fetch`, `pull`, `push` o comparación contra remoto.
+- Acciones Git mutables (`checkout`, `reset`, `commit`, `stash`, `merge`, `rebase`, etc.).
+- Working-tree diff o contenido de cambios no commiteados.
+- Renderizar líneas de diff en HTML/DOM.
+- Inputs libres, forms, búsqueda o filtros sobre Git.
+
+Cualquier punto anterior requiere fase nueva, plan propio y review según perímetro: Franky para operación/runtime, Chopper para seguridad/frontera Git y Usopp si hay UI visible.
+
+## Resultado canónico del bloque
+`/git` queda como superficie de consulta read-only:
+- frontend server-only dinámico;
+- adapter `server-only` con `MUGIWARA_CONTROL_PANEL_API_URL` privado;
+- selección por enlaces server-side usando solo `repo_id` y SHA backend-owned;
+- canonicalización temprana en `apps/web/src/middleware.ts` para evitar eco de query no aceptada en HTML/RSC intermedio;
+- sin líneas de diff en DOM: la UI expone metadata, contadores y estados de redacción/truncado/omisión;
+- guardrail `npm run verify:git-server-only` como gate de regresión frontend;
+- guardrail `npm run verify:git-control-backend-policy` como gate de frontera backend.
+
+## Verify esperado
+Como esta microfase es docs/OpenSpec/.engram-only:
+```bash
+git diff --check
+```
+
+Si se toca runtime/UI en una futura microfase Git:
+```bash
+npm run verify:git-server-only
+npm --prefix apps/web run typecheck
+npm --prefix apps/web run build
+npm run verify:visual-baseline
+git diff --check
+# smokes HTML/DOM anti-leakage live/degradados, con no-follow redirects si toca canonicalización
+```
+
+Si se toca backend Git en una futura microfase:
+```bash
+PYTHONPATH=. pytest apps/api/tests/test_git_control_api.py -q
+npm run verify:git-control-backend-policy
+npm run verify:perimeter-policy
+git diff --check
+```
+
+## Siguiente paso recomendado
+No implementar nueva capacidad Git ahora. Mantener el bloque cerrado y elegir solo una de estas rutas futuras si hay necesidad explícita:
+1. follow-up operativo/performance del middleware `/git` con Franky si hay evidencia de coste real;
+2. polish UI menor de `/git` con Usopp si duele la experiencia actual;
+3. plan nuevo para capacidad Git explícita, empezando por diseño/review antes de tocar código.

--- a/openspec/issue-40-git-control-page-plan.md
+++ b/openspec/issue-40-git-control-page-plan.md
@@ -5,7 +5,11 @@
 - Planificación: PR #88 cerrada.
 - Microfase 40.1: PR #89 mergeada; backend-only registry/status implementado.
 - Microfase 40.2: PR #90 mergeada; backend-only commits/branches read model implementado.
-- Tipo de fase: planificación SDD inicial + microfases backend runtime.
+- Microfase 40.3: PR #91 mergeada; backend commit detail + safe diff implementado.
+- Microfase 40.4: PR #92 mergeada; frontend `/git` server-only/read-only implementado.
+- Microfase 40.5: PR #93 mergeada; selector controlado repo/commit y canonicalización temprana anti-echo RSC implementados.
+- Microfase 40.6: closeout/canon preparado en `openspec/issue-40-6-closeout-canon.md`.
+- Tipo de fase: planificación SDD inicial + microfases backend/frontend runtime + closeout/canon.
 - Fecha: 2026-04-27
 
 ## Objetivo
@@ -149,31 +153,37 @@ El API debe indicar `omitted_reason`, `truncated`, `redacted` y contadores; no d
 **Review:** Franky + Chopper obligatorio.
 
 ### 40.4 — Frontend `/git` read-only page
+**Estado:** implementado en PR #92.
+
 **Objetivo:** añadir página UI que consuma los endpoints backend cerrados para índice, historial y detalle/diff de commits.
 
-**Incluye:** navegación, server-only adapter, página dinámica, estados de fuente/fallback, cards/listas responsive, copy de solo lectura y avisos de redacción/truncado.
+**Incluye:** navegación `Repos Git`, server-only adapter, página dinámica, estados de fuente/fallback, cards/listas responsive, copy de solo lectura y avisos de redacción/truncado/omisión. Tras review de Chopper, el frontend no renderiza líneas de diff en HTML/DOM; muestra metadata, contadores y estados.
 
-**No incluye:** acciones Git, working tree diff si 40.5 no está cerrado, búsqueda avanzada.
+**No incluye:** acciones Git, working-tree diff, búsqueda avanzada, refs/rangos/revspecs ni líneas de diff en DOM.
 
-**TDD/verify:** `verify:git-server-only` nuevo, typecheck/build, visual baseline, smoke HTML/DOM anti leakage (`MUGIWARA_CONTROL_PANEL_API_URL`, backend URL, rutas host, `.env`, tokens sintéticos, stdout/stderr, stack traces), browser smoke responsive.
+**TDD/verify:** `verify:git-server-only`, typecheck/build, visual baseline, smoke HTML/DOM anti leakage (`MUGIWARA_CONTROL_PANEL_API_URL`, backend URL, rutas host, `.env`, tokens sintéticos, stdout/stderr, stack traces), browser smoke responsive.
 
-**Review:** Usopp + Chopper; Franky solo si se añade polling/cache/runtime.
+**Review:** Usopp + Chopper.
 
-### 40.5 — Working tree read-only status/diff
-**Objetivo:** mostrar cambios sin commitear sin permitir acciones.
+### 40.5 — Frontend selector controlado repo/commit
+**Estado:** implementado en PR #93.
 
-**Incluye:** status summary por repo, archivos modificados/nuevos/borrados con nombres saneados; diff de working tree solo con la misma política de 40.3 y preferiblemente detrás de toggle/estado claro.
+**Objetivo:** permitir selección controlada de repo y commit en `/git` sin abrir input Git arbitrario.
 
-**Riesgo:** puede exponer secretos no commiteados; si hay duda, primera entrega debe limitarse a resumen sin contenido de diff para un PR propio.
+**Incluye:** repo cards y commits como enlaces server-side; `repo_id` aceptado solo si existe en `repoIndex.repos`; `sha` aceptado solo si existe en `commits.commits` del repo seleccionado; canonicalización temprana en `apps/web/src/middleware.ts` para redirigir queries no soportadas, duplicadas, inseguras o no validables antes de render RSC.
 
-**TDD/verify:** fixtures con `.env` no commiteado, archivos grandes/binarios/logs, renames/deletes; payload no debe contener contenido sensible ni rutas host.
+**No incluye:** paginación avanzada, búsqueda/filtros, refs/rangos/revspecs, remotes, acciones Git, working-tree diff, inputs libres ni líneas de diff en DOM.
 
-**Review:** Franky + Chopper + Usopp si toca UI.
+**TDD/verify:** `verify:git-server-only`, typecheck/build, visual baseline, `git diff --check`, smokes HTML/DOM anti-leakage live/degradados con redirects follow y no-follow.
+
+**Review:** Usopp + Chopper. Chopper aprobó tras fix de middleware anti-echo RSC; Usopp dejó `mergeable_with_minor_followups`.
 
 ### 40.6 — Closeout/canon
-**Objetivo:** actualizar docs vivas, OpenSpec, `.engram`, Project Summary del vault, issues/PRs y guardrails tras cerrar las microfases runtime.
+**Estado:** preparado en `openspec/issue-40-6-closeout-canon.md`.
 
-**Verify:** guardrails Git backend/frontend, perímetro, typecheck/build, tests backend Git, visual baseline si UI cambió, `git diff --check`, scans dirigidos anti-secretos.
+**Objetivo:** actualizar OpenSpec, `.engram` y canon vivo tras cerrar 40.1–40.5, dejando congelado el bloque read-only y documentando que cualquier nueva capacidad Git requiere fase explícita.
+
+**Verify:** docs-only `git diff --check`. Si una futura fase toca runtime/UI, volver a ejecutar `verify:git-server-only`, typecheck, build, visual baseline y smokes anti-leakage; si toca backend Git, ejecutar tests backend Git, `verify:git-control-backend-policy` y `verify:perimeter-policy`.
 
 ## Guardrails nuevos propuestos
 - `npm run verify:git-control-backend-policy`
@@ -192,12 +202,20 @@ El API debe indicar `omitted_reason`, `truncated`, `redacted` y contadores; no d
 - `AGENTS.md` de `apps/api/src/modules`, `apps/web/src/modules` si nace nueva carpeta.
 
 ## Riesgos abiertos
-- **Diffs históricos con secretos:** un secreto puede estar commiteado; la política por path no basta. Se requiere redacción por contenido y omisión fail-closed.
-- **Working tree no commiteado:** riesgo mayor que commit history; debe ir después y quizá empezar solo con summary.
-- **Subprocess Git:** aceptable solo con arg list, cwd fijo, timeout, env mínimo, `shell=False` y allowlist de comandos read-only; si se usa librería Git, revisar igualmente que no haga discovery o reads no acotados.
+- **Nueva capacidad Git por inercia:** refs/rangos/revspecs, remotes, acciones Git, working-tree diff y líneas de diff en DOM quedan fuera del bloque cerrado y requieren planificación/review propios.
+- **Diffs históricos con secretos:** mitigado por safe diff backend y por no renderizar líneas de diff en frontend; cualquier cambio que vuelva a exponer contenido debe pasar por Chopper.
+- **Working tree no commiteado:** riesgo mayor que commit history por secretos no commiteados; no está implementado y no debe añadirse sin fase nueva.
+- **Subprocess Git:** aceptable solo en el backend ya revisado, con arg list, cwd fijo, timeout, entorno mínimo, `shell=False` y comandos read-only allowlisteados.
 - **Remote/ahead-behind:** no ejecutar red en request. Comparar solo refs locales; cualquier `fetch` pertenece a productor/operación separada, no al endpoint.
-- **Rutas absolutas:** útiles para backend, no para UI/API pública del control plane; usar labels lógicos.
-- **Tamaño/performance:** paginación y límites desde el primer endpoint; diffs truncados siempre.
+- **Rutas absolutas:** útiles internamente para backend, no para UI/API pública del control plane; usar labels lógicos.
+- **Coste de middleware `/git`:** el fetch temprano para canonicalización anti-echo puede merecer medición operativa si hay carga real; tratar como follow-up Franky, no como feature Git.
 
 ## Siguiente paso recomendado
-Implementar 40.1 como microfase backend-only: registry allowlisted + `GET /api/v1/git/repos` + `GET /api/v1/git/repos/{repo_id}/status` resumido, con TDD rojo primero y guardrail backend. No tocar UI ni diffs hasta cerrar review Franky + Chopper sobre la frontera Git.
+Cerrar el bloque con 40.6 y no implementar nueva capacidad Git ahora.
+
+Opciones futuras seguras solo si hay necesidad explícita:
+1. follow-up operativo/performance del middleware `/git` con Franky;
+2. polish UI menor de `/git` con Usopp;
+3. plan nuevo para capacidad Git concreta con revisión Franky/Chopper/Usopp según perímetro.
+
+No abrir refs/rangos/revspecs, remotes, acciones Git, working-tree diff ni líneas de diff en DOM sin diseño y review nuevos.


### PR DESCRIPTION
## Objetivo
Closeout/canon del bloque Git control page 40.1–40.5 tras merge de PR #93.

## Opción elegida
A) closeout/canon del bloque 40.1–40.5.

## Motivo
`/git` ya quedó cerrado como superficie read-only/server-only con selector controlado repo/commit y middleware anti-echo RSC. Abrir refs/rangos/revspecs, remotes, acciones Git, working-tree diff o líneas de diff en DOM sería ampliar superficie sensible sin fase explícita.

## Cambios
- Añade `openspec/issue-40-6-closeout-canon.md`.
- Añade `openspec/issue-40-6-closeout-canon-verify-checklist.md`.
- Añade `.engram/issue-40-6-closeout-canon.md`.
- Actualiza `openspec/issue-40-git-control-page-plan.md` para corregir drift: 40.4 y 40.5 ya están cerradas, y working-tree diff queda fuera de alcance hasta nueva fase.

## Verify
- `git diff --check`

## Riesgo
Docs/OpenSpec/.engram-only. Sin runtime, backend, frontend, dependencias, scripts, configuración operativa ni seguridad efectiva.

## Review
Cambio de bajo riesgo documental. No solicito handoff externo a Franky/Chopper/Usopp salvo que alguien quiera revisar el canon de scope.
