### PR TITLE
docs: record runtime readiness smoke

### DIFF
--- a/.engram/runtime-readiness-smoke-private-v1.md
+++ b/.engram/runtime-readiness-smoke-private-v1.md
@@ -1,0 +1,31 @@
+# Runtime readiness smoke — private v1
+
+## Contexto
+Tras PR #94 e Issue #40 cerrada, se ejecutó el smoke pequeño de runtime readiness recomendado por el Project Summary del vault para decidir si `mugiwara-control-panel` puede declararse operativo privado v1.
+
+## Alcance ejecutado
+Smoke sin features nuevas:
+- web + API en loopback;
+- `/healthcheck` backend y frontend;
+- timers/manifests reales Healthcheck;
+- guardrails principales;
+- no-leakage básico.
+
+## Resultado
+Listo para declarar **operativo privado v1** bajo perímetro privado/local/Tailscale, sin soporte internet-public.
+
+Evidencia principal:
+- Guardrails de perímetro, Healthcheck producers/runners, Healthcheck/Dashboard server-only y Git server-only pasaron.
+- `npm --prefix apps/web run typecheck` pasó.
+- `PYTHONPATH=. pytest apps/api/tests -q` pasó con `129 passed`.
+- `npm --prefix apps/web run build` pasó y `/healthcheck` quedó dinámica.
+- FastAPI `GET /api/v1/healthcheck` respondió `200`, `status=ready`, `meta.sanitized=true`, seis módulos reales en `pass/low`.
+- Next production `/healthcheck` respondió `200`, renderizó módulos reales y no tuvo errores de consola en browser smoke.
+- Cinco timers Healthcheck user-level activos.
+- Cinco manifests reales JSON con permisos `0640` y no-leakage básico `PASS`.
+
+## Hallazgo operativo
+El smoke de no-leakage web debe ejecutarse sobre `next build` + `next start`, no sobre `next dev`: en dev mode el HTML/RSC puede contener datos propios del runtime de desarrollo como URL de fetch y `fileName` con rutas fuente, generando falsos positivos que no representan el bundle production.
+
+## Restricciones vivas
+No se añadieron fuentes Healthcheck, capacidades Git, runtime changes, timers, manifests, permisos, UI nueva ni auth pública. La declaración v1 privada no cubre exposición pública, carga/performance ni nuevas capacidades.

