### PR TITLE
feat: redesign skills reader editor

### DIFF
--- a/.engram/phase-19-2-skills-picker-reader-editor-closeout.md
+++ b/.engram/phase-19-2-skills-picker-reader-editor-closeout.md
@@ -1,0 +1,26 @@
+# Phase 19.2 closeout — Skills picker reader/editor
+
+## Context
+Pablo reported that `/skills` still felt like an infinite global list and that the informational containers did not add value. The requested interaction is source selection, skill dropdown, and one reader/editor window with Markdown rendering in reader mode.
+
+## Changes
+- Reworked `/skills` into a compact source + skill picker flow.
+- Removed non-actionable informational containers from the page.
+- Added a filtered skill dropdown for `global` or the selected Mugiwara source.
+- Added a focused reader/editor window for the selected skill.
+- Added reader/editor mode toggle.
+- Added conservative Markdown rendering for reader mode.
+- Kept editor/preview/save path behind the existing BFF same-origin model.
+- Updated skills surface docs and OpenSpec phase notes.
+
+## Verification
+- `npm --prefix apps/web run typecheck` passed.
+- `npm --prefix apps/web run build` passed.
+- `PYTHONPATH=. pytest apps/api/tests/test_skills_api.py apps/api/tests/test_mugiwaras_api.py -q` passed: 12 tests.
+- `npm run verify:skills-server-only` passed.
+- `npm run verify:visual-baseline` completed.
+- `git diff --check` passed.
+- Browser smoke on `http://127.0.0.1:3020/skills?mugiwara=franky` confirmed no old containers, source selector, skill dropdown, Markdown reader and editor toggle; console clean.
+
+## Notes
+The Markdown renderer is intentionally conservative and local. It is sufficient for readable `SKILL.md` content without expanding the dependency surface in this microphase.

--- a/apps/web/src/app/skills/page.tsx
+++ b/apps/web/src/app/skills/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { Fragment, useEffect, useMemo, useState, type ReactElement } from 'react'
 
 import type { SkillAuditRecord, SkillCatalogItem, SkillDetail, SkillPreviewResponse } from '@contracts/skills'
 
@@ -13,13 +13,7 @@ import {
   SkillsApiError,
   updateSkill,
 } from '@/modules/skills/api/skills-http'
-import {
-  getSkillExposureLabel,
-  mapCatalogSkillToBadgeStatus,
-  mapRiskToBadgeStatus,
-  mapSkillsViewStateToBadgeStatus,
-} from '@/modules/skills/view-models/skill-surface.mappers'
-import { skillSurfaceFixture } from '@/modules/skills/view-models/skill-surface.fixture'
+import { mapCatalogSkillToBadgeStatus, mapRiskToBadgeStatus, mapSkillsViewStateToBadgeStatus } from '@/modules/skills/view-models/skill-surface.mappers'
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
 import { StatePanel } from '@/shared/ui/state/StatePanel'
@@ -30,8 +24,13 @@ import { appTheme, type AppStatus } from '@/shared/theme/tokens'
 type SkillsViewState = 'loading' | 'ready' | 'empty' | 'error' | 'not_configured'
 type PreviewState = 'idle' | 'loading' | 'ready' | 'error'
 type SaveState = 'idle' | 'saving' | 'success' | 'stale' | 'error'
+type WorkspaceMode = 'reader' | 'editor'
 
 const DEFAULT_ACTOR = 'zoro'
