### PR TITLE
feat: run control panel as private tailscale service

### DIFF
--- a/.engram/control-panel-tailscale-service.md
+++ b/.engram/control-panel-tailscale-service.md
@@ -1,0 +1,37 @@
+# Control Panel private Tailscale service
+
+## Contexto
+Después del runtime readiness smoke PR #95, Pablo pidió uso permanente del control panel y acceso por Tailscale fuera de la red local.
+
+## Implementación
+Servicios `systemd --user` añadidos e instalados:
+- `mugiwara-control-panel-api.service`: FastAPI solo loopback `127.0.0.1:8011`.
+- `mugiwara-control-panel-web.service`: Next.js production por Tailscale `100.65.118.27:3017`.
+
+Runners:
+- `scripts/run-control-panel-api.sh` rechaza API fuera de loopback y usa el Python del venv Hermes con `uvicorn`.
+- `scripts/run-control-panel-web.sh` detecta IPv4 Tailscale y rechaza bind wildcard; consume API solo por `http://127.0.0.1:8011`.
+- `scripts/install-control-panel-user-services.sh` construye Next production, instala units en `~/.config/systemd/user`, habilita y arranca ambos servicios.
+
+## Verify ejecutado
+- `npm run verify:control-panel-service-runner` pasó.
+- `npm run verify:perimeter-policy` pasó.
+- `npm run verify:health-dashboard-server-only` pasó.
+- `npm --prefix apps/web run typecheck` pasó.
+- `PYTHONPATH=. pytest apps/api/tests -q` pasó con `129 passed`.
+- `npm --prefix apps/web run build` pasó.
+- `systemd-analyze --user verify ...api.service ...web.service` pasó.
+- Installer ejecutado correctamente.
+- `systemctl --user is-active` confirmó ambos servicios `active`.
+- `ss -ltnp` confirmó API `127.0.0.1:8011` y web `100.65.118.27:3017`.
+- Smoke API `/api/v1/healthcheck`: `status=ready`, `meta.sanitized=true`.
+- Smoke web Tailscale `/healthcheck`: HTTP 200, módulos reales y no-leakage básico `PASS`.
+- Browser smoke Tailscale: consola limpia.
+- `loginctl show-user $USER -p Linger` confirmó `Linger=yes`, por lo que los servicios user-level pueden levantarse tras boot sin login interactivo.
+
+## URL de uso
+- `http://100.65.118.27:3017`
+- `http://delaya-control.tail2ce3eb.ts.net:3017`
+
+## Restricciones vivas
+Esto sigue siendo operación privada/Tailscale. No se ha abierto `internet-public`, Tailscale Funnel, API directa, auth pública ni nuevas features.

--- a/.engram/control-panel-tailscale-service.md
+++ b/.engram/control-panel-tailscale-service.md
@@ -6,7 +6,7 @@ Después del runtime readiness smoke PR #95, Pablo pidió uso permanente del con
 ## Implementación
 Servicios `systemd --user` añadidos e instalados:
 - `mugiwara-control-panel-api.service`: FastAPI solo loopback `127.0.0.1:8011`.
-- `mugiwara-control-panel-web.service`: Next.js production por Tailscale `100.65.118.27:3017`.
+- `mugiwara-control-panel-web.service`: Next.js production por Tailscale `<tailscale-ip>:3017`.
 
 Runners:
 - `scripts/run-control-panel-api.sh` rechaza API fuera de loopback y usa el Python del venv Hermes con `uvicorn`.
@@ -23,15 +23,15 @@ Runners:
 - `systemd-analyze --user verify ...api.service ...web.service` pasó.
 - Installer ejecutado correctamente.
 - `systemctl --user is-active` confirmó ambos servicios `active`.
-- `ss -ltnp` confirmó API `127.0.0.1:8011` y web `100.65.118.27:3017`.
+- `ss -ltnp` confirmó API `127.0.0.1:8011` y web `<tailscale-ip>:3017`.
 - Smoke API `/api/v1/healthcheck`: `status=ready`, `meta.sanitized=true`.
 - Smoke web Tailscale `/healthcheck`: HTTP 200, módulos reales y no-leakage básico `PASS`.
 - Browser smoke Tailscale: consola limpia.
 - `loginctl show-user $USER -p Linger` confirmó `Linger=yes`, por lo que los servicios user-level pueden levantarse tras boot sin login interactivo.
 
 ## URL de uso