--- a/openspec/runtime-readiness-smoke-private-v1-verify-checklist.md
+++ b/openspec/runtime-readiness-smoke-private-v1-verify-checklist.md
@@ -1,0 +1,55 @@
+# Runtime readiness smoke — verify checklist
+
+## Preflight repo/vault
+- [x] `git status --short --branch` ejecutado en `main` antes de crear rama.
+- [x] `git log --oneline --decorate -5` ejecutado.
+- [x] `gh issue view 40 --json state,url` confirma Issue #40 cerrada.
+- [x] Rama `zoro/runtime-readiness-smoke` creada.
+
+## Alcance
+- [x] Scope limitado a smoke runtime web+API, `/healthcheck`, timers/manifests reales, guardrails y no-leakage básico.
+- [x] Sin features nuevas.
+- [x] Sin fuentes Healthcheck nuevas.
+- [x] Sin capacidades Git nuevas.
+
+## Guardrails principales
+- [x] `npm run verify:perimeter-policy`
+- [x] `npm run verify:health-dashboard-server-only`
+- [x] `npm run verify:healthcheck-source-policy`
+- [x] `npm run verify:vault-sync-status-producer`
+- [x] `npm run verify:vault-sync-status-runner`
+- [x] `npm run verify:backup-health-status-producer`
+- [x] `npm run verify:backup-health-status-runner`
+- [x] `npm run verify:project-health-runner`
+- [x] `npm run verify:gateway-status-runner`
+- [x] `npm run verify:cronjobs-status-runner`
+- [x] `npm run verify:git-server-only`
+
+## Build/tests
+- [x] `npm --prefix apps/web run typecheck`
+- [x] `PYTHONPATH=. pytest apps/api/tests -q`
+- [x] `npm --prefix apps/web run build`
+
+## Runtime smoke
+- [x] FastAPI arrancado en loopback.
+- [x] Next.js arrancado en loopback con `MUGIWARA_CONTROL_PANEL_API_URL` server-only apuntando al API local.
+- [x] `GET /api/v1/healthcheck` devuelve 200 y `meta.sanitized=true`.
+- [x] `/healthcheck` devuelve 200.
+- [x] `/healthcheck` muestra contenido Healthcheck real sin fallback por API caída.
+
+## Timers/manifests reales
+- [x] Cinco timers Healthcheck user-level activos.
+- [x] Cinco manifests existen y son JSON mapping.
+- [x] Permisos no públicos en manifests.
+- [x] No-leakage básico en manifests.
+
+## No-leakage básico
+- [x] API `/api/v1/healthcheck` sin backend URL, `.env`, stdout/stderr, traceback, tokens ni rutas sensibles obvias.
+- [x] HTML `/healthcheck` sin backend URL, env names, `.env`, stdout/stderr, traceback, tokens ni rutas sensibles obvias.
+- [x] Respuestas HTTP sin errores crudos.
+
+## Cierre
+- [x] Resultados documentados.
+- [x] `.engram` closeout creado.
+- [x] `git diff --check` pasa.
+- [x] Decisión listo/no listo registrada.

