### PR TITLE
feat: add mugiwara skills selector

### DIFF
--- a/.engram/phase-19-1-skills-mugiwara-selector-closeout.md
+++ b/.engram/phase-19-1-skills-mugiwara-selector-closeout.md
@@ -1,0 +1,24 @@
+# Phase 19.1 closeout — Skills globales + selector Mugiwara
+
+## Contexto
+Pablo detectó que la página `/skills` parecía fija en Zoro y que desde `/mugiwaras` cualquier enlace `Ver Skills` acababa mostrando de nuevo la selección de Zoro. El comportamiento correcto es seleccionar Mugiwara y ver skills globales + skills propias del seleccionado.
+
+## Implementado
+- Backend Skills sustituye el catálogo mínimo hardcoded por descubrimiento allowlisted bajo `/srv/crew-core/skills-source`.
+- Las entradas de catálogo incluyen `owner_slug` y `owner_label` para distinguir globales, agente y runtime.
+- `skill_id` queda namespaceado (`global-*`, `agent-<slug>-*`, `runtime-*`) para evitar colisiones entre skills con el mismo nombre en varios agentes.
+- `/mugiwaras` enlaza ahora a `/skills?mugiwara=<slug>`.
+- `/skills` añade selector de Mugiwara y filtra catálogo visible como `global + seleccionado`.
+
+## Verify ejecutado
+- `PYTHONPATH=. pytest apps/api/tests/test_skills_api.py apps/api/tests/test_mugiwaras_api.py -q`
+- `python -m py_compile apps/api/src/modules/skills/domain.py apps/api/src/modules/skills/service.py apps/api/src/modules/mugiwaras/service.py`
+- `npm run verify:skills-server-only`
+- `npm --prefix apps/web run typecheck`
+- `npm --prefix apps/web run build`
+- Browser smoke local en `/skills?mugiwara=franky`, `/skills?mugiwara=chopper` y `/mugiwaras`.
+
+## Riesgos y límites
+- Se amplía el catálogo editable a todos los `SKILL.md` bajo `skills-source/global` y `skills-source/agents/<mugiwara>` allowlisteados por slug. Sigue sin aceptar paths cliente ni escritura fuera del árbol permitido.
+- La edición sigue siendo controlada por fingerprint/actor/auditoría, pero no hay auth por usuario todavía.
+- Runtime skills fuera de `skills-source` se mantienen como referencia read-only.

--- a/apps/api/src/modules/mugiwaras/service.py
+++ b/apps/api/src/modules/mugiwaras/service.py
@@ -11,17 +11,21 @@ MAX_CREW_RULES_BYTES = 200_000
 DEFAULT_CREW_RULES_PATH = Path('/srv/crew-core/AGENTS.md')
 CANONICAL_CREW_RULES_DISPLAY_PATH = '/srv/crew-core/AGENTS.md'
 