+// Guardrail note: Skills uses BFF same-origin and server-only MUGIWARA_CONTROL_PANEL_API_URL; never expose backend URL to the browser.
+const GLOBAL_SOURCE = 'global'
+const RUNTIME_SOURCE = 'runtime'
+
 const MUGIWARA_OPTIONS = [
   { slug: 'luffy', label: 'Luffy' },
   { slug: 'zoro', label: 'Zoro' },
@@ -46,28 +45,71 @@ const MUGIWARA_OPTIONS = [
 ] as const
 
 type MugiwaraSkillSlug = (typeof MUGIWARA_OPTIONS)[number]['slug']
+type SkillSourceSlug = typeof GLOBAL_SOURCE | typeof RUNTIME_SOURCE | MugiwaraSkillSlug
 
 function isMugiwaraSkillSlug(value: string | null): value is MugiwaraSkillSlug {
   return MUGIWARA_OPTIONS.some((option) => option.slug === value)
 }
 
-function getInitialMugiwaraSlug(): MugiwaraSkillSlug {
+function isSkillSourceSlug(value: string | null): value is SkillSourceSlug {
+  return value === GLOBAL_SOURCE || value === RUNTIME_SOURCE || isMugiwaraSkillSlug(value)
+}
+
+function getInitialSourceSlug(): SkillSourceSlug {
   if (typeof window === 'undefined') {
-    return 'zoro'
+    return GLOBAL_SOURCE
   }
 
-  const value = new URLSearchParams(window.location.search).get('mugiwara')
-  return isMugiwaraSkillSlug(value) ? value : 'zoro'
+  const params = new URLSearchParams(window.location.search)
+  const source = params.get('source')
+  const mugiwara = params.get('mugiwara')
+
+  if (isSkillSourceSlug(source)) {
+    return source
+  }
+
+  return isMugiwaraSkillSlug(mugiwara) ? mugiwara : GLOBAL_SOURCE
 }
 
-function getVisibleSkillsForMugiwara(catalog: SkillCatalogItem[], ownerSlug: MugiwaraSkillSlug) {
-  return catalog.filter((skill) => skill.owner_slug === 'global' || skill.owner_slug === ownerSlug)
+function getSourceLabel(sourceSlug: SkillSourceSlug) {
+  if (sourceSlug === GLOBAL_SOURCE) {
+    return 'Globales'
+  }
+
+  if (sourceSlug === RUNTIME_SOURCE) {
+    return 'Runtime'
+  }
+
+  return MUGIWARA_OPTIONS.find((option) => option.slug === sourceSlug)?.label ?? sourceSlug
 }
 
-function getPreferredSkillId(catalog: SkillCatalogItem[], ownerSlug: MugiwaraSkillSlug) {
-  const agentSkill = catalog.find((skill) => skill.owner_slug === ownerSlug)
-  const globalSkill = catalog.find((skill) => skill.owner_slug === 'global')
-  return agentSkill?.skill_id ?? globalSkill?.skill_id ?? null
+function getSkillSourceOptions(catalog: SkillCatalogItem[]) {
+  const ownerSlugs = new Set(catalog.map((skill) => skill.owner_slug))
+  const options: Array<{ slug: SkillSourceSlug; label: string; count: number }> = []
+
+  if (ownerSlugs.has(GLOBAL_SOURCE)) {
+    options.push({ slug: GLOBAL_SOURCE, label: 'Globales', count: catalog.filter((skill) => skill.owner_slug === GLOBAL_SOURCE).length })
+  }
+
+  for (const option of MUGIWARA_OPTIONS) {
+    if (ownerSlugs.has(option.slug)) {
+      options.push({ slug: option.slug, label: option.label, count: catalog.filter((skill) => skill.owner_slug === option.slug).length })
+    }
+  }
+
+  if (ownerSlugs.has(RUNTIME_SOURCE)) {
+    options.push({ slug: RUNTIME_SOURCE, label: 'Runtime', count: catalog.filter((skill) => skill.owner_slug === RUNTIME_SOURCE).length })
+  }
+
+  return options
+}
+
+function getSkillsForSource(catalog: SkillCatalogItem[], sourceSlug: SkillSourceSlug) {
+  return catalog.filter((skill) => skill.owner_slug === sourceSlug).sort((a, b) => a.display_name.localeCompare(b.display_name, 'es'))
+}
+
+function getPreferredSkillId(skills: SkillCatalogItem[]) {
+  return skills[0]?.skill_id ?? null
 }
 
 function formatTimestamp(value: string) {
@@ -107,29 +149,29 @@ function getSkillsViewNotice(state: SkillsViewState, connectionLabel: string, er
     case 'loading':
       return {
         status: 'revision' as const,
-        title: 'Conectando con la frontera BFF de skills',
-        description: 'La UI está cargando catálogo, detalle y auditoría allowlisted mediante endpoints same-origin sin exponer la URL del backend.',
+        title: 'Cargando skills',
+        description: 'Estoy cargando fuentes, catálogo y auditoría mediante la frontera BFF same-origin.',
         detail: `Conexión: ${connectionLabel}`,
       }
     case 'not_configured':
       return {
         status: 'revision' as const,
         title: 'Skills no está conectado al backend',
-        description: 'No se puede cargar el catálogo ni habilitar edición porque falta configurar MUGIWARA_CONTROL_PANEL_API_URL en el runtime server. La página conserva el shell y el perímetro seguro, pero no hay skills reales disponibles en este estado.',
-        detail: 'Bloqueado: catálogo, detalle, preview y guardado. Seguro: BFF same-origin, sin URL interna en el navegador.',
+        description: 'Falta configurar la fuente server-only. Sin catálogo real no hay selección ni edición.',
+        detail: 'BFF same-origin conservado; la URL interna no se expone al navegador.',
       }
     case 'error':
       return {
         status: 'incidencia' as const,
         title: 'Skills no puede cargar la fuente real',
-        description: 'La página mantiene el shell y el perímetro seguro, pero la fuente real no permite cargar catálogo, detalle ni edición con garantías.',
-        detail: errorMessage ?? 'Bloqueado: catálogo, detalle, preview y guardado. Seguro: errores saneados sin URL interna ni salidas crudas.',
+        description: 'La fuente real no permite cargar catálogo o detalle con garantías.',
+        detail: errorMessage ?? 'Error saneado sin URL interna ni salidas crudas.',
       }
     case 'empty':
       return {
         status: 'sin-datos' as const,
-        title: 'La allowlist no devolvió skills visibles',
-        description: 'El backend respondió correctamente a través del BFF, pero no hay entradas disponibles para esta selección allowlisted.',
+        title: 'No hay skills visibles',
+        description: 'El backend respondió, pero la allowlist no devolvió entradas para seleccionar.',
         detail: `Conexión: ${connectionLabel}`,
       }
     case 'ready':
@@ -150,15 +192,154 @@ function formatSignedDelta(value: number) {
   return value > 0 ? `+${value}` : `${value}`
 }
 
+function renderInlineMarkdown(text: string) {
+  const segments = text.split(/(`[^`]+`|\*\*[^*]+\*\*)/g).filter(Boolean)
+
+  return segments.map((segment, index) => {
+    if (segment.startsWith('`') && segment.endsWith('`')) {
+      return (
+        <code key={`${segment}-${index}`} className="responsive-code" style={{ padding: '1px 5px', borderRadius: '6px', background: appTheme.colors.bgSurface1 }}>
+          {segment.slice(1, -1)}
+        </code>
+      )
+    }
+
+    if (segment.startsWith('**') && segment.endsWith('**')) {
+      return <strong key={`${segment}-${index}`}>{segment.slice(2, -2)}</strong>
+    }
+
+    return <Fragment key={`${segment}-${index}`}>{segment}</Fragment>
+  })
+}
+
+function MarkdownReader({ content }: { content: string }) {
+  const blocks: ReactElement[] = []
+  const lines = content.split('\n')
+  let listItems: string[] = []
+  let orderedListItems: string[] = []
+  let codeLines: string[] = []
+  let inCodeBlock = false
+
+  function flushList() {
+    if (listItems.length > 0) {
+      const items = listItems
+      listItems = []
+      blocks.push(
+        <ul key={`list-${blocks.length}`} style={{ margin: 0, paddingLeft: '20px', display: 'grid', gap: '6px' }}>
+          {items.map((item, index) => (
+            <li key={`${item}-${index}`}>{renderInlineMarkdown(item)}</li>
+          ))}
+        </ul>,
+      )
+    }
+
+    if (orderedListItems.length > 0) {
+      const items = orderedListItems
+      orderedListItems = []
+      blocks.push(
+        <ol key={`ordered-list-${blocks.length}`} style={{ margin: 0, paddingLeft: '22px', display: 'grid', gap: '6px' }}>
+          {items.map((item, index) => (
+            <li key={`${item}-${index}`}>{renderInlineMarkdown(item)}</li>
+          ))}
+        </ol>,
+      )
+    }
+  }
+
+  function flushCode() {
+    if (codeLines.length === 0) {
+      return
+    }
+
+    const code = codeLines.join('\n')
+    codeLines = []
+    blocks.push(
+      <pre key={`code-${blocks.length}`} className="responsive-code" style={{ margin: 0, padding: '12px', borderRadius: '12px', background: appTheme.colors.bgSurface1, color: appTheme.colors.textSecondary }}>
+        {code}
+      </pre>,
+    )
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd()
+
+    if (line.startsWith('```')) {
+      if (inCodeBlock) {
+        inCodeBlock = false
+        flushCode()
+      } else {
+        flushList()
+        inCodeBlock = true
+      }
+      continue
+    }
+
+    if (inCodeBlock) {
+      codeLines.push(rawLine)
+      continue
+    }
+
+    if (!line.trim()) {
+      flushList()
+      continue
+    }
+
+    const headingMatch = line.match(/^(#{1,3})\s+(.+)$/)
+    if (headingMatch) {
+      flushList()
+      const level = headingMatch[1].length
+      const headingContent = renderInlineMarkdown(headingMatch[2])
+      if (level === 1) {
+        blocks.push(<h2 key={`heading-${blocks.length}`} className="text-break" style={{ margin: 0, color: appTheme.colors.textPrimary }}>{headingContent}</h2>)
+      } else if (level === 2) {
+        blocks.push(<h3 key={`heading-${blocks.length}`} className="text-break" style={{ margin: 0, color: appTheme.colors.textPrimary }}>{headingContent}</h3>)
+      } else {
+        blocks.push(<h4 key={`heading-${blocks.length}`} className="text-break" style={{ margin: 0, color: appTheme.colors.textPrimary }}>{headingContent}</h4>)
+      }
+      continue
+    }
+
+    const listMatch = line.match(/^[-*]\s+(.+)$/)
+    if (listMatch) {
+      if (orderedListItems.length > 0) {
+        flushList()
+      }
+      listItems.push(listMatch[1])
+      continue
+    }
+
+    const orderedListMatch = line.match(/^\d+\.\s+(.+)$/)
+    if (orderedListMatch) {
+      if (listItems.length > 0) {
+        flushList()
+      }
+      orderedListItems.push(orderedListMatch[1])
+      continue
+    }
+
+    flushList()
+    blocks.push(
+      <p key={`paragraph-${blocks.length}`} className="text-break" style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
+        {renderInlineMarkdown(line)}
+      </p>,
+    )
+  }
+
+  flushList()
+  flushCode()
+
+  return <div style={{ display: 'grid', gap: '12px', minWidth: 0 }}>{blocks}</div>
+}
+
 export default function SkillsPage() {
-  const policy = skillSurfaceFixture
   const apiConnectionLabel = getSkillsApiConnectionLabel()
   const [viewState, setViewState] = useState<SkillsViewState>('loading')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [catalog, setCatalog] = useState<SkillCatalogItem[]>([])
-  const [selectedMugiwaraSlug, setSelectedMugiwaraSlug] = useState<MugiwaraSkillSlug>(() => getInitialMugiwaraSlug())
+  const [selectedSourceSlug, setSelectedSourceSlug] = useState<SkillSourceSlug>(() => getInitialSourceSlug())
   const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null)
   const [selectedSkill, setSelectedSkill] = useState<SkillDetail | null>(null)
+  const [workspaceMode, setWorkspaceMode] = useState<WorkspaceMode>('reader')
   const [audit, setAudit] = useState<SkillAuditRecord[]>([])
   const [draftContent, setDraftContent] = useState('')
   const [actorInput, setActorInput] = useState(DEFAULT_ACTOR)
@@ -184,10 +365,14 @@ export default function SkillsPage() {
         }
 
         const items = catalogResponse.data.items
-        const initialMugiwara = getInitialMugiwaraSlug()
-        setSelectedMugiwaraSlug(initialMugiwara)
+        const initialSource = getInitialSourceSlug()
+        const sourceExists = items.some((item) => item.owner_slug === initialSource)
+        const nextSource = sourceExists ? initialSource : (items[0]?.owner_slug as SkillSourceSlug | undefined) ?? GLOBAL_SOURCE
+        const sourceSkills = getSkillsForSource(items, nextSource)
+
         setCatalog(items)
         setAudit(auditResponse.data.items)
+        setSelectedSourceSlug(nextSource)
 
         if (items.length === 0) {
           setSelectedSkillId(null)
@@ -196,13 +381,7 @@ export default function SkillsPage() {
           return
         }
 
-        setSelectedSkillId((current) => {
-          const visibleItems = getVisibleSkillsForMugiwara(items, initialMugiwara)
-          if (current && visibleItems.some((item) => item.skill_id === current)) {
-            return current
-          }
-          return getPreferredSkillId(visibleItems, initialMugiwara) ?? visibleItems[0]?.skill_id ?? null
-        })
+        setSelectedSkillId((current) => (current && sourceSkills.some((item) => item.skill_id === current) ? current : getPreferredSkillId(sourceSkills)))
         setViewState('ready')
       } catch (error) {
         if (cancelled) {
@@ -262,40 +441,17 @@ export default function SkillsPage() {
   useEffect(() => {
     if (!selectedSkill) {
       setDraftContent('')
-      setPreviewState('idle')
-      setPreviewError(null)
-      setPreviewResponse(null)
-      setSaveState('idle')
-      setSaveMessage(null)
-      setLastSavedAudit(null)
+      resetFeedbackState()
       return
     }
 
     setDraftContent(selectedSkill.content)
-    setPreviewState('idle')
-    setPreviewError(null)
-    setPreviewResponse(null)
-    setSaveState('idle')
-    setSaveMessage(null)
-    setLastSavedAudit(null)
+    resetFeedbackState()
   }, [selectedSkill])
 
-  const visibleCatalog = useMemo(() => getVisibleSkillsForMugiwara(catalog, selectedMugiwaraSlug), [catalog, selectedMugiwaraSlug])
-  const selectedMugiwaraLabel = MUGIWARA_OPTIONS.find((option) => option.slug === selectedMugiwaraSlug)?.label ?? 'Zoro'
-  const globalSkillsCount = catalog.filter((skill) => skill.owner_slug === 'global').length
-  const selectedMugiwaraSkillsCount = catalog.filter((skill) => skill.owner_slug === selectedMugiwaraSlug).length
-
-  useEffect(() => {
-    if (catalog.length === 0) {
-      return
-    }
-
-    const selectedStillVisible = selectedSkillId ? visibleCatalog.some((item) => item.skill_id === selectedSkillId) : false
-    if (!selectedStillVisible) {
-      setSelectedSkillId(getPreferredSkillId(visibleCatalog, selectedMugiwaraSlug) ?? visibleCatalog[0]?.skill_id ?? null)
-      setSelectedSkill(null)
-    }
-  }, [catalog, selectedMugiwaraSlug, selectedSkillId, visibleCatalog])
+  const sourceOptions = useMemo(() => getSkillSourceOptions(catalog), [catalog])
+  const sourceSkills = useMemo(() => getSkillsForSource(catalog, selectedSourceSlug), [catalog, selectedSourceSlug])
+  const selectedSourceLabel = getSourceLabel(selectedSourceSlug)
 
   const latestAudit = useMemo(() => {
     if (!selectedSkill) {
@@ -310,8 +466,6 @@ export default function SkillsPage() {
   const hasDraftChanges = selectedSkill ? draftContent !== selectedSkill.content : false
   const normalizedActor = actorInput.trim()
   const canSave = Boolean(selectedSkill?.editable && hasDraftChanges && normalizedActor && saveState !== 'saving')
-  const editableCount = visibleCatalog.filter((item) => item.editable).length
-  const readOnlyCount = visibleCatalog.length - editableCount
   const draftSummary = useMemo(() => {
     if (!selectedSkill) {
       return null
@@ -336,18 +490,6 @@ export default function SkillsPage() {
               ? 'revision'
               : 'operativo'
 
-
-  function handleSelectMugiwara(slug: MugiwaraSkillSlug) {
-    setSelectedMugiwaraSlug(slug)
-    const nextUrl = new URL(window.location.href)
-    nextUrl.searchParams.set('mugiwara', slug)
-    window.history.replaceState(null, '', `${nextUrl.pathname}?${nextUrl.searchParams.toString()}`)
-    const nextVisibleCatalog = getVisibleSkillsForMugiwara(catalog, slug)
-    setSelectedSkillId(getPreferredSkillId(nextVisibleCatalog, slug) ?? nextVisibleCatalog[0]?.skill_id ?? null)
-    setSelectedSkill(null)
-    resetFeedbackState()
-  }
-
   function resetFeedbackState() {
     setPreviewState('idle')
     setPreviewError(null)
@@ -355,6 +497,30 @@ export default function SkillsPage() {
     setSaveState('idle')
     setSaveMessage(null)
     setLastSavedAudit(null)
+  }
+
+  function updateUrlForSource(sourceSlug: SkillSourceSlug) {
+    const nextUrl = new URL(window.location.href)
+    nextUrl.searchParams.delete('mugiwara')
+    nextUrl.searchParams.set('source', sourceSlug)
+    window.history.replaceState(null, '', `${nextUrl.pathname}?${nextUrl.searchParams.toString()}`)
+  }
+
+  function handleSelectSource(sourceSlug: SkillSourceSlug) {
+    setSelectedSourceSlug(sourceSlug)
+    updateUrlForSource(sourceSlug)
+    const nextSkills = getSkillsForSource(catalog, sourceSlug)
+    setSelectedSkillId(getPreferredSkillId(nextSkills))
+    setSelectedSkill(null)
+    setWorkspaceMode('reader')
+    resetFeedbackState()
+  }
+
+  function handleSelectSkill(skillId: string) {
+    setSelectedSkillId(skillId || null)
+    setSelectedSkill(null)
+    setWorkspaceMode('reader')
+    resetFeedbackState()
   }
 
   function handleDraftChange(nextValue: string) {
@@ -439,12 +605,12 @@ export default function SkillsPage() {
         content: draftContent,
         expected_sha256: selectedSkill.fingerprint.sha256,
       })
-
       setSelectedSkill(response.data.skill)
       setAudit((current) => [response.data.audit, ...current.filter((item) => item.timestamp !== response.data.audit.timestamp)])
       setSaveState('success')
       setSaveMessage(`Guardado aplicado sobre ${response.data.skill.skill_id} por ${response.data.audit.actor}.`)
       setLastSavedAudit(response.data.audit)
+      setWorkspaceMode('reader')
     } catch (error) {
       if (error instanceof SkillsApiError && error.code === 'stale') {
         setSaveState('stale')
@@ -462,846 +628,207 @@ export default function SkillsPage() {
       <PageHeader
         eyebrow="Skills"
         title="Skills"
-        subtitle="Catálogo preparado para backend real con preview y guardado controlado; el estado de origen indica si la fuente está conectada."
+        subtitle="Selecciona una fuente, elige una skill y alterna entre lectura Markdown y edición controlada."
         mugiwaraSlug="zoro"
-        detailPills={["Edición allowlisted", "Diff explícito", "Auditoría visible"]}
+        detailPills={["Globales o Mugiwara", "Lector Markdown", "Editor auditado"]}
       />
 
-      {isRootUnavailable && sourceNotice ? (
-        <SurfaceCard title="Acción requerida" elevated eyebrow="Fuente raíz" accent={viewState === 'error' ? 'danger' : 'gold'}>
+      {sourceNotice ? (
+        <SurfaceCard title={sourceNotice.title} elevated eyebrow="Estado" accent={viewState === 'error' ? 'danger' : 'sky'}>
           <StatePanel
             status={sourceNotice.status}
             title={sourceNotice.title}
             description={sourceNotice.description}
             detail={sourceNotice.detail}
-            eyebrow="Estado principal"
+            eyebrow="Fuente"
             ariaRole={viewState === 'error' ? 'alert' : 'status'}
           >
-            <div style={{ display: 'grid', gap: '10px' }}>
-              <SourceStatePills items={[{ label: viewState === 'not_configured' ? 'Configurar backend server-only' : 'Revisar fuente Skills', tone: viewState === 'not_configured' ? 'not-configured' : 'degraded' }]} />
-              <ul style={{ margin: 0, paddingLeft: '18px', color: appTheme.colors.textSecondary, display: 'grid', gap: '6px' }}>
-                <li>Falta una fuente real: no se ofrece selección de skill ni edición productiva.</li>
-                <li>La frontera BFF sigue same-origin y no expone la URL interna del backend.</li>
-                <li>Siguiente paso operativo: configurar el runtime server y recargar la página.</li>
-              </ul>
-            </div>
+            <SourceStatePills
+              items={
+                viewState === 'ready'
+                  ? [{ label: 'API real conectada', tone: 'connected' }]
+                  : [{ label: viewState === 'not_configured' ? 'Fuente no configurada' : viewState === 'error' ? 'Error/degradado' : 'Cargando', tone: viewState === 'not_configured' ? 'not-configured' : viewState === 'error' ? 'degraded' : 'snapshot' }]
+              }
+            />
           </StatePanel>
         </SurfaceCard>
       ) : null}
 
-      <SurfaceCard
-        title={isRootUnavailable ? 'Workspace bloqueado' : 'Workspace de edición'}
-        elevated
-        eyebrow="Dojo"
-        accent={isRootUnavailable ? 'sky' : 'success'}
-      >
-        <div style={{ display: 'grid', gap: '14px' }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap', alignItems: 'start' }}>
-            <div style={{ display: 'grid', gap: '8px', maxWidth: '720px' }}>
-              <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
-                {isRootUnavailable
-                  ? 'La edición controlada queda bloqueada hasta que el catálogo real de skills esté disponible desde el backend configurado.'
-                  : 'Esta vista no es un catálogo pasivo: aquí existe edición controlada sobre skills allowlisted, con preview de diff, actor visible y guardado auditado.'}
-              </p>
-              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                <StatusBadge status={workspaceStatus} />
-                <span
-                  style={{
-                    borderRadius: '999px',
-                    padding: '4px 10px',
-                    border: `1px solid ${appTheme.colors.borderSubtle}`,
-                    background: appTheme.colors.bgSurface1,
-                    color: appTheme.colors.brandGold400,
-                    fontSize: '12px',
-                    fontWeight: 700,
-                  }}
-                >
-                  {isRootUnavailable ? 'Fuente real no disponible' : selectedSkill?.editable ? 'Modo edición allowlisted' : selectedSkill ? 'Modo referencia' : 'Selecciona una skill'}
-                </span>
-                <span
-                  style={{
-                    borderRadius: '999px',
-                    padding: '4px 10px',
-                    border: `1px solid ${appTheme.colors.borderSubtle}`,
-                    background: appTheme.colors.bgSurface1,
-                    color: appTheme.colors.brandSky500,
-                    fontSize: '12px',
-                    fontWeight: 700,
-                  }}
-                >
-                  {isRootUnavailable ? 'catálogo bloqueado' : `${selectedMugiwaraLabel}: ${selectedMugiwaraSkillsCount} · globales: ${globalSkillsCount}`}
-                </span>
-              </div>
-            </div>
+      <SurfaceCard title="Selector de skills" elevated eyebrow="Fuente y skill" accent="sky">
+        <div className="layout-grid layout-grid--cards-280" style={{ gap: '14px', alignItems: 'end' }}>
+          <label style={{ display: 'grid', gap: '8px', minWidth: 0 }}>
+            <span style={{ color: appTheme.colors.textMuted, fontSize: '13px', fontWeight: 700 }}>Fuente</span>
+            <select
+              value={selectedSourceSlug}
+              onChange={(event) => handleSelectSource(event.target.value as SkillSourceSlug)}
+              disabled={isRootUnavailable || catalog.length === 0}
+              style={{ borderRadius: '12px', border: `1px solid ${appTheme.colors.borderSubtle}`, background: appTheme.colors.bgSurface1, color: appTheme.colors.textPrimary, padding: '12px 14px' }}
+            >
+              {sourceOptions.map((option) => (
+                <option key={option.slug} value={option.slug}>{`${option.label} (${option.count})`}</option>
+              ))}
+            </select>
+          </label>
 
-            <div style={{ display: 'grid', gap: '8px' }}>
-              <span style={{ color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 700 }}>Skill activa</span>
-              <strong className="text-break" style={{ fontSize: '18px' }}>{selectedSkill?.display_name ?? 'Ninguna seleccionada'}</strong>
-              <span className="text-break" style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                {isRootUnavailable
-                  ? 'No hay selección posible hasta conectar la fuente real de skills.'
-                  : selectedSkill?.editable
-                    ? 'Lista para edición controlada cuando haya cambios y actor visible.'
-                    : selectedSkill
-                      ? 'Se muestra como referencia documental: sin escritura productiva.'
-                      : 'Selecciona una entrada del catálogo para abrir el workspace.'}
+          <label style={{ display: 'grid', gap: '8px', minWidth: 0 }}>
+            <span style={{ color: appTheme.colors.textMuted, fontSize: '13px', fontWeight: 700 }}>Skill</span>
+            <select
+              value={selectedSkillId ?? ''}
+              onChange={(event) => handleSelectSkill(event.target.value)}
+              disabled={isRootUnavailable || sourceSkills.length === 0}
+              style={{ borderRadius: '12px', border: `1px solid ${appTheme.colors.borderSubtle}`, background: appTheme.colors.bgSurface1, color: appTheme.colors.textPrimary, padding: '12px 14px' }}
+            >
+              {sourceSkills.length === 0 ? <option value="">Sin skills en esta fuente</option> : null}
+              {sourceSkills.map((skill) => (
+                <option key={skill.skill_id} value={skill.skill_id}>{skill.display_name}</option>
+              ))}
+            </select>
+          </label>
+
+          <div style={{ display: 'grid', gap: '8px', minWidth: 0 }}>
+            <span style={{ color: appTheme.colors.textMuted, fontSize: '13px', fontWeight: 700 }}>Resumen</span>
+            <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+              <StatusBadge status={mapSkillsViewStateToBadgeStatus(viewState)} />
+              <span style={{ borderRadius: '999px', padding: '4px 10px', border: `1px solid ${appTheme.colors.borderSubtle}`, color: appTheme.colors.brandSky500, fontSize: '12px', fontWeight: 700 }}>
+                {selectedSourceLabel}: {sourceSkills.length}
+              </span>
+              <span style={{ borderRadius: '999px', padding: '4px 10px', border: `1px solid ${appTheme.colors.borderSubtle}`, color: appTheme.colors.textSecondary, fontSize: '12px', fontWeight: 700 }}>
+                {apiConnectionLabel}
               </span>
             </div>
           </div>
-
-          <div className="layout-grid layout-grid--cards-180" style={{ gap: '10px' }}>
-            {[
-              {
-                label: 'Actor visible',
-                value: normalizedActor || 'sin definir',
-                tone: normalizedActor ? appTheme.colors.brandSky500 : appTheme.colors.stateDanger,
-              },
-              {
-                label: 'Borrador',
-                value: !selectedSkill ? 'sin selección' : hasDraftChanges ? 'cambios pendientes' : 'sin cambios',
-                tone: !selectedSkill ? appTheme.colors.textMuted : hasDraftChanges ? appTheme.colors.stateWarning : appTheme.colors.stateSuccess,
-              },
-              {
-                label: 'Preview',
-                value: previewResponse ? 'calculado' : previewState === 'loading' ? 'en curso' : previewState === 'error' ? 'incidencia' : 'pendiente',
-                tone:
-                  previewState === 'error'
-                    ? appTheme.colors.stateDanger
-                    : previewResponse
-                      ? appTheme.colors.brandBlue700
-                      : appTheme.colors.textMuted,
-              },
-              {
-                label: 'Guardado',
-                value: saveState === 'success' ? 'listo' : saveState === 'saving' ? 'en curso' : canSave ? 'habilitado' : 'bloqueado',
-                tone:
-                  saveState === 'error'
-                    ? appTheme.colors.stateDanger
-                    : saveState === 'stale'
-                      ? appTheme.colors.stateStale
-                      : canSave || saveState === 'success'
-                        ? appTheme.colors.stateSuccess
-                        : appTheme.colors.textMuted,
-              },
-            ].map((item) => (
-              <div
-                key={item.label}
-                style={{
-                  borderRadius: '12px',
-                  border: `1px solid ${appTheme.colors.borderSubtle}`,
-                  background: appTheme.colors.bgSurface1,
-                  padding: '12px',
-                  display: 'grid',
-                  gap: '6px',
-                }}
-              >
-                <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>{item.label}</span>
-                <strong style={{ color: item.tone, fontSize: '16px' }}>{item.value}</strong>
-              </div>
-            ))}
-          </div>
-
-          {selectedSkill ? (
-            <StatePanel
-              status={workspaceStatus}
-              title={selectedSkill.editable ? 'Workspace productivo activo' : 'Workspace en modo referencia'}
-              description={
-                selectedSkill.editable
-                  ? 'La edición ocurre aquí con allowlist, fingerprint esperado, preview explícito y guardado auditado. No es una ficha documental.'
-                  : 'Esta skill se puede inspeccionar, pero no habilita cambios productivos. El contraste con las skills editables debe quedar claro.'
-              }
-              detail={
-                selectedSkill.editable && draftSummary
-                  ? `delta líneas ${formatSignedDelta(draftSummary.lineDelta)} · delta chars ${formatSignedDelta(draftSummary.charDelta)}`
-                  : selectedSkill.skill_id
-              }
-              eyebrow="Modo de trabajo"
-            >
-              {selectedSkill.editable ? (
-                <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                  {['1. Edita el borrador', '2. Calcula preview', '3. Guarda con actor visible'].map((step) => (
-                    <span
-                      key={step}
-                      style={{
-                        borderRadius: '999px',
-                        padding: '4px 10px',
-                        border: `1px solid ${appTheme.colors.borderSubtle}`,
-                        background: appTheme.colors.bgSurface2,
-                        color: appTheme.colors.textSecondary,
-                        fontSize: '12px',
-                        fontWeight: 600,
-                      }}
-                    >
-                      {step}
-                    </span>
-                  ))}
-                </div>
-              ) : null}
-            </StatePanel>
-          ) : null}
         </div>
       </SurfaceCard>
 
-      <section className="layout-grid layout-grid--cards-280">
-        <SurfaceCard title="Frontera de edición" elevated eyebrow="Contrato" accent="gold">
-          <div id="edit-boundary" style={{ display: 'grid', gap: '10px' }}>
-            <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
-              La UI ya cierra el flujo permitido de edición controlada: solo skills allowlisted, actor visible, fingerprint esperado
-              y feedback explícito de guardado o conflicto.
-            </p>
-            <StatusBadge status="operativo" />
-            <ul style={{ margin: 0, paddingLeft: '18px', color: appTheme.colors.textSecondary, display: 'grid', gap: '8px' }}>
-              {policy.boundary_rules.map((rule) => (
-                <li key={rule}>{rule}</li>
-              ))}
-            </ul>
-          </div>
-        </SurfaceCard>
-
-        <SurfaceCard title="Estado del origen" elevated eyebrow="Enlace" accent="sky">
-          <div style={{ display: 'grid', gap: '10px', minWidth: 0 }}>
-            <p className="text-break" style={{ margin: 0, color: appTheme.colors.textSecondary }}>
-              El navegador habla con una frontera BFF same-origin; la URL real del backend queda solo en configuración server-only
-              y los errores llegan saneados sin romper el shell ni el build.
-            </p>
-            <StatusBadge status={mapSkillsViewStateToBadgeStatus(viewState)} />
-            <span className="text-break" style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-              Conexión: {apiConnectionLabel}
-            </span>
-            {sourceNotice ? (
-              isRootUnavailable ? (
-                <div style={{ display: 'grid', gap: '8px', minWidth: 0 }}>
-                  <strong className="text-break" style={{ color: appTheme.colors.textPrimary, fontSize: '15px' }}>Frontera BFF conservada</strong>
-                  <p className="text-break" style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.5 }}>
-                    El diagnóstico principal está arriba. Aquí solo se confirma que el navegador sigue usando same-origin y que la URL interna del backend no se expone.
-                  </p>
-                  <SourceStatePills items={[{ label: viewState === 'not_configured' ? 'Fuente no configurada' : 'Error/degradado', tone: viewState === 'not_configured' ? 'not-configured' : 'degraded' }]} />
-                </div>
-              ) : (
-                <StatePanel
-                  status={sourceNotice.status}
-                  title={sourceNotice.title}
-                  description={sourceNotice.description}
-                  detail={sourceNotice.detail}
-                  eyebrow="Estado de fuente"
-                >
-                  <SourceStatePills
-                    items={
-                      viewState === 'empty'
-                        ? [{ label: 'API real conectada', tone: 'connected' }, { label: 'Sin datos productivos', tone: 'not-configured' }]
-                        : [{ label: 'Error/degradado', tone: 'degraded' }]
-                    }
-                  />
-                </StatePanel>
-              )
-            ) : (
-              <StatePanel
-                status="operativo"
-                title="BFF same-origin conectado"
-                description="Catálogo, detalle y auditoría llegan desde la API real a través de la allowlist activa sin exponer la URL del backend al navegador."
-                detail={`Conexión: ${apiConnectionLabel}`}
-                eyebrow="Estado de fuente"
-              >
-                <SourceStatePills items={[{ label: 'API real conectada', tone: 'connected' }]} />
-              </StatePanel>
-            )}
-          </div>
-        </SurfaceCard>
-
-        <SurfaceCard title="Auditoría mínima" elevated eyebrow="Rastro" accent="gold">
-          <div id="audit-minimum" style={{ display: 'grid', gap: '10px' }}>
-            <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
-              La respuesta real del backend ya enseña trazabilidad resumida antes y después del guardado: actor, timestamp,
-              diff y resultado auditado.
-            </p>
-            <StatusBadge status={audit.length > 0 ? 'operativo' : 'revision'} />
-            <ul style={{ margin: 0, paddingLeft: '18px', color: appTheme.colors.textSecondary, display: 'grid', gap: '8px' }}>
-              {policy.audit_minimum.map((item) => (
-                <li key={item}>{item}</li>
-              ))}
-            </ul>
-          </div>
-        </SurfaceCard>
-      </section>
-
-      <section className="section-block layout-grid layout-grid--sidebar-detail">
-        <SurfaceCard title="Catálogo real" elevated eyebrow="Global + Mugiwara" accent="sky">
-          <div style={{ display: 'grid', gap: '12px' }}>
-            <div style={{ display: 'grid', gap: '8px' }}>
-              <span style={{ color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 700 }}>Mugiwara seleccionado</span>
-              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                {MUGIWARA_OPTIONS.map((option) => {
-                  const selected = option.slug === selectedMugiwaraSlug
-
-                  return (
-                    <button
-                      key={option.slug}
-                      type="button"
-                      onClick={() => handleSelectMugiwara(option.slug)}
-                      aria-pressed={selected}
-                      disabled={isRootUnavailable}
-                      style={{
-                        borderRadius: '999px',
-                        border: `1px solid ${selected ? appTheme.colors.brandSky500 : appTheme.colors.borderSubtle}`,
-                        background: selected ? appTheme.colors.bgSurface2 : appTheme.colors.bgSurface1,
-                        color: selected ? appTheme.colors.brandSky500 : appTheme.colors.textSecondary,
-                        padding: '7px 11px',
-                        fontSize: '12px',
-                        fontWeight: 700,
-                        cursor: isRootUnavailable ? 'not-allowed' : 'pointer',
-                        opacity: isRootUnavailable ? 0.6 : 1,
-                      }}
-                    >
-                      {option.label}
-                    </button>
-                  )
-                })}
+      <SurfaceCard title={selectedSkill?.display_name ?? 'Lector / editor'} elevated eyebrow="Ventana" accent={workspaceMode === 'editor' ? 'success' : 'sky'}>
+        {selectedSkill ? (
+          <div style={{ display: 'grid', gap: '14px', minWidth: 0 }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap', alignItems: 'center' }}>
+              <div style={{ display: 'grid', gap: '6px', minWidth: 0 }}>
+                <span className="text-break" style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{selectedSkill.skill_id}</span>
               </div>
-              <p style={{ margin: 0, color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                Mostrando skills globales y skills propias de <strong>{selectedMugiwaraLabel}</strong>.
-              </p>
+              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
+                <span style={{ color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 700 }}>Edición</span>
+                <StatusBadge status={mapCatalogSkillToBadgeStatus(selectedSkill)} />
+                <span style={{ color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 700 }}>Riesgo repo público</span>
+                <StatusBadge status={mapRiskToBadgeStatus(selectedSkill.public_repo_risk)} />
+                <button
+                  type="button"
+                  onClick={() => setWorkspaceMode('reader')}
+                  aria-pressed={workspaceMode === 'reader'}
+                  style={{ borderRadius: '999px', border: `1px solid ${workspaceMode === 'reader' ? appTheme.colors.brandSky500 : appTheme.colors.borderSubtle}`, background: workspaceMode === 'reader' ? appTheme.colors.bgSurface2 : 'transparent', color: workspaceMode === 'reader' ? appTheme.colors.brandSky500 : appTheme.colors.textSecondary, padding: '8px 12px', fontWeight: 700, cursor: 'pointer' }}
+                >
+                  Lector
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setWorkspaceMode('editor')}
+                  aria-pressed={workspaceMode === 'editor'}
+                  style={{ borderRadius: '999px', border: `1px solid ${workspaceMode === 'editor' ? appTheme.colors.stateSuccess : appTheme.colors.borderSubtle}`, background: workspaceMode === 'editor' ? 'rgba(63, 175, 107, 0.12)' : 'transparent', color: workspaceMode === 'editor' ? appTheme.colors.stateSuccess : appTheme.colors.textSecondary, padding: '8px 12px', fontWeight: 700, cursor: 'pointer' }}
+                >
+                  Editor
+                </button>
+              </div>
             </div>
-            {sourceNotice ? (
+
+            <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+              <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>Fuente: <strong>{selectedSkill.owner_label}</strong></span>
+              <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>bytes: <strong>{selectedSkill.fingerprint.bytes}</strong></span>
+              <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>fingerprint: <strong>{selectedSkill.fingerprint.sha256.slice(0, 12)}…</strong></span>
+            </div>
+
+            {workspaceMode === 'reader' ? (
+              <div style={{ borderRadius: '16px', border: `1px solid ${appTheme.colors.borderSubtle}`, background: appTheme.colors.bgSurface1, padding: '18px', minWidth: 0, maxHeight: '68vh', overflowY: 'auto' }}>
+                <MarkdownReader content={selectedSkill.content} />
+              </div>
+            ) : (
+              <div style={{ display: 'grid', gap: '12px', minWidth: 0 }}>
+                <div className="layout-grid layout-grid--cards-180" style={{ gap: '10px' }}>
+                  <label style={{ display: 'grid', gap: '6px', minWidth: 0 }}>
+                    <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Actor visible</span>
+                    <input
+                      id="skills-actor-input"
+                      type="text"
+                      value={actorInput}
+                      onChange={(event) => setActorInput(event.target.value)}
+                      placeholder="zoro"
+                      disabled={saveState === 'saving' || !selectedSkill.editable}
+                      style={{ borderRadius: '12px', border: `1px solid ${appTheme.colors.borderSubtle}`, background: appTheme.colors.bgSurface1, color: appTheme.colors.textPrimary, padding: '12px 14px' }}
+                    />
+                  </label>
+                  <div style={{ display: 'grid', gap: '6px', minWidth: 0 }}>
+                    <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Estado del borrador</span>
+                    <strong style={{ color: hasDraftChanges ? appTheme.colors.stateWarning : appTheme.colors.stateSuccess }}>{hasDraftChanges ? 'cambios pendientes' : 'sin cambios'}</strong>
+                    {draftSummary ? <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>líneas {formatSignedDelta(draftSummary.lineDelta)} · chars {formatSignedDelta(draftSummary.charDelta)}</span> : null}
+                  </div>
+                  <div style={{ display: 'grid', gap: '6px', minWidth: 0 }}>
+                    <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Guardado</span>
+                    <StatusBadge status={getSaveStateStatus(saveState)} />
+                  </div>
+                </div>
+
+                <textarea
+                  value={draftContent}
+                  onChange={(event) => handleDraftChange(event.target.value)}
+                  readOnly={!selectedSkill.editable}
+                  disabled={saveState === 'saving'}
+                  style={{ minHeight: '420px', borderRadius: '16px', border: `1px solid ${selectedSkill.editable ? appTheme.colors.stateSuccess : appTheme.colors.borderSubtle}`, background: appTheme.colors.bgSurface1, color: appTheme.colors.textSecondary, padding: '16px', resize: 'vertical', fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', lineHeight: 1.5 }}
+                />
+
+                <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+                  <button type="button" onClick={handlePreviewDiff} disabled={!selectedSkill.editable || !hasDraftChanges || previewState === 'loading' || saveState === 'saving'} style={{ borderRadius: '999px', border: 'none', padding: '10px 16px', cursor: !hasDraftChanges ? 'not-allowed' : 'pointer', background: appTheme.colors.brandBlue700, color: appTheme.colors.textPrimary, fontWeight: 700, opacity: !selectedSkill.editable || !hasDraftChanges ? 0.55 : 1 }}>
+                    {previewState === 'loading' ? 'Calculando diff…' : 'Preview de diff'}
+                  </button>
+                  <button type="button" onClick={handleSaveSkill} disabled={!canSave} style={{ borderRadius: '999px', border: 'none', padding: '10px 16px', cursor: canSave ? 'pointer' : 'not-allowed', background: appTheme.colors.stateSuccess, color: appTheme.colors.textPrimary, fontWeight: 700, opacity: canSave ? 1 : 0.55 }}>
+                    {saveState === 'saving' ? 'Guardando…' : 'Guardar skill'}
+                  </button>
+                  <button type="button" onClick={handleResetDraft} disabled={!hasDraftChanges || saveState === 'saving'} style={{ borderRadius: '999px', border: `1px solid ${appTheme.colors.borderSubtle}`, background: 'transparent', color: appTheme.colors.textSecondary, padding: '10px 16px', cursor: hasDraftChanges ? 'pointer' : 'not-allowed', fontWeight: 700 }}>
+                    Reset
+                  </button>
+                  <button type="button" onClick={handleReloadSkill} disabled={saveState === 'saving'} style={{ borderRadius: '999px', border: `1px solid ${appTheme.colors.borderSubtle}`, background: 'transparent', color: appTheme.colors.brandSky500, padding: '10px 16px', cursor: 'pointer', fontWeight: 700 }}>
+                    Recargar
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {previewResponse ? (
               <StatePanel
-                status={sourceNotice.status}
-                title={isRootUnavailable ? 'Catálogo bloqueado por fuente raíz' : sourceNotice.title}
-                description={
-                  isRootUnavailable
-                    ? 'No hay catálogo real que seleccionar en este estado. La causa se explica arriba; aquí solo se mantiene el hueco de navegación sin duplicar el diagnóstico.'
-                    : sourceNotice.description
-                }
-                detail={isRootUnavailable ? null : sourceNotice.detail}
-                eyebrow="Catálogo"
+                status="revision"
+                title="Preview de diff calculado"
+                description={`Añadidas ${previewResponse.diff_summary.lines_added}; eliminadas ${previewResponse.diff_summary.lines_removed}; hunks ${previewResponse.diff_summary.hunks}.`}
+                detail={previewResponse.diff_summary.truncated ? 'Preview truncado.' : 'Preview completo dentro del límite.'}
+                eyebrow="Diff"
+              >
+                <pre className="responsive-code" style={{ margin: 0, padding: '12px', borderRadius: '12px', background: appTheme.colors.bgSurface1, color: appTheme.colors.textSecondary }}>
+                  {previewResponse.diff_summary.preview.join('\n')}
+                </pre>
+              </StatePanel>
+            ) : null}
+
+            {previewState === 'error' || saveMessage ? (
+              <StatePanel
+                status={previewState === 'error' || saveState === 'error' || saveState === 'stale' ? 'incidencia' : 'operativo'}
+                title={previewState === 'error' ? 'No se pudo calcular el preview' : saveState === 'success' ? 'Guardado aplicado' : saveState === 'stale' ? 'Fingerprint desactualizado' : 'Estado de edición'}
+                description={previewState === 'error' ? previewError ?? 'Error saneado.' : saveMessage ?? 'Sin mensaje.'}
+                detail={lastSavedAudit ? `audit ${formatTimestamp(lastSavedAudit.timestamp)} · ${lastSavedAudit.result}` : null}
+                eyebrow="Feedback"
+                ariaRole={previewState === 'error' || saveState === 'error' || saveState === 'stale' ? 'alert' : 'status'}
               />
             ) : null}
 
-            {visibleCatalog.map((skill) => {
-              const isSelected = skill.skill_id === selectedSkillId
-
-              return (
-                <button
-                  key={skill.skill_id}
-                  type="button"
-                  onClick={() => {
-                    setSelectedSkillId(skill.skill_id)
-                    setSelectedSkill(null)
-                  }}
-                  aria-pressed={isSelected}
-                  style={{
-                    textAlign: 'left',
-                    borderRadius: '12px',
-                    padding: '12px',
-                    cursor: 'pointer',
-                    border: `1px solid ${isSelected ? appTheme.colors.brandSky500 : skill.editable ? appTheme.colors.stateSuccess : appTheme.colors.borderSubtle}`,
-                    background: isSelected ? appTheme.colors.bgSurface2 : appTheme.colors.bgSurface1,
-                    color: appTheme.colors.textPrimary,
-                    display: 'grid',
-                    gap: '8px',
-                    boxShadow: skill.editable ? `inset 3px 0 0 ${appTheme.colors.stateSuccess}` : 'none',
-                  }}
-                >
-                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
-                    <strong>{skill.display_name}</strong>
-                    <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>{skill.owner_label}</span>
-                    <StatusBadge status={mapCatalogSkillToBadgeStatus(skill)} />
-                  </div>
-                  <span className="text-break" style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{skill.skill_id}</span>
-                  <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                    <span
-                      style={{
-                        borderRadius: '999px',
-                        padding: '4px 10px',
-                        border: `1px solid ${appTheme.colors.borderSubtle}`,
-                        color: skill.editable ? appTheme.colors.stateSuccess : appTheme.colors.brandSky500,
-                        background: skill.editable ? 'rgba(63, 175, 107, 0.12)' : 'transparent',
-                        fontSize: '12px',
-                        fontWeight: 600,
-                      }}
-                    >
-                      {getSkillExposureLabel(skill.editable ? 'allowlisted-edit' : 'read-only-reference')}
-                    </span>
-                    <StatusBadge status={mapRiskToBadgeStatus(skill.public_repo_risk)} />
-                  </div>
-                  <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>
-                    {skill.editable
-                      ? 'Permite editar borrador, calcular diff y guardar con auditoría visible.'
-                      : 'Se consulta como referencia; no abre flujo productivo de guardado.'}
-                  </span>
-                </button>
-              )
-            })}
+            {latestAudit ? (
+              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', color: appTheme.colors.textMuted, fontSize: '12px' }}>
+                <span>Última auditoría: <strong style={{ color: appTheme.colors.textSecondary }}>{formatTimestamp(latestAudit.timestamp)}</strong></span>
+                <span>actor: <strong style={{ color: appTheme.colors.textSecondary }}>{latestAudit.actor}</strong></span>
+                <span>resultado: <strong style={{ color: appTheme.colors.textSecondary }}>{latestAudit.result}</strong></span>
+              </div>
+            ) : null}
           </div>
-        </SurfaceCard>
-
-        <div style={{ display: 'grid', gap: '14px' }}>
-          <SurfaceCard
-            title={isRootUnavailable ? 'Editor bloqueado' : selectedSkill?.editable ? 'Editor allowlisted' : selectedSkill ? 'Detalle de referencia' : 'Editor allowlisted'}
-            elevated
-            eyebrow={isRootUnavailable ? 'En espera' : selectedSkill?.editable ? 'Forja' : selectedSkill ? 'Referencia' : 'Forja'}
-            accent={isRootUnavailable ? 'sky' : selectedSkill?.editable ? 'success' : selectedSkill ? 'sky' : 'success'}
-          >
-            {selectedSkill ? (
-              <div style={{ display: 'grid', gap: '12px' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
-                  <strong style={{ fontSize: '18px' }}>{selectedSkill.display_name}</strong>
-                  <StatusBadge status={mapCatalogSkillToBadgeStatus(selectedSkill)} />
-                </div>
-
-                <div
-                  style={{
-                    display: 'grid',
-                    gap: '10px',
-                    padding: '14px',
-                    borderRadius: '12px',
-                    border: `1px solid ${selectedSkill.editable ? appTheme.colors.stateSuccess : appTheme.colors.borderSubtle}`,
-                    background: selectedSkill.editable ? 'rgba(63, 175, 107, 0.08)' : appTheme.colors.bgSurface1,
-                  }}
-                >
-                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap', alignItems: 'center' }}>
-                    <span style={{ color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 700 }}>Modo activo</span>
-                    <span
-                      style={{
-                        borderRadius: '999px',
-                        padding: '4px 10px',
-                        border: `1px solid ${appTheme.colors.borderSubtle}`,
-                        color: selectedSkill.editable ? appTheme.colors.stateSuccess : appTheme.colors.textSecondary,
-                        fontSize: '12px',
-                        fontWeight: 700,
-                      }}
-                    >
-                      {selectedSkill.editable ? 'Edición controlada' : 'Referencia read-only'}
-                    </span>
-                  </div>
-                  <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
-                    {selectedSkill.editable
-                      ? 'Este panel funciona como editor productivo: permite tocar el borrador, calcular preview y guardar con auditoría visible.'
-                      : 'Esta vista conserva la lectura del contenido y el rastro auditado, pero no abre escritura productiva.'}
-                  </p>
-                  {selectedSkill.editable ? (
-                    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>Actor: <strong style={{ color: appTheme.colors.textSecondary }}>{normalizedActor || 'sin definir'}</strong></span>
-                      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>Draft: <strong style={{ color: appTheme.colors.textSecondary }}>{hasDraftChanges ? 'cambios pendientes' : 'sin cambios'}</strong></span>
-                      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>Guardar: <strong style={{ color: appTheme.colors.textSecondary }}>{canSave ? 'habilitado' : 'bloqueado'}</strong></span>
-                    </div>
-                  ) : (
-                    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>Lectura: <strong style={{ color: appTheme.colors.textSecondary }}>solo referencia</strong></span>
-                      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>Preview: <strong style={{ color: appTheme.colors.textSecondary }}>no aplica</strong></span>
-                      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>Guardado: <strong style={{ color: appTheme.colors.textSecondary }}>deshabilitado por diseño</strong></span>
-                    </div>
-                  )}
-                </div>
-
-                <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                  <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                    owner_scope: {selectedSkill.owner_scope}
-                  </span>
-                  <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                    fingerprint: {selectedSkill.fingerprint.sha256.slice(0, 12)}…
-                  </span>
-                  <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                    bytes: {selectedSkill.fingerprint.bytes}
-                  </span>
-                </div>
-
-                <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                  <span
-                    style={{
-                      borderRadius: '999px',
-                      padding: '4px 10px',
-                      border: `1px solid ${appTheme.colors.borderSubtle}`,
-                      color: selectedSkill.editable ? appTheme.colors.stateSuccess : appTheme.colors.textSecondary,
-                      fontSize: '12px',
-                      fontWeight: 600,
-                    }}
-                  >
-                    {getSkillExposureLabel(selectedSkill.editable ? 'allowlisted-edit' : 'read-only-reference')}
-                  </span>
-                  <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>
-                    {selectedSkill.editable
-                      ? 'Guardado productivo habilitado con actor visible y control de fingerprint.'
-                      : 'Skill de solo referencia: se consulta y se puede recargar, pero no abre preview ni guardado.'}
-                  </span>
-                </div>
-
-                <div style={{ display: 'grid', gap: '6px' }}>
-                  <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>repo_path allowlisted</span>
-                  <code
-                    className="responsive-code"
-                    style={{
-                      padding: '10px',
-                      borderRadius: '12px',
-                      background: appTheme.colors.bgSurface1,
-                      color: appTheme.colors.textSecondary,
-                    }}
-                  >
-                    {selectedSkill.repo_path}
-                  </code>
-                </div>
-
-                {selectedSkill.editable ? (
-                  <>
-                    <div style={{ display: 'grid', gap: '6px' }}>
-                      <label htmlFor="skills-actor-input" style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>
-                        Actor visible del guardado
-                      </label>
-                      <input
-                        id="skills-actor-input"
-                        type="text"
-                        value={actorInput}
-                        onChange={(event) => setActorInput(event.target.value)}
-                        placeholder="zoro"
-                        disabled={saveState === 'saving'}
-                        style={{
-                          borderRadius: '12px',
-                          border: `1px solid ${appTheme.colors.borderSubtle}`,
-                          background: appTheme.colors.bgSurface1,
-                          color: appTheme.colors.textPrimary,
-                          padding: '12px 14px',
-                        }}
-                      />
-                    </div>
-
-                    <div style={{ display: 'grid', gap: '6px' }}>
-                      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap', alignItems: 'center' }}>
-                        <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Editor del borrador</span>
-                        {draftSummary ? (
-                          <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>
-                            líneas {formatSignedDelta(draftSummary.lineDelta)} · chars {formatSignedDelta(draftSummary.charDelta)}
-                          </span>
-                        ) : null}
-                      </div>
-                      <textarea
-                        value={draftContent}
-                        onChange={(event) => handleDraftChange(event.target.value)}
-                        disabled={saveState === 'saving'}
-                        style={{
-                          minHeight: '240px',
-                          borderRadius: '12px',
-                          border: `1px solid ${appTheme.colors.borderSubtle}`,
-                          background: appTheme.colors.bgSurface1,
-                          color: appTheme.colors.textSecondary,
-                          padding: '14px',
-                          resize: 'vertical',
-                          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
-                        }}
-                      />
-                    </div>
-
-                    <div
-                      style={{
-                        display: 'grid',
-                        gap: '10px',
-                        padding: '12px',
-                        borderRadius: '12px',
-                        background: appTheme.colors.bgSurface1,
-                        border: `1px solid ${appTheme.colors.stateSuccess}`,
-                      }}
-                    >
-                      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
-                        <strong style={{ fontSize: '14px' }}>Acciones de edición</strong>
-                        <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>Preview antes de guardar</span>
-                      </div>
-                      <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
-                        <button
-                          type="button"
-                          onClick={handlePreviewDiff}
-                          disabled={!hasDraftChanges || previewState === 'loading' || saveState === 'saving'}
-                          style={{
-                            borderRadius: '999px',
-                            border: 'none',
-                            padding: '10px 16px',
-                            cursor: !hasDraftChanges ? 'not-allowed' : 'pointer',
-                            background: appTheme.colors.brandBlue700,
-                            color: appTheme.colors.textPrimary,
-                            fontWeight: 700,
-                            opacity: !hasDraftChanges ? 0.55 : 1,
-                          }}
-                        >
-                          {previewState === 'loading' ? 'Calculando diff…' : 'Preview de diff'}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={handleSaveSkill}
-                          disabled={!canSave}
-                          style={{
-                            borderRadius: '999px',
-                            border: 'none',
-                            padding: '10px 16px',
-                            cursor: canSave ? 'pointer' : 'not-allowed',
-                            background: appTheme.colors.stateSuccess,
-                            color: appTheme.colors.textPrimary,
-                            fontWeight: 700,
-                            opacity: canSave ? 1 : 0.55,
-                          }}
-                        >
-                          {saveState === 'saving' ? 'Guardando…' : 'Guardar skill'}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={handleResetDraft}
-                          disabled={!hasDraftChanges || saveState === 'saving'}
-                          style={{
-                            borderRadius: '999px',
-                            border: `1px solid ${appTheme.colors.borderSubtle}`,
-                            padding: '10px 16px',
-                            cursor: !hasDraftChanges ? 'not-allowed' : 'pointer',
-                            background: appTheme.colors.bgSurface1,
-                            color: appTheme.colors.textSecondary,
-                            fontWeight: 700,
-                            opacity: !hasDraftChanges ? 0.55 : 1,
-                          }}
-                        >
-                          Reset borrador
-                        </button>
-                        <button
-                          type="button"
-                          onClick={handleReloadSkill}
-                          disabled={saveState === 'saving'}
-                          style={{
-                            borderRadius: '999px',
-                            border: `1px solid ${appTheme.colors.borderSubtle}`,
-                            padding: '10px 16px',
-                            cursor: 'pointer',
-                            background: appTheme.colors.bgSurface2,
-                            color: appTheme.colors.textSecondary,
-                            fontWeight: 700,
-                          }}
-                        >
-                          Recargar skill
-                        </button>
-                      </div>
-                    </div>
-
-                    {!hasDraftChanges ? (
-                      <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
-                        Modifica el borrador para habilitar preview y guardado controlado.
-                      </p>
-                    ) : !normalizedActor ? (
-                      <p style={{ margin: 0, color: appTheme.colors.stateDanger }}>
-                        El actor visible es obligatorio para poder guardar y auditar la operación.
-                      </p>
-                    ) : null}
-                  </>
-                ) : (
-                  <>
-                    <div style={{ display: 'grid', gap: '6px' }}>
-                      <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Contenido de referencia</span>
-                      <textarea
-                        value={draftContent}
-                        readOnly
-                        style={{
-                          minHeight: '240px',
-                          borderRadius: '12px',
-                          border: `1px solid ${appTheme.colors.borderSubtle}`,
-                          background: appTheme.colors.bgSurface2,
-                          color: appTheme.colors.textSecondary,
-                          padding: '14px',
-                          resize: 'vertical',
-                          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
-                        }}
-                      />
-                    </div>
-
-                    <div
-                      style={{
-                        display: 'grid',
-                        gap: '10px',
-                        padding: '12px',
-                        borderRadius: '12px',
-                        background: appTheme.colors.bgSurface1,
-                        border: `1px solid ${appTheme.colors.borderSubtle}`,
-                      }}
-                    >
-                      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
-                        <strong style={{ fontSize: '14px' }}>Acciones disponibles</strong>
-                        <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>Lectura y sincronización</span>
-                      </div>
-                      <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
-                        <button
-                          type="button"
-                          onClick={handleReloadSkill}
-                          disabled={saveState === 'saving'}
-                          style={{
-                            borderRadius: '999px',
-                            border: `1px solid ${appTheme.colors.borderSubtle}`,
-                            padding: '10px 16px',
-                            cursor: saveState === 'saving' ? 'not-allowed' : 'pointer',
-                            background: appTheme.colors.bgSurface2,
-                            color: appTheme.colors.textSecondary,
-                            fontWeight: 700,
-                            opacity: saveState === 'saving' ? 0.55 : 1,
-                          }}
-                        >
-                          Recargar skill
-                        </button>
-                      </div>
-                    </div>
-
-                    <StatePanel
-                      status="revision"
-                      title="Skill de referencia"
-                      description="Este detalle forma parte del catálogo visible, pero no pertenece a la frontera productiva de edición del MVP."
-                      eyebrow="Solo lectura"
-                    />
-                  </>
-                )}
-              </div>
-            ) : viewState === 'ready' ? (
-              <StatePanel
-                status="sin-datos"
-                title="Sin skill seleccionada"
-                description="Selecciona una entrada del catálogo allowlisted para cargar su detalle real y habilitar el flujo controlado de preview/guardado."
-                eyebrow="Estado vacío"
-              />
-            ) : (
-              <StatePanel
-                status={sourceNotice?.status ?? 'revision'}
-                title={isRootUnavailable ? 'Editor deshabilitado hasta conectar Skills' : sourceNotice?.title ?? 'Detalle pendiente de fuente real'}
-                description={
-                  isRootUnavailable
-                    ? 'Sin catálogo real no se muestra editor, detalle ni referencia productiva. La acción principal es resolver la conexión de fuente, no seleccionar una skill.'
-                    : sourceNotice?.description ?? 'El detalle aparecerá aquí cuando la fuente real esté disponible.'
-                }
-                detail={isRootUnavailable ? null : sourceNotice?.detail ?? null}
-                eyebrow="Estado de detalle"
-              />
-            )}
-          </SurfaceCard>
-
-          <SurfaceCard title="Preview, conflicto y auditoría" elevated eyebrow="Cierre" accent="gold">
-            <div style={{ display: 'grid', gap: '10px' }}>
-              <div
-                style={{
-                  display: 'grid',
-                  gap: '8px',
-                  paddingBottom: '10px',
-                  borderBottom: `1px solid ${appTheme.colors.borderSubtle}`,
-                }}
-              >
-                <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
-                  <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>Estado de operación</span>
-                  <StatusBadge status={getSaveStateStatus(saveState)} />
-                </div>
-                <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                  Actor visible: <strong>{isRootUnavailable ? 'no aplica' : normalizedActor || 'sin definir'}</strong>
-                </span>
-                <span style={{ color: saveState === 'error' ? appTheme.colors.stateDanger : appTheme.colors.textSecondary, fontSize: '13px' }}>
-                  {isRootUnavailable ? 'Sin operación disponible hasta conectar la fuente real de Skills.' : saveMessage ?? 'Todavía no se ha ejecutado un guardado en esta selección.'}
-                </span>
-                {saveState === 'stale' ? (
-                  <span style={{ color: appTheme.colors.stateStale, fontSize: '13px' }}>
-                    El backend rechazó el guardado por fingerprint desactualizado. Recarga la skill para volver a sincronizar el
-                    contenido allowlisted antes de reintentar.
-                  </span>
-                ) : null}
-                {lastSavedAudit ? (
-                  <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>
-                    Último guardado: {formatTimestamp(lastSavedAudit.timestamp)} · resultado {lastSavedAudit.result}
-                  </span>
-                ) : null}
-              </div>
-
-              {previewState === 'error' && previewError ? (
-                <StatePanel
-                  status="incidencia"
-                  title="Preview no disponible"
-                  description="El backend no pudo calcular el diff solicitado. La UI mantiene el estado explícito para evitar errores silenciosos."
-                  detail={previewError}
-                  eyebrow="Estado de preview"
-                />
-              ) : null}
-
-              {isRootUnavailable ? (
-                <StatePanel
-                  status={sourceNotice?.status ?? 'revision'}
-                  title="Preview y auditoría en espera de fuente real"
-                  description="No hay skill editable, preview ni rastro auditado que consultar hasta que el catálogo real esté conectado. El panel queda visible como contexto secundario, no como llamada a la acción."
-                  eyebrow="Estado bloqueado"
-                />
-              ) : previewResponse ? (
-                <>
-                  <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
-                    <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                      Diff: +{previewResponse.diff_summary.lines_added} / -{previewResponse.diff_summary.lines_removed}
-                    </span>
-                    <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                      hunks: {previewResponse.diff_summary.hunks}
-                    </span>
-                    <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>
-                      after: {previewResponse.after.sha256.slice(0, 12)}…
-                    </span>
-                  </div>
-                  <pre
-                    className="responsive-code"
-                    style={{
-                      margin: 0,
-                      padding: '14px',
-                      borderRadius: '12px',
-                      background: appTheme.colors.bgSurface1,
-                      color: appTheme.colors.textSecondary,
-                      maxHeight: '260px',
-                    }}
-                  >
-                    {previewResponse.diff_summary.preview.join('\n') || 'Sin preview textual disponible.'}
-                  </pre>
-                </>
-              ) : previewState === 'error' ? null : (
-                <StatePanel
-                  status={selectedSkill?.editable ? 'sin-datos' : 'revision'}
-                  title={selectedSkill?.editable ? 'Sin preview solicitado todavía' : 'Preview deshabilitado para esta skill'}
-                  description={
-                    selectedSkill?.editable
-                      ? 'El preview de diff aparecerá aquí cuando prepares cambios sobre una skill editable y lo solicites al backend.'
-                      : 'Las skills de solo referencia muestran contenido, pero no exponen preview de diff ni guardado productivo.'
-                  }
-                  eyebrow="Estado vacío"
-                />
-              )}
-
-              <div
-                style={{
-                  borderTop: `1px solid ${appTheme.colors.borderSubtle}`,
-                  paddingTop: '10px',
-                  display: 'grid',
-                  gap: '10px',
-                }}
-              >
-                {isRootUnavailable ? null : latestAudit ? (
-                  <>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
-                      <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                        Último actor: <strong>{latestAudit.actor}</strong>
-                      </span>
-                      <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>
-                        {formatTimestamp(latestAudit.timestamp)}
-                      </span>
-                    </div>
-                    <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                      Resultado auditado: <strong>{latestAudit.result}</strong>
-                    </span>
-                    <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                      Último diff: +{latestAudit.diff_summary.lines_added} / -{latestAudit.diff_summary.lines_removed} · hunks {latestAudit.diff_summary.hunks}
-                    </span>
-                    {latestAudit.reason ? (
-                      <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                        Motivo auditado: <strong>{latestAudit.reason}</strong>
-                      </span>
-                    ) : null}
-                  </>
-                ) : (
-                  <StatePanel
-                    status="sin-datos"
-                    title="Sin auditoría resumida visible"
-                    description="Todavía no hay rastro auditado para la skill seleccionada o la fuente sigue vacía. La ausencia se expresa de forma explícita para no confundirla con un fallo silencioso."
-                    eyebrow="Estado vacío"
-                  />
-                )}
-              </div>
-            </div>
-          </SurfaceCard>
-        </div>
-      </section>
+        ) : (
+          <StatePanel status="sin-datos" title="Selecciona una skill" description="Elige primero una fuente y después una skill para abrir el lector/editor." eyebrow="Sin selección" />
+        )}
+      </SurfaceCard>
     </>
   )
 }

--- a/docs/skills-surface.md
+++ b/docs/skills-surface.md
@@ -49,7 +49,13 @@ Campos mínimos por entrada:
 - `editable_sections` si se quiere granularidad futura
 - `public_repo_risk`
 
-La página `/skills` debe permitir seleccionar Mugiwara y mostrar simultáneamente las skills globales y las skills propias del Mugiwara seleccionado.
+La página `/skills` debe evitar listados largos por defecto. El flujo de lectura/edición es:
+1. seleccionar una fuente (`global` o un Mugiwara allowlisteado);
+2. elegir una skill de esa fuente en un desplegable filtrado;
+3. abrir una única ventana de trabajo para esa skill;
+4. alternar entre modo lector y modo editor.
+
+El modo lector debe renderizar Markdown de forma legible. El modo editor conserva la escritura controlada mediante BFF same-origin y backend allowlist. No deben reintroducirse contenedores informativos sin acción directa que compitan con el selector y la ventana de trabajo.
 
 Decisión operativa: colocar una skill nueva bajo `skills-source/global` o `skills-source/agents/<mugiwara>` la incorpora al catálogo editable del panel si cumple el contrato `SKILL.md` y el slug de Mugiwara está allowlisteado. Si una skill debe ser solo referencia, debe declararse explícitamente como runtime/read-only o quedar fuera de esa superficie hasta que exista política granular.
 

--- a/openspec/phase-19-2-skills-picker-reader-editor-verify-checklist.md
+++ b/openspec/phase-19-2-skills-picker-reader-editor-verify-checklist.md
@@ -1,0 +1,36 @@
+# Phase 19.2 verify checklist — Skills picker reader/editor
+
+## Functional
+- [x] Old informational containers `Contrato`, `Enlace` and `Rastro` are absent from `/skills`.
+- [x] Source selector includes `Globales` and each Mugiwara source with counts.
+- [x] Skill selector is filtered by the selected source.
+- [x] Selecting `global` changes the skill list to global skills only.
+- [x] Selecting a skill opens a focused reader/editor window.
+- [x] Reader mode renders Markdown headings, lists, paragraphs and code blocks.
+- [x] Editor mode remains available from the same window.
+
+## Security / architecture
+- [x] Browser still uses BFF same-origin endpoints.
+- [x] Backend URL remains server-only.
+- [x] No client-side filesystem path construction was introduced.
+- [x] Existing backend allowlist and skill ID validation remain unchanged.
+
+## Commands
+- [x] `npm --prefix apps/web run typecheck`
+- [x] `npm --prefix apps/web run build`
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_skills_api.py apps/api/tests/test_mugiwaras_api.py -q`
+- [x] `npm run verify:skills-server-only`
+- [x] `npm run verify:visual-baseline`
+- [x] `git diff --check`
+
+## Browser smoke
+- [x] Local production server on `127.0.0.1:3020` served `/skills?mugiwara=franky` with HTTP 200.
+- [x] Visual inspection confirmed selector + dropdown + reader/editor window.
+- [x] Console had no JavaScript errors.
+- [x] Source switching to `global` produced a 15-item global skill dropdown.
+- [x] Editor toggle opened editable controls.
+
+## Pending before close
+- [ ] PR review handoff.
+- [ ] Merge/deploy if approved or explicitly requested.
+- [ ] Production smoke after deploy.

--- a/openspec/phase-19-2-skills-picker-reader-editor.md
+++ b/openspec/phase-19-2-skills-picker-reader-editor.md
@@ -1,0 +1,34 @@
+# Phase 19.2 — Skills picker reader/editor
+
+## Context
+Pablo rejected the previous `/skills` layout because it still exposed long lists and non-actionable informational containers. The target UX is a compact mobile-friendly flow: choose a source, choose a skill, then read or edit that skill in one focused window.
+
+## Goals
+- Remove non-actionable informational containers from `/skills`.
+- Avoid showing an infinite list of global skills by default.
+- Let the user select either `global` or a Mugiwara as the active source.
+- Show a filtered skill dropdown for the selected source.
+- Open a single reader/editor window for the selected skill.
+- Let the user switch between reader and editor modes.
+- Render Markdown in reader mode.
+- Preserve the existing same-origin BFF and backend allowlist security model.
+
+## Non-goals
+- No new backend write surface.
+- No arbitrary filesystem browsing from the browser.
+- No bulk skill operations.
+- No public exposure of backend URL or raw server paths beyond existing metadata contract.
+
+## Implementation notes
+- `/skills` is client-side for source/skill selection and reader/editor state.
+- Skill content still comes from the existing BFF endpoints.
+- Markdown rendering is intentionally local and conservative for headings, lists, paragraphs, code blocks and inline formatting.
+- The editor path keeps preview/save controls and audit metadata from the existing MVP.
+
+## Verification
+- TypeScript typecheck.
+- Next.js production build.
+- API regression tests for skills and Mugiwaras.
+- BFF guardrail check.
+- Visual baseline checklist plus browser smoke on `/skills?mugiwara=franky`.
+- Console clean during browser smoke.


### PR DESCRIPTION
## Qué cambia
- Rediseña `/skills` para eliminar los contenedores informativos sin acción directa.
- Sustituye los listados largos por selector de fuente (`Globales` o Mugiwara) + desplegable filtrado de skills.
- Añade una única ventana de trabajo con toggle `Lector` / `Editor`.
- Renderiza Markdown en modo lector con un renderer conservador local.
- Mantiene el editor, preview/save y auditoría sobre el BFF same-origin existente.
- Actualiza docs, OpenSpec y closeout Engram de la fase 19.2.

## Por qué
Pablo pidió evitar el listado infinito de globales, poder seleccionar global o cada Mugiwara, elegir una skill en desplegable y ver entonces lector/editor con Markdown renderizado.

## Verificación de Zoro
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build`
- `PYTHONPATH=. pytest apps/api/tests/test_skills_api.py apps/api/tests/test_mugiwaras_api.py -q` → 12 passed
- `npm run verify:skills-server-only`
- `npm run verify:visual-baseline`
- `git diff --check`
- Browser smoke local: `http://127.0.0.1:3020/skills?mugiwara=franky`
  - sin contenedores antiguos `Contrato/Enlace/Rastro`
  - selector de fuente y desplegable de skill visibles
  - cambio a `global` genera dropdown de 15 skills globales
  - lector Markdown visible
  - toggle a editor funcional
  - consola sin errores

## Riesgo
- UI/UX visible en una pantalla principal del panel privado.
- Sin nueva superficie backend ni filesystem libre en cliente.
- El renderer Markdown es conservador y local; no busca compatibilidad completa GitHub-flavored Markdown.

## Review solicitada
- Usopp: UI/UX, jerarquía, móvil/responsive y claridad del nuevo flujo.
- Chopper: confirmar que no se amplía superficie de edición ni se rompe el guardrail BFF/server-only.