-- `http://100.65.118.27:3017`
-- `http://delaya-control.tail2ce3eb.ts.net:3017`
+- `http://<tailscale-ip>:3017`
+- `http://<magicdns-host>:3017`
 
 ## Restricciones vivas
 Esto sigue siendo operación privada/Tailscale. No se ha abierto `internet-public`, Tailscale Funnel, API directa, auth pública ni nuevas features.

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -23,6 +23,40 @@ Guardarraíl de este contrato:
 npm run verify:perimeter-policy
 ```
 
+
+## Servicio privado persistente por Tailscale
+`mugiwara-control-panel` puede instalarse como dos servicios `systemd --user` para uso permanente privado:
+
+- `mugiwara-control-panel-api.service`: FastAPI, loopback-only en `127.0.0.1:8011`.
+- `mugiwara-control-panel-web.service`: Next.js production, accesible por Tailscale en `100.65.118.27:3017` en este host.
+
+Instalación:
+
+```bash
+scripts/install-control-panel-user-services.sh
+```
+
+URL privada actual:
+
+```text
+http://100.65.118.27:3017
+http://delaya-control.tail2ce3eb.ts.net:3017
+```
+
+Contrato de seguridad:
+
+1. La API no se expone por Tailscale ni por LAN; escucha solo en loopback.
+2. La web consume `MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011` solo server-side.
+3. El runner web detecta la IPv4 de Tailscale y rechaza bind wildcard (`0.0.0.0`/`::`).
+4. Esto sigue siendo `internet-public: unsupported`: no usa Tailscale Funnel, no abre puertos públicos ni añade auth pública/rate-limit.
+5. Si Tailscale no está disponible, el servicio web falla y systemd reintenta, en vez de caer silenciosamente a exposición pública.
+
+Guardarraíl:
+
+```bash
+npm run verify:control-panel-service-runner
+```
+
 ## Variables actuales
 
 | Variable | Consumidor | Exposición | Uso |

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -28,7 +28,7 @@ npm run verify:perimeter-policy
 `mugiwara-control-panel` puede instalarse como dos servicios `systemd --user` para uso permanente privado:
 
 - `mugiwara-control-panel-api.service`: FastAPI, loopback-only en `127.0.0.1:8011`.
-- `mugiwara-control-panel-web.service`: Next.js production, accesible por Tailscale en `100.65.118.27:3017` en este host.
+- `mugiwara-control-panel-web.service`: Next.js production, accesible por Tailscale en `<tailscale-ip>:3017` en este host.
 
 Instalación:
 
@@ -39,8 +39,8 @@ scripts/install-control-panel-user-services.sh
 URL privada actual:
 
 ```text
-http://100.65.118.27:3017
-http://delaya-control.tail2ce3eb.ts.net:3017
+http://<tailscale-ip>:3017
+http://<magicdns-host>:3017
 ```
 
 Contrato de seguridad:

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -57,6 +57,25 @@ Guardarraíl:
 npm run verify:control-panel-service-runner
 ```
 
+Prerrequisito de arranque tras reboot:
+
+```bash
+loginctl show-user "$(id -un)" -p Linger
+```
+
+Debe devolver `Linger=yes` para que los servicios user-level puedan levantarse tras boot sin login interactivo.
+
+Rollback operativo:
+
+```bash
+systemctl --user disable --now mugiwara-control-panel-api.service mugiwara-control-panel-web.service
+rm -f "${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/mugiwara-control-panel-api.service"
+rm -f "${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/mugiwara-control-panel-web.service"
+systemctl --user daemon-reload
+```
+
+Si cambia la IP Tailscale del host, actualizar este documento, `openspec/control-panel-tailscale-service.md` y el guardarraíl `verify:control-panel-service-runner` antes de declarar válido el nuevo endpoint privado.
+
 ## Variables actuales
 
 | Variable | Consumidor | Exposición | Uso |

--- a/openspec/control-panel-tailscale-service-verify-checklist.md
+++ b/openspec/control-panel-tailscale-service-verify-checklist.md
@@ -1,0 +1,47 @@
+# Control Panel private Tailscale service — verify checklist
+
+## Preflight
+- [x] Repo limpio en `main...origin/main` antes de rama.
+- [x] Rama `zoro/control-panel-tailscale-service` creada.
+- [x] Tailscale detectado: `delaya-control.tail2ce3eb.ts.net.` / `100.65.118.27`.
+
+## Implementación
+- [x] API service unit añadido.
+- [x] Web service unit añadido.
+- [x] API runner añadido.
+- [x] Web runner añadido.
+- [x] Installer añadido.
+- [x] Guardrail estático añadido y enlazado en `package.json`.
+- [x] Docs runtime actualizadas.
+- [x] `.engram` closeout creado.
+
+## Verify estático y tests
+- [x] `npm run verify:control-panel-service-runner`
+- [x] `npm run verify:perimeter-policy`
+- [x] `npm run verify:health-dashboard-server-only`
+- [x] `npm --prefix apps/web run typecheck`
+- [x] `PYTHONPATH=. pytest apps/api/tests -q`
+- [x] `npm --prefix apps/web run build`
+- [x] `systemd-analyze --user verify ops/systemd/user/mugiwara-control-panel-api.service ops/systemd/user/mugiwara-control-panel-web.service`
+
+## Instalación runtime
+- [x] `scripts/install-control-panel-user-services.sh`
+- [x] `systemctl --user is-active mugiwara-control-panel-api.service`
+- [x] `systemctl --user is-active mugiwara-control-panel-web.service`
+- [x] `ss -ltnp` confirma API en `127.0.0.1:8011`.
+- [x] `ss -ltnp` confirma web en `100.65.118.27:3017`.
+
+## Smoke
+- [x] `GET http://127.0.0.1:8011/api/v1/healthcheck` responde 200 y `meta.sanitized=true`.
+- [x] `GET http://100.65.118.27:3017/healthcheck` responde 200.
+- [x] HTML por Tailscale renderiza Healthcheck real.
+- [x] No-leakage básico API/HTML.
+- [x] Browser smoke por Tailscale con consola limpia.
+
+## Cierre
+- [x] `git diff --check`
+- [ ] PR abierta.
+- [ ] Handoff PR dejado.
+- [ ] Franky invocado y responde.
+- [ ] Chopper invocado y responde.
+- [ ] Reviewers comentan PR o declaran bloqueo por permisos.