--- a/openspec/runtime-readiness-smoke-private-v1.md
+++ b/openspec/runtime-readiness-smoke-private-v1.md
@@ -1,0 +1,133 @@
+# Runtime readiness smoke — private v1
+
+## Objetivo
+Ejecutar una microfase pequeña de smoke runtime para decidir si el control plane puede declararse operativo privado v1, sin abrir features nuevas ni añadir fuentes Healthcheck/Git.
+
+## Contexto
+- PR #94 está mergeada y Issue #40 cerrada.
+- La Git control page queda cerrada hasta una eventual 40.6+ explícita.
+- El Project Summary del vault ya recomienda este smoke como siguiente paso.
+
+## Alcance mínimo elegido
+1. **Web + API**: levantar FastAPI y Next.js en loopback, con `MUGIWARA_CONTROL_PANEL_API_URL` server-only apuntando al API local de la rama.
+2. **`/healthcheck`**: comprobar endpoint FastAPI `GET /api/v1/healthcheck` y página web `/healthcheck` consumiendo backend real, no fixture por API caída.
+3. **Timers/manifests reales**: verificar los cinco timers user-level y los cinco manifests Healthcheck existentes:
+   - `vault-sync-status`
+   - `backup-health-status`
+   - `project-health-status`
+   - `gateway-status`
+   - `cronjobs-status`
+4. **Guardrails principales**: ejecutar checks estáticos de perímetro, Healthcheck producers/runners y superficies server-only relevantes para el smoke.
+5. **No-leakage básico**: escanear respuestas API/HTML contra canarios y marcadores sensibles básicos: backend URL, env names públicas/privadas, `.env`, `stdout`, `stderr`, `traceback`, rutas internas obvias y tokens.
+
+## Fuera de alcance
+- Nuevas features.
+- Nuevas fuentes Healthcheck.
+- Nuevas capacidades Git.
+- Cambios de UI/copy salvo documentación del smoke.
+- Cambios de runtime, timers, manifests, permisos o unidades systemd.
+- Auth pública, exposición a internet o hardening nuevo.
+
+## Definition of Done
+- Repo/vault de partida verificados.
+- Rama `zoro/runtime-readiness-smoke` creada desde `main` limpio.
+- OpenSpec, checklist y closeout `.engram` registran el smoke.
+- Verify real ejecutado y documentado con resultados por superficie.
+- Decisión explícita: listo/no listo para operativo privado v1.
+
+## Criterio de readiness
+Se puede declarar **operativo privado v1** si:
+- API y web arrancan en loopback.
+- `/api/v1/healthcheck` responde 200 con `meta.sanitized=true`.
+- `/healthcheck` responde 200 usando backend real y no filtra topología ni errores crudos.
+- Los cinco timers existen y están activos.
+- Los cinco manifests existen, son JSON mapping, tienen permisos no públicos y no contienen marcadores sensibles básicos.
+- Los guardrails principales pasan.
+- No aparecen fugas básicas en API/HTML.
+
+Si falla cualquier punto crítico, el resultado debe ser **no listo**, con bloqueo concreto y siguiente acción recomendada.
+
+## Verify planificado
+- `git status --short --branch`
+- `git log --oneline --decorate -5`
+- `gh issue view 40 --json state,url`
+- `npm run verify:perimeter-policy`
+- `npm run verify:health-dashboard-server-only`
+- `npm run verify:healthcheck-source-policy`
+- `npm run verify:vault-sync-status-producer`
+- `npm run verify:vault-sync-status-runner`
+- `npm run verify:backup-health-status-producer`
+- `npm run verify:backup-health-status-runner`
+- `npm run verify:project-health-runner`
+- `npm run verify:gateway-status-runner`
+- `npm run verify:cronjobs-status-runner`
+- `npm run verify:git-server-only`
+- `npm --prefix apps/web run typecheck`
+- `PYTHONPATH=. pytest apps/api/tests -q`
+- `npm --prefix apps/web run build`
+- `systemctl --user is-active` de los cinco timers
+- validación shape/permisos/no-leakage de manifests reales
+- smoke API `GET /api/v1/healthcheck`
+- smoke web `/healthcheck`
+- scan no-leakage básico sobre respuestas API/HTML
+- `git diff --check`
+
+
+## Resultados ejecutados
+
+### Preflight
+- Repo de partida en `main...origin/main`, limpio antes de crear la rama.
+- Últimos commits: `95a09a0` merge PR #94, `4b3a087`, `755f65c`, `ab10ba5`, `e782354`.
+- Issue #40 confirmado `CLOSED`: https://github.com/asistentes-mugiwara/mugiwara-control-panel/issues/40.
+- Rama creada: `zoro/runtime-readiness-smoke`.
+
+### Guardrails, tests y build
+Pasaron:
+- `npm run verify:perimeter-policy`
+- `npm run verify:health-dashboard-server-only`
+- `npm run verify:healthcheck-source-policy`
+- `npm run verify:vault-sync-status-producer`
+- `npm run verify:vault-sync-status-runner`
+- `npm run verify:backup-health-status-producer`
+- `npm run verify:backup-health-status-runner`
+- `npm run verify:project-health-runner`
+- `npm run verify:gateway-status-runner`
+- `npm run verify:cronjobs-status-runner`
+- `npm run verify:git-server-only`
+- `npm --prefix apps/web run typecheck`
+- `PYTHONPATH=. pytest apps/api/tests -q` → `129 passed`
+- `npm --prefix apps/web run build` → rutas principales dinámicas, incluido `/healthcheck`.
+
+### Runtime smoke
+- FastAPI arrancó en `127.0.0.1:8011`.
+- Next.js production arrancó en `127.0.0.1:3017` con `MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011` solo server-side.
+- `GET /api/v1/healthcheck` devolvió `200`, `status=ready`, `meta.read_only=true`, `meta.sanitized=true`, `meta.source=backend-owned-safe-catalog` y 6 módulos en `pass/low`.
+- `/healthcheck` devolvió `200`, renderizó módulos reales (`Vault sync`, `Backups`, `Project health`, `Gateways`, `Cronjobs`) y el browser smoke no registró errores de consola.
+
+### Timers/manifests reales
+Timers user-level activos:
+- `mugiwara-vault-sync-status.timer`
+- `mugiwara-backup-health-status.timer`
+- `mugiwara-project-health-status.timer`
+- `mugiwara-gateway-status.timer`
+- `mugiwara-cronjobs-status.timer`
+
+Manifests reales validados como JSON mapping, permisos `0640` y no-leakage básico `PASS`:
+- `vault-sync-status.json`: `last_success_at,result,status,updated_at`
+- `backup-health-status.json`: `checksum_present,last_success_at,result,retention_count,status,updated_at`
+- `project-health-status.json`: `main_branch,remote_synced,result,status,updated_at,workspace_clean`
+- `gateway-status.json`: `gateways,result,status,updated_at`
+- `cronjobs-status.json`: `jobs,result,status,updated_at`
+
+### No-leakage básico
+- API `/api/v1/healthcheck`: `PASS` contra backend URL, env names, `.env`, stdout/stderr, tracebacks, tokens, rutas runtime/proyecto, `state.db`, `chat_id` y `prompt_body`.
+- HTML production `/healthcheck`: `PASS` contra los mismos marcadores.
+- Nota operativa: el primer intento con `next dev` produjo falsos positivos de leakage por HTML/RSC de desarrollo que serializaba URL de fetch y `fileName` con rutas fuente. El criterio de readiness se ejecutó finalmente con `next build` + `next start`, no con dev server.
+
+## Decisión
+**Listo para declarar operativo privado v1**, bajo el perímetro ya definido: loopback/red privada/Tailscale, no exposición pública a internet y sin nuevas features.
+
+## Riesgos residuales
+- La declaración aplica a operación privada actual; no implica soporte internet-public ni auth/rate-limit/CSRF completos fuera del perímetro privado.
+- El smoke no cubre carga, resiliencia prolongada ni performance de `/git`; esos follow-ups no son bloqueantes para v1 privada.
+- No se han añadido nuevas fuentes Healthcheck ni nuevas capacidades Git; cualquier ampliación futura requiere fase explícita y review.