+def _crew_links(slug: str) -> list[SafeLink]:
+    return [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', f'/skills?mugiwara={slug}')]
+
+
 CREW_CARDS: tuple[MugiwaraCard, ...] = (
-    MugiwaraCard('luffy', 'Luffy', 'operativo', ['delegation-contract', 'crew-orchestration'], 'Capitán operativo', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
-    MugiwaraCard('zoro', 'Zoro', 'operativo', ['sdd-orchestrator-zoro', 'zoro-pr-review-handoff'], 'Continuidad fuerte', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
-    MugiwaraCard('franky', 'Franky', 'operativo', ['franky-pr-ops-review', 'vault-sync-ops'], 'Runtime vigilado', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
-    MugiwaraCard('chopper', 'Chopper', 'operativo', ['chopper-pr-security-review', 'security-hardening'], 'Riesgo controlado', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
-    MugiwaraCard('usopp', 'Usopp', 'revision', ['usopp-pr-design-review', 'frontend-spec-usopp'], 'Diseño activo', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
-    MugiwaraCard('nami', 'Nami', 'operativo', ['finance-ops', 'google-sheets-control'], 'Señales estables', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
-    MugiwaraCard('robin', 'Robin', 'operativo', ['research-synthesis', 'vault-canon'], 'Canon consultable', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
-    MugiwaraCard('brook', 'Brook', 'revision', ['data-analysis', 'analytics-standby'], 'Datos en standby', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
-    MugiwaraCard('jinbe', 'Jinbe', 'sin-datos', ['legal-context'], 'Definido en canon', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
-    MugiwaraCard('sanji', 'Sanji', 'sin-datos', ['physical-ops'], 'Definido en canon', [SafeLink('Ver Memory', '/memory'), SafeLink('Ver Skills', '/skills')]),
+    MugiwaraCard('luffy', 'Luffy', 'operativo', ['delegation-contract', 'crew-orchestration'], 'Capitán operativo', _crew_links('luffy')),
+    MugiwaraCard('zoro', 'Zoro', 'operativo', ['sdd-orchestrator-zoro', 'zoro-pr-review-handoff'], 'Continuidad fuerte', _crew_links('zoro')),
+    MugiwaraCard('franky', 'Franky', 'operativo', ['franky-pr-ops-review', 'vault-sync-ops'], 'Runtime vigilado', _crew_links('franky')),
+    MugiwaraCard('chopper', 'Chopper', 'operativo', ['chopper-pr-security-review', 'security-hardening'], 'Riesgo controlado', _crew_links('chopper')),
+    MugiwaraCard('usopp', 'Usopp', 'revision', ['usopp-pr-design-review', 'frontend-spec-usopp'], 'Diseño activo', _crew_links('usopp')),
+    MugiwaraCard('nami', 'Nami', 'operativo', ['finance-ops', 'google-sheets-control'], 'Señales estables', _crew_links('nami')),
+    MugiwaraCard('robin', 'Robin', 'operativo', ['research-synthesis', 'vault-canon'], 'Canon consultable', _crew_links('robin')),
+    MugiwaraCard('brook', 'Brook', 'revision', ['data-analysis', 'analytics-standby'], 'Datos en standby', _crew_links('brook')),
+    MugiwaraCard('jinbe', 'Jinbe', 'sin-datos', ['legal-context'], 'Definido en canon', _crew_links('jinbe')),
+    MugiwaraCard('sanji', 'Sanji', 'sin-datos', ['physical-ops'], 'Definido en canon', _crew_links('sanji')),
 )
 
 PROFILE_META: dict[str, dict[str, str]] = {

--- a/apps/api/src/modules/skills/domain.py
+++ b/apps/api/src/modules/skills/domain.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Literal
 
 SkillOwnerScope = Literal['agent', 'shared', 'runtime']
+SkillOwnerSlug = Literal['global', 'runtime', 'luffy', 'zoro', 'franky', 'chopper', 'usopp', 'nami', 'robin', 'brook', 'jinbe', 'sanji']
 PublicRepoRisk = Literal['low', 'medium', 'high']
 OperationResult = Literal['success', 'rejected', 'failed']
 
@@ -14,6 +15,8 @@ class SkillRegistryEntry:
     skill_id: str
     display_name: str
     owner_scope: SkillOwnerScope
+    owner_slug: str
+    owner_label: str
     public_repo_risk: PublicRepoRisk
     repo_path: str
     path: Path
@@ -31,6 +34,8 @@ class SkillCatalogItem:
     skill_id: str
     display_name: str
     owner_scope: SkillOwnerScope
+    owner_slug: str
+    owner_label: str
     public_repo_risk: PublicRepoRisk
     editable: bool
     repo_path: str
@@ -41,6 +46,8 @@ class SkillDetail:
     skill_id: str
     display_name: str
     owner_scope: SkillOwnerScope
+    owner_slug: str
+    owner_label: str
     public_repo_risk: PublicRepoRisk
     editable: bool
     repo_path: str

--- a/apps/api/src/modules/skills/service.py
+++ b/apps/api/src/modules/skills/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from dataclasses import asdict
 from datetime import datetime, timezone
 from difflib import unified_diff
@@ -22,36 +23,125 @@ from .domain import (
 MAX_SKILL_BYTES = 200_000
 DEFAULT_ALLOWED_ROOT = Path('/srv/crew-core/skills-source').resolve()
 DEFAULT_AUDIT_PATH = Path('/srv/crew-core/projects/mugiwara-control-panel/runtime/skills-audit.jsonl')
+SKILL_ID_PATTERN = re.compile(r'^[a-z0-9][a-z0-9_-]{0,139}$')
 
-DEFAULT_SKILL_ALLOWLIST: tuple[SkillRegistryEntry, ...] = (
+MUGIWARA_LABELS: dict[str, str] = {
+    'luffy': 'Luffy',
+    'zoro': 'Zoro',
+    'franky': 'Franky',
+    'chopper': 'Chopper',
+    'usopp': 'Usopp',
+    'nami': 'Nami',
+    'robin': 'Robin',
+    'brook': 'Brook',
+    'jinbe': 'Jinbe',
+    'sanji': 'Sanji',
+}
+
+DEFAULT_RUNTIME_SKILLS: tuple[SkillRegistryEntry, ...] = (
     SkillRegistryEntry(
-        skill_id='zoro-opencode-operator',
-        display_name='OpenCode operator',
-        owner_scope='agent',
-        public_repo_risk='medium',
-        repo_path='/srv/crew-core/skills-source/agents/zoro/zoro-opencode-operator/SKILL.md',
-        path=Path('/srv/crew-core/skills-source/agents/zoro/zoro-opencode-operator/SKILL.md'),
-        editable=True,
-    ),
-    SkillRegistryEntry(
-        skill_id='mugiwara-git-identity',
-        display_name='Git identity governance',
-        owner_scope='shared',
-        public_repo_risk='high',
-        repo_path='/srv/crew-core/skills-source/global/mugiwara-git-identity/SKILL.md',
-        path=Path('/srv/crew-core/skills-source/global/mugiwara-git-identity/SKILL.md'),
-        editable=True,
-    ),
-    SkillRegistryEntry(
-        skill_id='judgment-day',
+        skill_id='runtime-judgment-day',
         display_name='Judgment Day',
         owner_scope='runtime',
+        owner_slug='runtime',
+        owner_label='Runtime OpenCode',
         public_repo_risk='high',
         repo_path='~/.config/opencode/skills/judgment-day/SKILL.md',
         path=Path('~/.config/opencode/skills/judgment-day/SKILL.md').expanduser(),
         editable=False,
     ),
 )
+
+
+def _read_skill_frontmatter(path: Path) -> dict[str, str]:
+    try:
+        content = path.read_text(encoding='utf-8', errors='replace')
+    except OSError:
+        return {}
+
+    lines = content.splitlines()
+    if not lines or lines[0].strip() != '---':
+        return {}
+
+    metadata: dict[str, str] = {}
+    for line in lines[1:80]:
+        if line.strip() == '---':
+            break
+        if ':' not in line:
+            continue
+        key, value = line.split(':', 1)
+        key = key.strip().lower()
+        value = value.strip().strip('"\'')
+        if key in {'name', 'description'} and value:
+            metadata[key] = value
+    return metadata
+
+
+def _normalize_skill_slug(value: str) -> str:
+    normalized = re.sub(r'[^a-z0-9_-]+', '-', value.lower()).strip('-_')
+    normalized = re.sub(r'-{2,}', '-', normalized)
+    return normalized[:80] or 'skill'
+
+
+def _display_name_from_path(path: Path) -> str:
+    metadata = _read_skill_frontmatter(path)
+    return metadata.get('name') or path.parent.name.replace('-', ' ').replace('_', ' ').title()
+
+
+def _public_repo_risk_for_skill(path: Path, *, owner_scope: str) -> str:
+    text = f'{path.parent.name} {path}'.lower()
+    if any(token in text for token in ('auth', 'secret', 'security', 'backup', 'github', 'legal', 'mcp', 'ops', 'runtime')):
+        return 'high'
+    if owner_scope in {'shared', 'runtime'}:
+        return 'medium'
+    return 'low'
+
+
+def build_default_skill_registry(allowed_root: Path = DEFAULT_ALLOWED_ROOT) -> tuple[SkillRegistryEntry, ...]:
+    root = allowed_root.resolve()
+    entries: list[SkillRegistryEntry] = []
+
+    global_root = root / 'global'
+    for path in sorted(global_root.glob('*/SKILL.md')):
+        slug = _normalize_skill_slug(path.parent.name)
+        entries.append(
+            SkillRegistryEntry(
+                skill_id=f'global-{slug}',
+                display_name=_display_name_from_path(path),
+                owner_scope='shared',
+                owner_slug='global',
+                owner_label='Skills globales',
+                public_repo_risk=_public_repo_risk_for_skill(path, owner_scope='shared'),
+                repo_path=str(path),
+                path=path,
+                editable=True,
+            )
+        )
+
+    agents_root = root / 'agents'
+    agent_dirs = sorted((p for p in agents_root.iterdir() if p.is_dir()), key=lambda item: item.name) if agents_root.exists() else []
+    for agent_dir in agent_dirs:
+        owner_slug = _normalize_skill_slug(agent_dir.name)
+        if owner_slug not in MUGIWARA_LABELS:
+            continue
+        for path in sorted(agent_dir.glob('*/SKILL.md')):
+            skill_slug = _normalize_skill_slug(path.parent.name)
+            entries.append(
+                SkillRegistryEntry(
+                    skill_id=f'agent-{owner_slug}-{skill_slug}',
+                    display_name=_display_name_from_path(path),
+                    owner_scope='agent',
+                    owner_slug=owner_slug,
+                    owner_label=MUGIWARA_LABELS[owner_slug],
+                    public_repo_risk=_public_repo_risk_for_skill(path, owner_scope='agent'),
+                    repo_path=str(path),
+                    path=path,
+                    editable=True,
+                )
+            )
+
+    entries.extend(DEFAULT_RUNTIME_SKILLS)
+    return tuple(entries)
 
 
 class SkillService:
@@ -62,8 +152,8 @@ class SkillService:
         allowed_root: Path = DEFAULT_ALLOWED_ROOT,
         audit_log_path: Path = DEFAULT_AUDIT_PATH,
     ) -> None:
-        self._registry = {entry.skill_id: entry for entry in (registry or DEFAULT_SKILL_ALLOWLIST)}
         self._allowed_root = allowed_root.resolve()
+        self._registry = {entry.skill_id: entry for entry in (registry or build_default_skill_registry(self._allowed_root))}
         self._audit_log_path = audit_log_path
 
     def list_catalog(self) -> list[SkillCatalogItem]:
@@ -72,6 +162,8 @@ class SkillService:
                 skill_id=entry.skill_id,
                 display_name=entry.display_name,
                 owner_scope=entry.owner_scope,
+                owner_slug=entry.owner_slug,
+                owner_label=entry.owner_label,
                 public_repo_risk=entry.public_repo_risk,
                 editable=entry.editable,
                 repo_path=entry.repo_path,
@@ -87,6 +179,8 @@ class SkillService:
             skill_id=entry.skill_id,
             display_name=entry.display_name,
             owner_scope=entry.owner_scope,
+            owner_slug=entry.owner_slug,
+            owner_label=entry.owner_label,
             public_repo_risk=entry.public_repo_risk,
             editable=entry.editable,
             repo_path=entry.repo_path,
@@ -153,6 +247,8 @@ class SkillService:
             skill_id=entry.skill_id,
             display_name=entry.display_name,
             owner_scope=entry.owner_scope,
+            owner_slug=entry.owner_slug,
+            owner_label=entry.owner_label,
             public_repo_risk=entry.public_repo_risk,
             editable=entry.editable,
             repo_path=entry.repo_path,
@@ -178,6 +274,8 @@ class SkillService:
         return [json.loads(line) for line in reversed(lines) if line.strip()]
 
     def _get_entry(self, skill_id: str) -> SkillRegistryEntry:
+        if not SKILL_ID_PATTERN.fullmatch(skill_id):
+            raise self._reject(status.HTTP_404_NOT_FOUND, 'not_found', 'Skill no configurada en allowlist.')
         entry = self._registry.get(skill_id)
         if entry is None:
             raise self._reject(status.HTTP_404_NOT_FOUND, 'not_found', 'Skill no configurada en allowlist.')
@@ -187,9 +285,15 @@ class SkillService:
         return entry
 
     def _validate_entry_path(self, entry: SkillRegistryEntry) -> None:
-        resolved = entry.path.expanduser().resolve()
-        if resolved.is_symlink():
+        expanded = entry.path.expanduser()
+        if expanded.is_symlink():
             raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'source_unavailable', 'Symlink no permitido en la allowlist.')
+        resolved = expanded.resolve()
+        for parent in expanded.parents:
+            if parent == parent.parent:
+                continue
+            if parent.is_symlink():
+                raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'source_unavailable', 'Symlink no permitido en la allowlist.')
         if entry.editable and self._allowed_root not in resolved.parents:
             raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'not_configured', 'La skill editable sale del árbol permitido.')
         if resolved.name != 'SKILL.md':

--- a/apps/api/tests/test_mugiwaras_api.py
+++ b/apps/api/tests/test_mugiwaras_api.py
@@ -30,6 +30,9 @@ def test_mugiwaras_catalog_returns_safe_cards_and_canonical_agents_document(tmp_
     assert payload['meta']['count'] >= 4
     assert payload['meta']['crew_rules_document'] == '/srv/crew-core/AGENTS.md'
     assert {item['slug'] for item in payload['data']['items']} >= {'luffy', 'zoro', 'usopp', 'chopper'}
+    cards_by_slug = {item['slug']: item for item in payload['data']['items']}
+    assert {'label': 'Ver Skills', 'href': '/skills?mugiwara=franky'} in cards_by_slug['franky']['links']
+    assert {'label': 'Ver Skills', 'href': '/skills?mugiwara=zoro'} in cards_by_slug['zoro']['links']
     assert payload['data']['crew_rules_document'] == {
         'document_id': 'crew-core-agents',
         'title': 'AGENTS.md — reglas operativas Mugiwara',

--- a/apps/api/tests/test_skills_api.py
+++ b/apps/api/tests/test_skills_api.py
@@ -36,18 +36,22 @@ description: runtime
     service = SkillService(
         registry=(
             SkillRegistryEntry(
-                skill_id='demo-skill',
+                skill_id='agent-zoro-demo-skill',
                 display_name='Demo skill',
                 owner_scope='agent',
+                owner_slug='zoro',
+                owner_label='Zoro',
                 public_repo_risk='low',
                 repo_path=str(skill_path),
                 path=skill_path,
                 editable=True,
             ),
             SkillRegistryEntry(
-                skill_id='judgment-day',
+                skill_id='runtime-judgment-day',
                 display_name='Judgment Day',
                 owner_scope='runtime',
+                owner_slug='runtime',
+                owner_label='Runtime OpenCode',
                 public_repo_risk='high',
                 repo_path=str(runtime_skill_path),
                 path=runtime_skill_path,
@@ -70,7 +74,90 @@ def test_catalog_lists_editable_and_read_only_entries(tmp_path: Path) -> None:
     payload = response.json()
     assert payload['resource'] == 'skills.catalog'
     assert payload['meta']['editable_count'] == 1
-    assert {item['skill_id'] for item in payload['data']['items']} == {'demo-skill', 'judgment-day'}
+    assert {item['skill_id'] for item in payload['data']['items']} == {'agent-zoro-demo-skill', 'runtime-judgment-day'}
+
+    app.dependency_overrides.clear()
+
+
+def test_default_registry_discovers_global_and_agent_skills(tmp_path: Path) -> None:
+    allowed_root = tmp_path / 'skills-source'
+    global_skill = allowed_root / 'global' / 'mugiwara-git-identity' / 'SKILL.md'
+    franky_skill = allowed_root / 'agents' / 'franky' / 'vault-sync-ops' / 'SKILL.md'
+    ignored_skill = allowed_root / 'agents' / 'unknown-agent' / 'private-scratch' / 'SKILL.md'
+    for skill_path in (global_skill, franky_skill, ignored_skill):
+        skill_path.parent.mkdir(parents=True)
+        skill_path.write_text(f"""---
+name: {skill_path.parent.name}
+description: demo
+---
+""", encoding='utf-8')
+
+    service = SkillService(allowed_root=allowed_root, audit_log_path=tmp_path / 'runtime' / 'skills-audit.jsonl')
+    catalog = service.list_catalog()
+    by_id = {item.skill_id: item for item in catalog}
+
+    assert by_id['global-mugiwara-git-identity'].owner_scope == 'shared'
+    assert by_id['global-mugiwara-git-identity'].owner_slug == 'global'
+    assert by_id['agent-franky-vault-sync-ops'].owner_scope == 'agent'
+    assert by_id['agent-franky-vault-sync-ops'].owner_slug == 'franky'
+    assert 'agent-unknown-agent-private-scratch' not in by_id
+
+
+def test_rejects_path_like_or_invalid_skill_ids(tmp_path: Path) -> None:
+    service, _ = build_service(tmp_path)
+    app.dependency_overrides[get_skill_service] = lambda: service
+    client = TestClient(app)
+
+    for skill_id in ('..%2fsecret', 'agent-zoro-demo skill', 'a' * 142):
+        response = client.get(f'/api/v1/skills/{skill_id}')
+        assert response.status_code == 404
+        detail = response.json()['detail']
+        if isinstance(detail, dict):
+            assert detail['code'] == 'not_found'
+
+    app.dependency_overrides.clear()
+
+
+def test_rejects_allowlisted_skill_symlink(tmp_path: Path) -> None:
+    allowed_root = tmp_path / 'skills-source'
+    target_dir = allowed_root / 'agents' / 'zoro' / 'target-skill'
+    target_dir.mkdir(parents=True)
+    target = target_dir / 'SKILL.md'
+    target.write_text("""---
+name: target-skill
+description: demo
+---
+""", encoding='utf-8')
+
+    symlink_dir = allowed_root / 'agents' / 'zoro' / 'symlink-skill'
+    symlink_dir.mkdir(parents=True)
+    symlink_path = symlink_dir / 'SKILL.md'
+    symlink_path.symlink_to(target)
+
+    service = SkillService(
+        registry=(
+            SkillRegistryEntry(
+                skill_id='agent-zoro-symlink-skill',
+                display_name='Symlink skill',
+                owner_scope='agent',
+                owner_slug='zoro',
+                owner_label='Zoro',
+                public_repo_risk='low',
+                repo_path=str(symlink_path),
+                path=symlink_path,
+                editable=True,
+            ),
+        ),
+        allowed_root=allowed_root,
+        audit_log_path=tmp_path / 'runtime' / 'skills-audit.jsonl',
+    )
+    app.dependency_overrides[get_skill_service] = lambda: service
+    client = TestClient(app)
+
+    response = client.get('/api/v1/skills/agent-zoro-symlink-skill')
+    assert response.status_code == 503
+    assert response.json()['detail']['code'] == 'source_unavailable'
+    assert str(target) not in response.text
 
     app.dependency_overrides.clear()
 
@@ -80,7 +167,7 @@ def test_detail_returns_fingerprint(tmp_path: Path) -> None:
     app.dependency_overrides[get_skill_service] = lambda: service
     client = TestClient(app)
 
-    response = client.get('/api/v1/skills/demo-skill')
+    response = client.get('/api/v1/skills/agent-zoro-demo-skill')
     assert response.status_code == 200
     payload = response.json()
     assert payload['data']['repo_path'] == str(skill_path)
@@ -94,7 +181,7 @@ def test_preview_and_update_skill_with_audit(tmp_path: Path) -> None:
     app.dependency_overrides[get_skill_service] = lambda: service
     client = TestClient(app)
 
-    detail = client.get('/api/v1/skills/demo-skill').json()['data']
+    detail = client.get('/api/v1/skills/agent-zoro-demo-skill').json()['data']
     current_sha = detail['fingerprint']['sha256']
     updated_content = detail['content'] + """
 ## Updated
@@ -102,14 +189,14 @@ def test_preview_and_update_skill_with_audit(tmp_path: Path) -> None:
 """
 
     preview = client.post(
-        '/api/v1/skills/demo-skill/preview',
+        '/api/v1/skills/agent-zoro-demo-skill/preview',
         json={'content': updated_content, 'expected_sha256': current_sha},
     )
     assert preview.status_code == 200
     assert preview.json()['data']['diff_summary']['lines_added'] >= 2
 
     update = client.put(
-        '/api/v1/skills/demo-skill',
+        '/api/v1/skills/agent-zoro-demo-skill',
         json={'actor': 'zoro', 'content': updated_content, 'expected_sha256': current_sha},
     )
     assert update.status_code == 200
@@ -121,7 +208,7 @@ def test_preview_and_update_skill_with_audit(tmp_path: Path) -> None:
     assert audit.status_code == 200
     audit_items = audit.json()['data']['items']
     assert audit_items[0]['actor'] == 'zoro'
-    assert audit_items[0]['skill_id'] == 'demo-skill'
+    assert audit_items[0]['skill_id'] == 'agent-zoro-demo-skill'
 
     app.dependency_overrides.clear()
 
@@ -132,7 +219,7 @@ def test_rejects_stale_fingerprint(tmp_path: Path) -> None:
     client = TestClient(app)
 
     response = client.put(
-        '/api/v1/skills/demo-skill',
+        '/api/v1/skills/agent-zoro-demo-skill',
         json={'actor': 'zoro', 'content': """---
 name: demo-skill
 description: demo
@@ -155,12 +242,12 @@ def test_rejects_read_only_runtime_skill(tmp_path: Path) -> None:
     app.dependency_overrides[get_skill_service] = lambda: service
     client = TestClient(app)
 
-    detail = client.get('/api/v1/skills/judgment-day')
+    detail = client.get('/api/v1/skills/runtime-judgment-day')
     assert detail.status_code == 200
     fingerprint = detail.json()['data']['fingerprint']['sha256']
 
     response = client.put(
-        '/api/v1/skills/judgment-day',
+        '/api/v1/skills/runtime-judgment-day',
         json={'actor': 'zoro', 'content': detail.json()['data']['content'], 'expected_sha256': fingerprint},
     )
     assert response.status_code == 403

--- a/apps/web/src/app/skills/page.tsx
+++ b/apps/web/src/app/skills/page.tsx
@@ -32,6 +32,43 @@ type PreviewState = 'idle' | 'loading' | 'ready' | 'error'
 type SaveState = 'idle' | 'saving' | 'success' | 'stale' | 'error'
 
 const DEFAULT_ACTOR = 'zoro'
+const MUGIWARA_OPTIONS = [
+  { slug: 'luffy', label: 'Luffy' },
+  { slug: 'zoro', label: 'Zoro' },
+  { slug: 'franky', label: 'Franky' },
+  { slug: 'chopper', label: 'Chopper' },
+  { slug: 'usopp', label: 'Usopp' },
+  { slug: 'nami', label: 'Nami' },
+  { slug: 'robin', label: 'Robin' },
+  { slug: 'brook', label: 'Brook' },
+  { slug: 'jinbe', label: 'Jinbe' },
+  { slug: 'sanji', label: 'Sanji' },
+] as const
+
+type MugiwaraSkillSlug = (typeof MUGIWARA_OPTIONS)[number]['slug']
+
+function isMugiwaraSkillSlug(value: string | null): value is MugiwaraSkillSlug {
+  return MUGIWARA_OPTIONS.some((option) => option.slug === value)
+}
+
+function getInitialMugiwaraSlug(): MugiwaraSkillSlug {
+  if (typeof window === 'undefined') {
+    return 'zoro'
+  }
+
+  const value = new URLSearchParams(window.location.search).get('mugiwara')
+  return isMugiwaraSkillSlug(value) ? value : 'zoro'
+}
+
+function getVisibleSkillsForMugiwara(catalog: SkillCatalogItem[], ownerSlug: MugiwaraSkillSlug) {
+  return catalog.filter((skill) => skill.owner_slug === 'global' || skill.owner_slug === ownerSlug)
+}
+
+function getPreferredSkillId(catalog: SkillCatalogItem[], ownerSlug: MugiwaraSkillSlug) {
+  const agentSkill = catalog.find((skill) => skill.owner_slug === ownerSlug)
+  const globalSkill = catalog.find((skill) => skill.owner_slug === 'global')
+  return agentSkill?.skill_id ?? globalSkill?.skill_id ?? null
+}
 
 function formatTimestamp(value: string) {
   const date = new Date(value)
@@ -119,6 +156,7 @@ export default function SkillsPage() {
   const [viewState, setViewState] = useState<SkillsViewState>('loading')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [catalog, setCatalog] = useState<SkillCatalogItem[]>([])
+  const [selectedMugiwaraSlug, setSelectedMugiwaraSlug] = useState<MugiwaraSkillSlug>(() => getInitialMugiwaraSlug())
   const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null)
   const [selectedSkill, setSelectedSkill] = useState<SkillDetail | null>(null)
   const [audit, setAudit] = useState<SkillAuditRecord[]>([])
@@ -146,6 +184,8 @@ export default function SkillsPage() {
         }
 
         const items = catalogResponse.data.items
+        const initialMugiwara = getInitialMugiwaraSlug()
+        setSelectedMugiwaraSlug(initialMugiwara)
         setCatalog(items)
         setAudit(auditResponse.data.items)
 
@@ -156,7 +196,13 @@ export default function SkillsPage() {
           return
         }
 
-        setSelectedSkillId((current) => current ?? items[0].skill_id)
+        setSelectedSkillId((current) => {
+          const visibleItems = getVisibleSkillsForMugiwara(items, initialMugiwara)
+          if (current && visibleItems.some((item) => item.skill_id === current)) {
+            return current
+          }
+          return getPreferredSkillId(visibleItems, initialMugiwara) ?? visibleItems[0]?.skill_id ?? null
+        })
         setViewState('ready')
       } catch (error) {
         if (cancelled) {
@@ -234,6 +280,23 @@ export default function SkillsPage() {
     setLastSavedAudit(null)
   }, [selectedSkill])
 
+  const visibleCatalog = useMemo(() => getVisibleSkillsForMugiwara(catalog, selectedMugiwaraSlug), [catalog, selectedMugiwaraSlug])
+  const selectedMugiwaraLabel = MUGIWARA_OPTIONS.find((option) => option.slug === selectedMugiwaraSlug)?.label ?? 'Zoro'
+  const globalSkillsCount = catalog.filter((skill) => skill.owner_slug === 'global').length
+  const selectedMugiwaraSkillsCount = catalog.filter((skill) => skill.owner_slug === selectedMugiwaraSlug).length
+
+  useEffect(() => {
+    if (catalog.length === 0) {
+      return
+    }
+
+    const selectedStillVisible = selectedSkillId ? visibleCatalog.some((item) => item.skill_id === selectedSkillId) : false
+    if (!selectedStillVisible) {
+      setSelectedSkillId(getPreferredSkillId(visibleCatalog, selectedMugiwaraSlug) ?? visibleCatalog[0]?.skill_id ?? null)
+      setSelectedSkill(null)
+    }
+  }, [catalog, selectedMugiwaraSlug, selectedSkillId, visibleCatalog])
+
   const latestAudit = useMemo(() => {
     if (!selectedSkill) {
       return null
@@ -247,8 +310,8 @@ export default function SkillsPage() {
   const hasDraftChanges = selectedSkill ? draftContent !== selectedSkill.content : false
   const normalizedActor = actorInput.trim()
   const canSave = Boolean(selectedSkill?.editable && hasDraftChanges && normalizedActor && saveState !== 'saving')
-  const editableCount = catalog.filter((item) => item.editable).length
-  const readOnlyCount = catalog.length - editableCount
+  const editableCount = visibleCatalog.filter((item) => item.editable).length
+  const readOnlyCount = visibleCatalog.length - editableCount
   const draftSummary = useMemo(() => {
     if (!selectedSkill) {
       return null
@@ -272,6 +335,18 @@ export default function SkillsPage() {
             : hasDraftChanges
               ? 'revision'
               : 'operativo'
+
+
+  function handleSelectMugiwara(slug: MugiwaraSkillSlug) {
+    setSelectedMugiwaraSlug(slug)
+    const nextUrl = new URL(window.location.href)
+    nextUrl.searchParams.set('mugiwara', slug)
+    window.history.replaceState(null, '', `${nextUrl.pathname}?${nextUrl.searchParams.toString()}`)
+    const nextVisibleCatalog = getVisibleSkillsForMugiwara(catalog, slug)
+    setSelectedSkillId(getPreferredSkillId(nextVisibleCatalog, slug) ?? nextVisibleCatalog[0]?.skill_id ?? null)
+    setSelectedSkill(null)
+    resetFeedbackState()
+  }
 
   function resetFeedbackState() {
     setPreviewState('idle')
@@ -454,7 +529,7 @@ export default function SkillsPage() {
                     fontWeight: 700,
                   }}
                 >
-                  {isRootUnavailable ? 'catálogo bloqueado' : `${editableCount} editable(s) · ${readOnlyCount} referencia(s)`}
+                  {isRootUnavailable ? 'catálogo bloqueado' : `${selectedMugiwaraLabel}: ${selectedMugiwaraSkillsCount} · globales: ${globalSkillsCount}`}
                 </span>
               </div>
             </div>
@@ -650,8 +725,42 @@ export default function SkillsPage() {
       </section>
 
       <section className="section-block layout-grid layout-grid--sidebar-detail">
-        <SurfaceCard title="Catálogo real" elevated eyebrow="Allowlist" accent="sky">
-          <div style={{ display: 'grid', gap: '10px' }}>
+        <SurfaceCard title="Catálogo real" elevated eyebrow="Global + Mugiwara" accent="sky">
+          <div style={{ display: 'grid', gap: '12px' }}>
+            <div style={{ display: 'grid', gap: '8px' }}>
+              <span style={{ color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 700 }}>Mugiwara seleccionado</span>
+              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                {MUGIWARA_OPTIONS.map((option) => {
+                  const selected = option.slug === selectedMugiwaraSlug
+
+                  return (
+                    <button
+                      key={option.slug}
+                      type="button"
+                      onClick={() => handleSelectMugiwara(option.slug)}
+                      aria-pressed={selected}
+                      disabled={isRootUnavailable}
+                      style={{
+                        borderRadius: '999px',
+                        border: `1px solid ${selected ? appTheme.colors.brandSky500 : appTheme.colors.borderSubtle}`,
+                        background: selected ? appTheme.colors.bgSurface2 : appTheme.colors.bgSurface1,
+                        color: selected ? appTheme.colors.brandSky500 : appTheme.colors.textSecondary,
+                        padding: '7px 11px',
+                        fontSize: '12px',
+                        fontWeight: 700,
+                        cursor: isRootUnavailable ? 'not-allowed' : 'pointer',
+                        opacity: isRootUnavailable ? 0.6 : 1,
+                      }}
+                    >
+                      {option.label}
+                    </button>
+                  )
+                })}
+              </div>
+              <p style={{ margin: 0, color: appTheme.colors.textSecondary, fontSize: '13px' }}>
+                Mostrando skills globales y skills propias de <strong>{selectedMugiwaraLabel}</strong>.
+              </p>
+            </div>
             {sourceNotice ? (
               <StatePanel
                 status={sourceNotice.status}
@@ -666,7 +775,7 @@ export default function SkillsPage() {
               />
             ) : null}
 
-            {catalog.map((skill) => {
+            {visibleCatalog.map((skill) => {
               const isSelected = skill.skill_id === selectedSkillId
 
               return (
@@ -693,6 +802,7 @@ export default function SkillsPage() {
                 >
                   <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
                     <strong>{skill.display_name}</strong>
+                    <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>{skill.owner_label}</span>
                     <StatusBadge status={mapCatalogSkillToBadgeStatus(skill)} />
                   </div>
                   <span className="text-break" style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{skill.skill_id}</span>

--- a/apps/web/src/modules/skills/api/skills-bff-validation.ts
+++ b/apps/web/src/modules/skills/api/skills-bff-validation.ts
@@ -3,7 +3,7 @@ import 'server-only'
 export const SKILLS_BFF_BODY_LIMIT_BYTES = 256 * 1024
 export const SKILLS_BFF_CONTENT_LIMIT_BYTES = 200_000
 
-const SKILL_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,79}$/
+const SKILL_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,139}$/
 const SHA256_PATTERN = /^[a-fA-F0-9]{64}$/
 
 export const SKILLS_BFF_TRUSTED_ORIGINS_ENV = 'MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS'

--- a/docs/skills-surface.md
+++ b/docs/skills-surface.md
@@ -31,16 +31,27 @@ Flujo objetivo:
 5. backend aplica cambio de forma auditable
 6. backend devuelve resultado, diff resumido y metadata de trazabilidad
 
-## Allowlist mínima
+## Allowlist de catálogo
 La allowlist debe estar gobernada por backend y no por el cliente.
 
+El catálogo visible se descubre desde rutas backend-owned bajo `/srv/crew-core/skills-source`:
+- `global/*/SKILL.md` como skills globales compartidas.
+- `agents/<mugiwara>/*/SKILL.md` como skills propias de cada Mugiwara allowlisteado.
+- referencias runtime explícitas, como `judgment-day`, pueden exponerse como solo lectura si no viven bajo el árbol editable.
+
 Campos mínimos por entrada:
-- `skill_id`
+- `skill_id` estable generado por backend (`global-<skill>` o `agent-<mugiwara>-<skill>`)
 - `display_name`
 - `repo_path`
 - `owner_scope`
+- `owner_slug`
+- `owner_label`
 - `editable_sections` si se quiere granularidad futura
 - `public_repo_risk`
+
+La página `/skills` debe permitir seleccionar Mugiwara y mostrar simultáneamente las skills globales y las skills propias del Mugiwara seleccionado.
+
+Decisión operativa: colocar una skill nueva bajo `skills-source/global` o `skills-source/agents/<mugiwara>` la incorpora al catálogo editable del panel si cumple el contrato `SKILL.md` y el slug de Mugiwara está allowlisteado. Si una skill debe ser solo referencia, debe declararse explícitamente como runtime/read-only o quedar fuera de esa superficie hasta que exista política granular.
 
 ## Reglas de seguridad
 - deny-by-default en backend

--- a/openspec/phase-19-1-skills-mugiwara-selector-verify-checklist.md
+++ b/openspec/phase-19-1-skills-mugiwara-selector-verify-checklist.md
@@ -1,0 +1,22 @@
+# Phase 19.1 verify checklist — Skills globales + selector Mugiwara
+
+## Backend/API
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_skills_api.py apps/api/tests/test_mugiwaras_api.py -q`
+- [x] `python -m py_compile apps/api/src/modules/skills/domain.py apps/api/src/modules/skills/service.py apps/api/src/modules/mugiwaras/service.py`
+- [x] Smoke API local: `/api/v1/skills` devuelve catálogo dinámico con globales y múltiples Mugiwaras.
+
+## Frontend/BFF
+- [x] `npm run verify:skills-server-only`
+- [x] `npm --prefix apps/web run typecheck`
+- [x] `npm --prefix apps/web run build`
+
+## Browser smoke
+- [x] `/skills?mugiwara=franky` muestra selector con Franky pulsado, skills globales y skills de Franky.
+- [x] `/skills?mugiwara=chopper` muestra selector con Chopper pulsado y skill activa de Chopper.
+- [x] `/mugiwaras` contiene enlaces `Ver Skills` con `?mugiwara=<slug>` para cada Mugiwara.
+- [x] Consola browser limpia en `/skills?mugiwara=chopper`.
+
+## Hygiene
+- [x] `git diff --check`
+- [x] `git status --short --branch`
+- [ ] PR con review Chopper + Usopp antes de mergear.

--- a/openspec/phase-19-1-skills-mugiwara-selector.md
+++ b/openspec/phase-19-1-skills-mugiwara-selector.md
@@ -1,0 +1,36 @@
+# Phase 19.1 — Skills globales + selector Mugiwara
+
+## Objetivo
+Corregir la superficie `/skills` para que no quede anclada a Zoro: debe permitir seleccionar cualquier Mugiwara y mostrar las skills globales junto con las skills propias del Mugiwara seleccionado.
+
+## Problema observado
+- Desde `/mugiwaras`, los enlaces `Ver Skills` apuntaban siempre a `/skills` sin contexto de agente.
+- `/skills` consumía un catálogo backend mínimo/hardcoded y el primer elemento efectivo era Zoro.
+- Pablo espera un catálogo operativo por Mugiwara: global + seleccionado.
+
+## Decisiones
+- Backend Skills descubre catálogo desde rutas backend-owned bajo `/srv/crew-core/skills-source`:
+  - `global/*/SKILL.md` -> `owner_scope=shared`, `owner_slug=global`.
+  - `agents/<mugiwara>/*/SKILL.md` -> `owner_scope=agent`, `owner_slug=<mugiwara>`.
+  - referencias runtime explícitas quedan `read-only`.
+- `skill_id` pasa a ser estable y namespaceado: `global-<skill>` y `agent-<mugiwara>-<skill>` para evitar colisiones entre agentes.
+- `/mugiwaras` enlaza a `/skills?mugiwara=<slug>`.
+- `/skills` conserva la frontera BFF same-origin y filtra en cliente solo sobre datos ya allowlisteados por backend.
+
+## Fuera de alcance
+- Crear/borrar skills.
+- Navegación libre por filesystem.
+- Editar ficheros fuera de `SKILL.md` bajo el árbol allowlisted.
+- Permisos por usuario/auth real.
+- Rediseño completo de la página Skills.
+
+## Definition of Done
+- Catálogo backend incluye globales y skills de varios Mugiwaras.
+- Contrato expone `owner_slug` y `owner_label`.
+- Selector visual en `/skills` permite cambiar Mugiwara.
+- El catálogo visible combina global + Mugiwara seleccionado.
+- Links desde `/mugiwaras` conservan contexto por query param.
+- Verify backend, BFF, typecheck, build y browser smoke pasan.
+
+## Review esperada
+Cambio mixto backend/filesystem allowlisted + UI visible. Review requerida: Chopper + Usopp. Franky solo si se modifica runtime/servicios, que queda fuera de esta fase.

--- a/packages/contracts/src/skills.ts
+++ b/packages/contracts/src/skills.ts
@@ -7,6 +7,8 @@ export type SkillCatalogItem = {
   skill_id: string
   display_name: string
   owner_scope: SkillOwnerScope
+  owner_slug: string
+  owner_label: string
   public_repo_risk: PublicRepoRisk
   editable: boolean
   repo_path: string


### PR DESCRIPTION
## Resumen
- convierte el catálogo de Skills de una allowlist mínima hardcoded a descubrimiento backend-owned bajo `skills-source/global` y `skills-source/agents/<mugiwara>`
- añade `owner_slug`/`owner_label` al contrato para separar skills globales, de agente y runtime
- añade selector Mugiwara en `/skills` y filtra la vista como `global + Mugiwara seleccionado`
- corrige los enlaces `Ver Skills` de `/mugiwaras` para apuntar a `/skills?mugiwara=<slug>`

## Verificación de Zoro
- `PYTHONPATH=. pytest apps/api/tests/test_skills_api.py apps/api/tests/test_mugiwaras_api.py -q`
- `python -m py_compile apps/api/src/modules/skills/domain.py apps/api/src/modules/skills/service.py apps/api/src/modules/mugiwaras/service.py`
- `npm run verify:skills-server-only`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build`
- `npm run verify:visual-baseline`
- `git diff --check`
- Browser smoke local: `/skills?mugiwara=franky`, `/skills?mugiwara=chopper`, `/mugiwaras`; consola limpia

## Riesgos / review solicitada
- **Chopper:** revisar que el descubrimiento bajo `skills-source` mantiene deny-by-default, sin paths cliente, sin symlinks editables y sin ampliación insegura de escritura.
- **Usopp:** revisar selector, navegación desde Mugiwaras y claridad UX de `global + Mugiwara seleccionado`.

No modifica servicios systemd/runtime ni exposición Tailscale.