--- a/openspec/control-panel-tailscale-service-verify-checklist.md
+++ b/openspec/control-panel-tailscale-service-verify-checklist.md
@@ -40,8 +40,8 @@
 
 ## Cierre
 - [x] `git diff --check`
-- [ ] PR abierta.
-- [ ] Handoff PR dejado.
+- [x] PR abierta.
+- [x] Handoff PR dejado.
 - [x] Franky invocado y responde.
 - [x] Chopper invocado y responde.
-- [ ] Reviewers comentan PR o declaran bloqueo por permisos.
+- [x] Reviewers comentan PR o declaran bloqueo por permisos.

--- a/openspec/control-panel-tailscale-service-verify-checklist.md
+++ b/openspec/control-panel-tailscale-service-verify-checklist.md
@@ -3,7 +3,7 @@
 ## Preflight
 - [x] Repo limpio en `main...origin/main` antes de rama.
 - [x] Rama `zoro/control-panel-tailscale-service` creada.
-- [x] Tailscale detectado: `delaya-control.tail2ce3eb.ts.net.` / `100.65.118.27`.
+- [x] Tailscale detectado: `<magicdns-host>` / `<tailscale-ip>`.
 
 ## Implementación
 - [x] API service unit añadido.
@@ -29,11 +29,11 @@
 - [x] `systemctl --user is-active mugiwara-control-panel-api.service`
 - [x] `systemctl --user is-active mugiwara-control-panel-web.service`
 - [x] `ss -ltnp` confirma API en `127.0.0.1:8011`.
-- [x] `ss -ltnp` confirma web en `100.65.118.27:3017`.
+- [x] `ss -ltnp` confirma web en `<tailscale-ip>:3017`.
 
 ## Smoke
 - [x] `GET http://127.0.0.1:8011/api/v1/healthcheck` responde 200 y `meta.sanitized=true`.
-- [x] `GET http://100.65.118.27:3017/healthcheck` responde 200.
+- [x] `GET http://<tailscale-ip>:3017/healthcheck` responde 200.
 - [x] HTML por Tailscale renderiza Healthcheck real.
 - [x] No-leakage básico API/HTML.
 - [x] Browser smoke por Tailscale con consola limpia.
@@ -43,5 +43,5 @@
 - [ ] PR abierta.
 - [ ] Handoff PR dejado.
 - [x] Franky invocado y responde.
-- [ ] Chopper invocado y responde.
+- [x] Chopper invocado y responde.
 - [ ] Reviewers comentan PR o declaran bloqueo por permisos.

--- a/openspec/control-panel-tailscale-service-verify-checklist.md
+++ b/openspec/control-panel-tailscale-service-verify-checklist.md
@@ -42,6 +42,6 @@
 - [x] `git diff --check`
 - [ ] PR abierta.
 - [ ] Handoff PR dejado.
-- [ ] Franky invocado y responde.
+- [x] Franky invocado y responde.
 - [ ] Chopper invocado y responde.
 - [ ] Reviewers comentan PR o declaran bloqueo por permisos.

--- a/openspec/control-panel-tailscale-service.md
+++ b/openspec/control-panel-tailscale-service.md
@@ -77,5 +77,7 @@ Requiere Franky + Chopper:
 - Smoke web Tailscale `/healthcheck`: HTTP 200, módulos reales renderizados y consola limpia.
 - No-leakage básico API/HTML: `PASS`.
 
+- Franky dejó `approve` operativo con follow-ups documentales menores ya incorporados: rollback exacto, validación de `Linger=yes` y nota de actualización si cambia la IP Tailscale.
+
 ## Incidencia corregida
 El primer arranque de API falló bajo systemd porque el entorno user service resolvía `python3` a `/usr/bin/python3`, sin `uvicorn`. Se corrigió el runner para usar por defecto `/home/agentops/.hermes/hermes-agent/venv/bin/python3`, con override explícito `MUGIWARA_CONTROL_PANEL_PYTHON` si más adelante se crea un venv propio del proyecto.