### PR DESCRIPTION
## Objetivo
Registrar la microfase de runtime readiness smoke para decidir si `mugiwara-control-panel` puede declararse operativo privado v1 tras PR #94 / cierre de Issue #40.

## Alcance
- OpenSpec del smoke runtime privado v1.
- Checklist de verificación ejecutada.
- Closeout `.engram` de continuidad técnica.

## Sin cambios de producto/runtime
- No añade features.
- No añade fuentes Healthcheck.
- No añade capacidades Git.
- No toca backend, frontend, scripts ejecutables, dependencias, timers, manifests, units ni permisos.

## Verify ejecutado
- `git status --short --branch`
- `git log --oneline --decorate -5`
- `gh issue view 40 --json state,url`
- `npm run verify:perimeter-policy`
- `npm run verify:health-dashboard-server-only`
- `npm run verify:healthcheck-source-policy`
- `npm run verify:vault-sync-status-producer`
- `npm run verify:vault-sync-status-runner`
- `npm run verify:backup-health-status-producer`
- `npm run verify:backup-health-status-runner`
- `npm run verify:project-health-runner`
- `npm run verify:gateway-status-runner`
- `npm run verify:cronjobs-status-runner`
- `npm run verify:git-server-only`
- `npm --prefix apps/web run typecheck`
- `PYTHONPATH=. pytest apps/api/tests -q` (`129 passed`)
- `npm --prefix apps/web run build`
- Runtime smoke FastAPI + Next production `/healthcheck`
- Browser smoke `/healthcheck` con consola limpia
- Timers/manifests reales Healthcheck activos/JSON/permisos/no-leakage básico
- `git diff --check`

## Decisión documentada
Listo para declarar operativo privado v1 bajo perímetro privado/local/Tailscale, sin soporte internet-public.