--- a/openspec/control-panel-tailscale-service.md
+++ b/openspec/control-panel-tailscale-service.md
@@ -1,0 +1,81 @@
+# Control Panel private Tailscale service
+
+## Objetivo
+Dejar `mugiwara-control-panel` siempre levantado como servicios `systemd --user` y accesible por Tailscale fuera de la red local, sin convertirlo en superficie pública de internet.
+
+## Contexto
+PR #95 declaró el control plane operativo privado v1 mediante smoke runtime. Pablo pidió poder usarlo de forma permanente y entrar por Tailscale incluso fuera de la LAN.
+
+Runtime Tailscale detectado:
+- DNS: `delaya-control.tail2ce3eb.ts.net.`
+- IPv4: `100.65.118.27`
+
+## Alcance
+- Añadir servicio user-level para API FastAPI.
+- Añadir servicio user-level para Web Next.js production.
+- Mantener API en loopback (`127.0.0.1:8011`).
+- Exponer solo la web en la IP Tailscale (`100.65.118.27:3017`) o host configurado server-side.
+- Añadir scripts runner explícitos, instalador y guardrail estático.
+- Instalar, arrancar y verificar smoke real por Tailscale.
+
+## Fuera de alcance
+- Exposición `internet-public`.
+- Auth pública, OAuth, sesión o rate limiting nuevos.
+- Reverse proxy, TLS, Funnel, Serve o MagicDNS HTTPS.
+- Nuevas features de UI/backend.
+- Nuevas fuentes Healthcheck o capacidades Git.
+- Cambios en permisos de manifests Healthcheck.
+
+## Decisiones
+1. **API loopback-only**: el backend no se expone directamente por Tailscale. La web server-side consume `http://127.0.0.1:8011`.
+2. **Web Tailscale-only por defecto**: el runner web exige una IP Tailscale salvo override explícito. No cae silenciosamente a `0.0.0.0`.
+3. **Production Next**: el servicio web usa `next start`, no `next dev`; el installer construye `apps/web/.next` antes de arrancar.
+4. **systemd user-level**: evita `User=`/`Group=` y sigue el patrón operativo ya usado por los runners Healthcheck.
+5. **Fail closed**: si Tailscale no está disponible y no hay override, la web falla y systemd reintenta, en vez de abrir en todas las interfaces.
+
+## Definition of Done
+- Units versionadas en `ops/systemd/user/`.
+- Scripts runner e installer versionados en `scripts/`.
+- Guardrail `verify:control-panel-service-runner` pasa.
+- `systemd-analyze --user verify` acepta ambas units.
+- Installer instala, habilita y arranca ambos servicios.
+- `systemctl --user is-active` devuelve `active` para API y web.
+- API responde localmente en `127.0.0.1:8011/api/v1/healthcheck`.
+- Web responde por Tailscale en `http://100.65.118.27:3017/healthcheck`.
+- No-leakage básico en HTML production por Tailscale.
+- Browser smoke por Tailscale sin errores de consola.
+
+## Verify esperado
+- `npm run verify:control-panel-service-runner`
+- `systemd-analyze --user verify ops/systemd/user/mugiwara-control-panel-api.service ops/systemd/user/mugiwara-control-panel-web.service`
+- `scripts/install-control-panel-user-services.sh`
+- `systemctl --user is-active mugiwara-control-panel-api.service mugiwara-control-panel-web.service`
+- `curl -fsS http://127.0.0.1:8011/api/v1/healthcheck`
+- `curl -fsS http://100.65.118.27:3017/healthcheck`
+- no-leakage scan API/HTML
+- browser smoke Tailscale
+- `npm run verify:perimeter-policy`
+- `npm run verify:health-dashboard-server-only`
+- `npm --prefix apps/web run typecheck`
+- `PYTHONPATH=. pytest apps/api/tests -q`
+- `npm --prefix apps/web run build`
+- `git diff --check`
+
+## Review
+Requiere Franky + Chopper:
+- Franky: operabilidad, systemd user, restart policy, Tailscale bind, build/start, rollback.
+- Chopper: perímetro, no exposición pública, no leakage, API loopback-only.
+
+
+## Resultados ejecutados
+- Servicios instalados y habilitados como `systemd --user`.
+- `Linger=yes` confirmado para el usuario operativo.
+- API activa en `127.0.0.1:8011`.
+- Web activa en `100.65.118.27:3017`.
+- URL privada usable: `http://100.65.118.27:3017` y `http://delaya-control.tail2ce3eb.ts.net:3017`.
+- Smoke API `/api/v1/healthcheck`: HTTP 200, `status=ready`, `meta.sanitized=true`.
+- Smoke web Tailscale `/healthcheck`: HTTP 200, módulos reales renderizados y consola limpia.
+- No-leakage básico API/HTML: `PASS`.
+
+## Incidencia corregida
+El primer arranque de API falló bajo systemd porque el entorno user service resolvía `python3` a `/usr/bin/python3`, sin `uvicorn`. Se corrigió el runner para usar por defecto `/home/agentops/.hermes/hermes-agent/venv/bin/python3`, con override explícito `MUGIWARA_CONTROL_PANEL_PYTHON` si más adelante se crea un venv propio del proyecto.

--- a/openspec/control-panel-tailscale-service.md
+++ b/openspec/control-panel-tailscale-service.md
@@ -7,14 +7,14 @@ Dejar `mugiwara-control-panel` siempre levantado como servicios `systemd --user`
 PR #95 declaró el control plane operativo privado v1 mediante smoke runtime. Pablo pidió poder usarlo de forma permanente y entrar por Tailscale incluso fuera de la LAN.
 
 Runtime Tailscale detectado:
-- DNS: `delaya-control.tail2ce3eb.ts.net.`
-- IPv4: `100.65.118.27`
+- DNS: `<magicdns-host>`
+- IPv4: `<tailscale-ip>`
 
 ## Alcance
 - Añadir servicio user-level para API FastAPI.
 - Añadir servicio user-level para Web Next.js production.
 - Mantener API en loopback (`127.0.0.1:8011`).
-- Exponer solo la web en la IP Tailscale (`100.65.118.27:3017`) o host configurado server-side.
+- Exponer solo la web en la IP Tailscale (`<tailscale-ip>:3017`) o host configurado server-side.
 - Añadir scripts runner explícitos, instalador y guardrail estático.
 - Instalar, arrancar y verificar smoke real por Tailscale.
 
@@ -41,7 +41,7 @@ Runtime Tailscale detectado:
 - Installer instala, habilita y arranca ambos servicios.
 - `systemctl --user is-active` devuelve `active` para API y web.
 - API responde localmente en `127.0.0.1:8011/api/v1/healthcheck`.
-- Web responde por Tailscale en `http://100.65.118.27:3017/healthcheck`.
+- Web responde por Tailscale en `http://<tailscale-ip>:3017/healthcheck`.
 - No-leakage básico en HTML production por Tailscale.
 - Browser smoke por Tailscale sin errores de consola.
 
@@ -51,7 +51,7 @@ Runtime Tailscale detectado:
 - `scripts/install-control-panel-user-services.sh`
 - `systemctl --user is-active mugiwara-control-panel-api.service mugiwara-control-panel-web.service`
 - `curl -fsS http://127.0.0.1:8011/api/v1/healthcheck`
-- `curl -fsS http://100.65.118.27:3017/healthcheck`
+- `curl -fsS http://<tailscale-ip>:3017/healthcheck`
 - no-leakage scan API/HTML
 - browser smoke Tailscale
 - `npm run verify:perimeter-policy`
@@ -71,8 +71,8 @@ Requiere Franky + Chopper:
 - Servicios instalados y habilitados como `systemd --user`.
 - `Linger=yes` confirmado para el usuario operativo.
 - API activa en `127.0.0.1:8011`.
-- Web activa en `100.65.118.27:3017`.
-- URL privada usable: `http://100.65.118.27:3017` y `http://delaya-control.tail2ce3eb.ts.net:3017`.
+- Web activa en `<tailscale-ip>:3017`.
+- URL privada usable: `http://<tailscale-ip>:3017` y `http://<magicdns-host>:3017`.
 - Smoke API `/api/v1/healthcheck`: HTTP 200, `status=ready`, `meta.sanitized=true`.
 - Smoke web Tailscale `/healthcheck`: HTTP 200, módulos reales renderizados y consola limpia.
 - No-leakage básico API/HTML: `PASS`.

--- a/ops/systemd/user/mugiwara-control-panel-api.service
+++ b/ops/systemd/user/mugiwara-control-panel-api.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Mugiwara Control Panel private API service
+Documentation=https://github.com/asistentes-mugiwara/mugiwara-control-panel
+
+[Service]
+Type=simple
+WorkingDirectory=/srv/crew-core/projects/mugiwara-control-panel
+ExecStart=/usr/bin/env bash scripts/run-control-panel-api.sh
+Restart=on-failure
+RestartSec=5s
+TimeoutStartSec=30s
+
+# Private v1 contract: API remains loopback-only. The web service is the Tailscale-facing surface.
+Environment=MUGIWARA_CONTROL_PANEL_API_HOST=127.0.0.1
+Environment=MUGIWARA_CONTROL_PANEL_API_PORT=8011
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=full
+ProtectHome=read-only
+
+[Install]
+WantedBy=default.target

--- a/ops/systemd/user/mugiwara-control-panel-web.service
+++ b/ops/systemd/user/mugiwara-control-panel-web.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Mugiwara Control Panel private Tailscale web service
+Documentation=https://github.com/asistentes-mugiwara/mugiwara-control-panel
+Wants=mugiwara-control-panel-api.service
+After=mugiwara-control-panel-api.service
+
+[Service]
+Type=simple
+WorkingDirectory=/srv/crew-core/projects/mugiwara-control-panel
+ExecStart=/usr/bin/env bash scripts/run-control-panel-web.sh
+Restart=on-failure
+RestartSec=5s
+TimeoutStartSec=30s
+
+# Private v1 contract: web binds to Tailscale IPv4 by default and talks to API on loopback.
+Environment=MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011
+Environment=MUGIWARA_CONTROL_PANEL_WEB_PORT=3017
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=full
+ProtectHome=read-only
+
+[Install]
+WantedBy=default.target

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "write:backup-health-status": "python3 scripts/write-backup-health-status.py",
     "verify:system-metrics-backend-policy": "node scripts/check-system-metrics-backend-policy.mjs",
     "verify:system-metrics-server-only": "node scripts/check-system-metrics-server-only.mjs",
-    "verify:git-server-only": "node scripts/check-git-server-only.mjs"
+    "verify:git-server-only": "node scripts/check-git-server-only.mjs",
+    "verify:control-panel-service-runner": "node scripts/check-control-panel-service-runner.mjs"
   },
   "overrides": {
     "postcss": "8.5.10"

--- a/scripts/check-control-panel-service-runner.mjs
+++ b/scripts/check-control-panel-service-runner.mjs
@@ -97,7 +97,8 @@ for (const [text, label] of [[runtimeConfig, 'runtime config docs'], [openspec, 
   mustInclude(text, 'mugiwara-control-panel-api.service', label)
   mustInclude(text, 'mugiwara-control-panel-web.service', label)
   mustInclude(text, '127.0.0.1:8011', label)
-  mustInclude(text, '100.65.118.27:3017', label)
+  mustInclude(text, '<tailscale-ip>:3017', label)
+  mustInclude(text, '<magicdns-host>:3017', label)
   mustInclude(text, 'internet-public', label)
 }
 

--- a/scripts/check-control-panel-service-runner.mjs
+++ b/scripts/check-control-panel-service-runner.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/** Static guardrail for Mugiwara Control Panel private API + Tailscale web services. */
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = process.cwd()
+const paths = {
+  packageJson: join(repoRoot, 'package.json'),
+  apiRunner: join(repoRoot, 'scripts/run-control-panel-api.sh'),
+  webRunner: join(repoRoot, 'scripts/run-control-panel-web.sh'),
+  installer: join(repoRoot, 'scripts/install-control-panel-user-services.sh'),
+  apiService: join(repoRoot, 'ops/systemd/user/mugiwara-control-panel-api.service'),
+  webService: join(repoRoot, 'ops/systemd/user/mugiwara-control-panel-web.service'),
+  runtimeConfig: join(repoRoot, 'docs/runtime-config.md'),
+  openspec: join(repoRoot, 'openspec/control-panel-tailscale-service.md'),
+}
+const failures = []
+function read(pathName, label) {
+  if (!existsSync(pathName)) {
+    failures.push(`missing ${label}: ${pathName}`)
+    return ''
+  }
+  return readFileSync(pathName, 'utf8')
+}
+function mustInclude(text, snippet, label) {
+  if (!text.includes(snippet)) failures.push(`${label} must include: ${snippet}`)
+}
+function mustNotInclude(text, pattern, label, description) {
+  if (pattern.test(text)) failures.push(`${label} must not include ${description}`)
+}
+function stripComments(text) {
+  return text.split('\n').filter((line) => !line.trimStart().startsWith('#')).join('\n')
+}
+function stripHelp(text) {
+  const lines = []
+  let inHelp = false
+  for (const line of text.split('\n')) {
+    if (line.includes("<<'USAGE'")) { inHelp = true; continue }
+    if (inHelp) { if (line.trim() === 'USAGE') inHelp = false; continue }
+    if (!line.trimStart().startsWith('#')) lines.push(line)
+  }
+  return lines.join('\n')
+}
+
+const packageJsonText = read(paths.packageJson, 'package.json')
+const apiRunner = read(paths.apiRunner, 'API runner')
+const webRunner = read(paths.webRunner, 'web runner')
+const installer = read(paths.installer, 'installer')
+const apiService = read(paths.apiService, 'API service')
+const webService = read(paths.webService, 'web service')
+const runtimeConfig = read(paths.runtimeConfig, 'runtime config docs')
+const openspec = read(paths.openspec, 'OpenSpec')
+
+let packageJson
+try { packageJson = JSON.parse(packageJsonText) } catch { failures.push('package.json must be valid JSON') }
+if (packageJson?.scripts?.['verify:control-panel-service-runner'] !== 'node scripts/check-control-panel-service-runner.mjs') {
+  failures.push('package.json must expose verify:control-panel-service-runner')
+}
+
+mustInclude(apiRunner, 'api_host="${MUGIWARA_CONTROL_PANEL_API_HOST:-127.0.0.1}"', 'API runner')
+mustInclude(apiRunner, 'if [[ "$api_host" != "127.0.0.1" ]]', 'API runner')
+mustInclude(apiRunner, 'python_bin="${MUGIWARA_CONTROL_PANEL_PYTHON:-/home/agentops/.hermes/hermes-agent/venv/bin/python3}"', 'API runner')
+mustInclude(apiRunner, '"$python_bin" -m uvicorn apps.api.src.main:app --host "$api_host" --port "$api_port"', 'API runner')
+mustNotInclude(stripHelp(apiRunner), /0\.0\.0\.0|tailscale|NEXT_PUBLIC|--reload/, 'API runner', 'public bind, tailscale dependency, browser env or reload mode')
+
+mustInclude(webRunner, 'api_url="${MUGIWARA_CONTROL_PANEL_API_URL:-http://127.0.0.1:8011}"', 'web runner')
+mustInclude(webRunner, 'tailscale ip -4', 'web runner')
+mustInclude(webRunner, 'Refusing wildcard bind', 'web runner')
+mustInclude(webRunner, 'apps/web/.next/BUILD_ID', 'web runner')
+mustInclude(webRunner, 'npm --prefix apps/web run start -- --hostname "$web_host" --port "$web_port"', 'web runner')
+mustNotInclude(stripHelp(webRunner), /--hostname\s+0\.0\.0\.0|NEXT_PUBLIC|tailscale\s+(funnel|serve)|--reload/i, 'web runner', 'wildcard bind, browser env, Tailscale Funnel/Serve or dev reload')
+
+mustInclude(apiService, 'ExecStart=/usr/bin/env bash scripts/run-control-panel-api.sh', 'API service')
+mustInclude(apiService, 'Environment=MUGIWARA_CONTROL_PANEL_API_HOST=127.0.0.1', 'API service')
+mustInclude(apiService, 'Environment=MUGIWARA_CONTROL_PANEL_API_PORT=8011', 'API service')
+mustInclude(apiService, 'Restart=on-failure', 'API service')
+mustInclude(apiService, 'NoNewPrivileges=yes', 'API service')
+mustInclude(apiService, 'WantedBy=default.target', 'API service')
+mustNotInclude(stripComments(apiService), /User=|Group=|0\.0\.0\.0|NEXT_PUBLIC|funnel|serve/i, 'API service', 'system user/group, public bind or public exposure')
+
+mustInclude(webService, 'Wants=mugiwara-control-panel-api.service', 'web service')
+mustInclude(webService, 'After=mugiwara-control-panel-api.service', 'web service')
+mustInclude(webService, 'ExecStart=/usr/bin/env bash scripts/run-control-panel-web.sh', 'web service')
+mustInclude(webService, 'Environment=MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011', 'web service')
+mustInclude(webService, 'Environment=MUGIWARA_CONTROL_PANEL_WEB_PORT=3017', 'web service')
+mustInclude(webService, 'Restart=on-failure', 'web service')
+mustInclude(webService, 'WantedBy=default.target', 'web service')
+mustNotInclude(stripComments(webService), /User=|Group=|0\.0\.0\.0|NEXT_PUBLIC|funnel|serve/i, 'web service', 'system user/group, wildcard bind or public exposure')
+
+mustInclude(installer, 'npm --prefix apps/web run build', 'installer')
+mustInclude(installer, 'tailscale ip -4', 'installer')
+mustInclude(installer, 'systemctl --user enable --now "$api_service"', 'installer')
+mustInclude(installer, 'systemctl --user enable --now "$web_service"', 'installer')
+mustNotInclude(stripHelp(installer), /0\.0\.0\.0|funnel|serve|NEXT_PUBLIC|--host\s+0/i, 'installer', 'public exposure or browser env')
+
+for (const [text, label] of [[runtimeConfig, 'runtime config docs'], [openspec, 'OpenSpec']]) {
+  mustInclude(text, 'mugiwara-control-panel-api.service', label)
+  mustInclude(text, 'mugiwara-control-panel-web.service', label)
+  mustInclude(text, '127.0.0.1:8011', label)
+  mustInclude(text, '100.65.118.27:3017', label)
+  mustInclude(text, 'internet-public', label)
+}
+
+if (failures.length > 0) {
+  console.error('Control Panel service runner check failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+console.log('Control Panel service runner check passed')

--- a/scripts/install-control-panel-user-services.sh
+++ b/scripts/install-control-panel-user-services.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Install and enable Mugiwara Control Panel private API + Tailscale web user services.
+set -euo pipefail
+
+repo_root="/srv/crew-core/projects/mugiwara-control-panel"
+unit_source_dir="$repo_root/ops/systemd/user"
+unit_target_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+api_service="mugiwara-control-panel-api.service"
+web_service="mugiwara-control-panel-web.service"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  cat <<'USAGE'
+Install and enable the Mugiwara Control Panel private user services.
+
+Usage:
+  scripts/install-control-panel-user-services.sh
+
+Contract:
+  - installs user units under ~/.config/systemd/user
+  - builds the Next.js production app before starting web
+  - enables and starts mugiwara-control-panel-api.service
+  - enables and starts mugiwara-control-panel-web.service
+  - API binds only to 127.0.0.1:8011
+  - Web binds to the current Tailscale IPv4 on port 3017 by default
+  - Web uses MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011 server-side
+  - does not use wildcard bind, Tailscale Funnel, public internet exposure or alternate backend URL
+USAGE
+  exit 0
+fi
+
+for unit in "$api_service" "$web_service"; do
+  if [[ ! -f "$unit_source_dir/$unit" ]]; then
+    echo "missing unit source: $unit_source_dir/$unit" >&2
+    exit 1
+  fi
+done
+
+if ! command -v tailscale >/dev/null 2>&1; then
+  echo "tailscale command not found; refusing private Tailscale service install" >&2
+  exit 1
+fi
+
+tailscale_ip="$(tailscale ip -4 2>/dev/null | head -n 1 || true)"
+if [[ -z "$tailscale_ip" ]]; then
+  echo "no Tailscale IPv4 available; refusing install" >&2
+  exit 1
+fi
+
+cd "$repo_root"
+npm --prefix apps/web run build
+
+install -d -m 0750 "$unit_target_dir"
+install -m 0644 "$unit_source_dir/$api_service" "$unit_target_dir/$api_service"
+install -m 0644 "$unit_source_dir/$web_service" "$unit_target_dir/$web_service"
+
+systemctl --user daemon-reload
+systemctl --user enable --now "$api_service"
+systemctl --user enable --now "$web_service"
+systemctl --user --no-pager --full status "$api_service" "$web_service" || true
+printf 'Control Panel private URL: http://%s:3017
+' "$tailscale_ip"

--- a/scripts/run-control-panel-api.sh
+++ b/scripts/run-control-panel-api.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Run the private Mugiwara Control Panel FastAPI backend for user-level systemd.
+set -euo pipefail
+
+repo_root="/srv/crew-core/projects/mugiwara-control-panel"
+api_host="${MUGIWARA_CONTROL_PANEL_API_HOST:-127.0.0.1}"
+api_port="${MUGIWARA_CONTROL_PANEL_API_PORT:-8011}"
+python_bin="${MUGIWARA_CONTROL_PANEL_PYTHON:-/home/agentops/.hermes/hermes-agent/venv/bin/python3}"
+
+if [[ "$api_host" != "127.0.0.1" ]]; then
+  echo "Refusing to expose Control Panel API outside loopback: $api_host" >&2
+  exit 64
+fi
+
+cd "$repo_root"
+exec /usr/bin/env PYTHONPATH=. "$python_bin" -m uvicorn apps.api.src.main:app --host "$api_host" --port "$api_port"

--- a/scripts/run-control-panel-web.sh
+++ b/scripts/run-control-panel-web.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Run the private Mugiwara Control Panel Next.js frontend for user-level systemd.
+set -euo pipefail
+
+repo_root="/srv/crew-core/projects/mugiwara-control-panel"
+web_port="${MUGIWARA_CONTROL_PANEL_WEB_PORT:-3017}"
+api_url="${MUGIWARA_CONTROL_PANEL_API_URL:-http://127.0.0.1:8011}"
+web_host="${MUGIWARA_CONTROL_PANEL_WEB_HOST:-}"
+
+if [[ "$api_url" != "http://127.0.0.1:8011" ]]; then
+  echo "Refusing unexpected backend URL for private service: $api_url" >&2
+  exit 64
+fi
+
+if [[ -z "$web_host" ]]; then
+  if command -v tailscale >/dev/null 2>&1; then
+    web_host="$(tailscale ip -4 2>/dev/null | head -n 1 || true)"
+  fi
+fi
+
+if [[ -z "$web_host" ]]; then
+  if [[ "${MUGIWARA_CONTROL_PANEL_ALLOW_LOCALHOST_FALLBACK:-}" == "1" ]]; then
+    web_host="127.0.0.1"
+  else
+    echo "No Tailscale IPv4 detected. Refusing to start web service without private Tailscale bind." >&2
+    exit 75
+  fi
+fi
+
+if [[ "$web_host" == "0.0.0.0" || "$web_host" == "::" ]]; then
+  echo "Refusing wildcard bind for private Control Panel web service: $web_host" >&2
+  exit 64
+fi
+
+cd "$repo_root"
+if [[ ! -f apps/web/.next/BUILD_ID ]]; then
+  echo "Missing Next production build. Run npm --prefix apps/web run build or installer first." >&2
+  exit 78
+fi
+
+export MUGIWARA_CONTROL_PANEL_API_URL="$api_url"
+exec /usr/bin/env npm --prefix apps/web run start -- --hostname "$web_host" --port "$web_port"


### PR DESCRIPTION
## Objetivo
Dejar `mugiwara-control-panel` siempre levantado como servicios `systemd --user` y accesible por Tailscale fuera de la red local.

## Qué cambia
- Añade `mugiwara-control-panel-api.service`: FastAPI loopback-only `127.0.0.1:8011`.
- Añade `mugiwara-control-panel-web.service`: Next.js production por Tailscale `100.65.118.27:3017`.
- Añade runners explícitos:
  - `scripts/run-control-panel-api.sh`
  - `scripts/run-control-panel-web.sh`
- Añade installer:
  - `scripts/install-control-panel-user-services.sh`
- Añade guardrail:
  - `npm run verify:control-panel-service-runner`
- Actualiza `docs/runtime-config.md`, OpenSpec y `.engram`.

## Frontera de seguridad
- API no se expone por Tailscale ni LAN; solo loopback.
- Web rechaza wildcard bind y detecta IPv4 Tailscale.
- No usa Tailscale Funnel/Serve.
- No abre internet-public.
- No añade auth pública, features, fuentes Healthcheck ni capacidades Git.

## Verify ejecutado
- `npm run verify:control-panel-service-runner`
- `npm run verify:perimeter-policy`
- `npm run verify:health-dashboard-server-only`
- `npm --prefix apps/web run typecheck`
- `PYTHONPATH=. pytest apps/api/tests -q` (`129 passed`)
- `npm --prefix apps/web run build`
- `systemd-analyze --user verify ops/systemd/user/mugiwara-control-panel-api.service ops/systemd/user/mugiwara-control-panel-web.service`
- `scripts/install-control-panel-user-services.sh`
- `systemctl --user is-active mugiwara-control-panel-api.service mugiwara-control-panel-web.service`
- `ss -ltnp` confirma:
  - API `127.0.0.1:8011`
  - Web `100.65.118.27:3017`
- Smoke API `http://127.0.0.1:8011/api/v1/healthcheck`: 200, `meta.sanitized=true`
- Smoke web `http://100.65.118.27:3017/healthcheck`: 200, módulos reales, no-leakage básico PASS
- Browser smoke por Tailscale con consola limpia
- `loginctl show-user $USER -p Linger`: `Linger=yes`
- `git diff --check`

## URL privada resultante
- `http://100.65.118.27:3017`
- `http://delaya-control.tail2ce3eb.ts.net:3017`
