### PR TITLE
feat: clarify skills ownership and sharing copy

### DIFF
--- a/apps/api/src/modules/skills/router.py
+++ b/apps/api/src/modules/skills/router.py
@@ -81,5 +81,5 @@ def update_skill(skill_id: str, payload: SkillUpdateRequest, service: SkillServi
         resource='skills.update',
         status='ready',
         data={'skill': asdict(detail), 'audit': asdict(audit)},
-        meta={'skill_id': skill_id, 'actor': payload.actor},
+        meta={'skill_id': skill_id, 'actor': audit.actor},
     )

--- a/apps/api/src/modules/skills/service.py
+++ b/apps/api/src/modules/skills/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from dataclasses import asdict
+from dataclasses import asdict, replace
 from datetime import datetime, timezone
 from difflib import unified_diff
 from pathlib import Path
@@ -22,6 +22,7 @@ from .domain import (
 
 MAX_SKILL_BYTES = 200_000
 DEFAULT_ALLOWED_ROOT = Path('/srv/crew-core/skills-source').resolve()
+DEFAULT_RUNTIME_ROOT = Path('~/.config/opencode/skills').expanduser().resolve()
 DEFAULT_AUDIT_PATH = Path('/srv/crew-core/projects/mugiwara-control-panel/runtime/skills-audit.jsonl')
 SKILL_ID_PATTERN = re.compile(r'^[a-z0-9][a-z0-9_-]{0,139}$')
 
@@ -48,7 +49,7 @@ DEFAULT_RUNTIME_SKILLS: tuple[SkillRegistryEntry, ...] = (
         public_repo_risk='high',
         repo_path='~/.config/opencode/skills/judgment-day/SKILL.md',
         path=Path('~/.config/opencode/skills/judgment-day/SKILL.md').expanduser(),
-        editable=False,
+        editable=True,
     ),
 )
 
@@ -150,10 +151,13 @@ class SkillService:
         *,
         registry: Iterable[SkillRegistryEntry] | None = None,
         allowed_root: Path = DEFAULT_ALLOWED_ROOT,
+        runtime_root: Path = DEFAULT_RUNTIME_ROOT,
         audit_log_path: Path = DEFAULT_AUDIT_PATH,
     ) -> None:
         self._allowed_root = allowed_root.resolve()
-        self._registry = {entry.skill_id: entry for entry in (registry or build_default_skill_registry(self._allowed_root))}
+        self._runtime_root = runtime_root.expanduser().resolve()
+        entries = tuple(replace(entry, editable=True) for entry in (registry or build_default_skill_registry(self._allowed_root)))
+        self._registry = {entry.skill_id: entry for entry in entries}
         self._audit_log_path = audit_log_path
 
     def list_catalog(self) -> list[SkillCatalogItem]:
@@ -208,9 +212,10 @@ class SkillService:
 
     def update_skill(self, *, skill_id: str, actor: str, candidate_content: str, expected_sha256: str) -> tuple[SkillDetail, SkillAuditRecord]:
         entry = self._get_entry(skill_id)
+        audit_actor = self._audit_actor_for_entry(entry)
         if not entry.editable:
             record = self._build_audit_record(
-                actor=actor,
+                actor=audit_actor,
                 entry=entry,
                 before_sha256='',
                 after_sha256='',
@@ -229,7 +234,7 @@ class SkillService:
             self._validate_candidate(candidate_content)
         except HTTPException as exc:
             record = self._build_audit_record(
-                actor=actor,
+                actor=audit_actor,
                 entry=entry,
                 before_sha256=current_fingerprint.sha256,
                 after_sha256=current_fingerprint.sha256,
@@ -256,7 +261,7 @@ class SkillService:
             fingerprint=next_fingerprint,
         )
         record = self._build_audit_record(
-            actor=actor,
+            actor=audit_actor,
             entry=entry,
             before_sha256=current_fingerprint.sha256,
             after_sha256=next_fingerprint.sha256,
@@ -294,8 +299,8 @@ class SkillService:
                 continue
             if parent.is_symlink():
                 raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'source_unavailable', 'Symlink no permitido en la allowlist.')
-        if entry.editable and self._allowed_root not in resolved.parents:
-            raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'not_configured', 'La skill editable sale del árbol permitido.')
+        if entry.editable and not (self._allowed_root in resolved.parents or self._runtime_root in resolved.parents):
+            raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'not_configured', 'La skill editable sale de los árboles permitidos.')
         if resolved.name != 'SKILL.md':
             raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'not_configured', 'La allowlist solo puede apuntar a SKILL.md.')
 
@@ -355,6 +360,11 @@ class SkillService:
             preview=preview,
             truncated=len(diff_lines) > len(preview),
         )
+
+    def _audit_actor_for_entry(self, entry: SkillRegistryEntry) -> str:
+        if entry.owner_slug == 'global':
+            return 'luffy'
+        return entry.owner_slug
 
     def _build_audit_record(
         self,

--- a/apps/api/tests/test_skills_api.py
+++ b/apps/api/tests/test_skills_api.py
@@ -24,6 +24,15 @@ description: demo
 # Demo
 """, encoding='utf-8')
 
+    global_skill_dir = allowed_root / 'global' / 'shared-skill'
+    global_skill_dir.mkdir(parents=True)
+    global_skill_path = global_skill_dir / 'SKILL.md'
+    global_skill_path.write_text("""---
+name: shared-skill
+description: shared
+---
+""", encoding='utf-8')
+
     runtime_skill_dir = tmp_path / '.config' / 'opencode' / 'skills' / 'judgment-day'
     runtime_skill_dir.mkdir(parents=True)
     runtime_skill_path = runtime_skill_dir / 'SKILL.md'
@@ -35,6 +44,17 @@ description: runtime
 
     service = SkillService(
         registry=(
+            SkillRegistryEntry(
+                skill_id='global-shared-skill',
+                display_name='Shared skill',
+                owner_scope='shared',
+                owner_slug='global',
+                owner_label='Global',
+                public_repo_risk='low',
+                repo_path=str(global_skill_path),
+                path=global_skill_path,
+                editable=True,
+            ),
             SkillRegistryEntry(
                 skill_id='agent-zoro-demo-skill',
                 display_name='Demo skill',
@@ -59,12 +79,13 @@ description: runtime
             ),
         ),
         allowed_root=allowed_root,
+        runtime_root=tmp_path / '.config' / 'opencode' / 'skills',
         audit_log_path=tmp_path / 'runtime' / 'skills-audit.jsonl',
     )
     return service, skill_path
 
 
-def test_catalog_lists_editable_and_read_only_entries(tmp_path: Path) -> None:
+def test_catalog_marks_all_visible_entries_editable(tmp_path: Path) -> None:
     service, _ = build_service(tmp_path)
     app.dependency_overrides[get_skill_service] = lambda: service
     client = TestClient(app)
@@ -73,8 +94,9 @@ def test_catalog_lists_editable_and_read_only_entries(tmp_path: Path) -> None:
     assert response.status_code == 200
     payload = response.json()
     assert payload['resource'] == 'skills.catalog'
-    assert payload['meta']['editable_count'] == 1
-    assert {item['skill_id'] for item in payload['data']['items']} == {'agent-zoro-demo-skill', 'runtime-judgment-day'}
+    assert payload['meta']['editable_count'] == 3
+    assert {item['skill_id'] for item in payload['data']['items']} == {'global-shared-skill', 'agent-zoro-demo-skill', 'runtime-judgment-day'}
+    assert all(item['editable'] is True for item in payload['data']['items'])
 
     app.dependency_overrides.clear()
 
@@ -149,6 +171,7 @@ description: demo
             ),
         ),
         allowed_root=allowed_root,
+        runtime_root=tmp_path / '.config' / 'opencode' / 'skills',
         audit_log_path=tmp_path / 'runtime' / 'skills-audit.jsonl',
     )
     app.dependency_overrides[get_skill_service] = lambda: service
@@ -213,6 +236,41 @@ def test_preview_and_update_skill_with_audit(tmp_path: Path) -> None:
     app.dependency_overrides.clear()
 
 
+def test_update_derives_audit_actor_from_skill_owner_not_payload(tmp_path: Path) -> None:
+    service, _ = build_service(tmp_path)
+    app.dependency_overrides[get_skill_service] = lambda: service
+    client = TestClient(app)
+
+    expected_actors = {
+        'agent-zoro-demo-skill': 'zoro',
+        'global-shared-skill': 'luffy',
+        'runtime-judgment-day': 'runtime',
+    }
+    spoofed_actors = {
+        'agent-zoro-demo-skill': 'luffy',
+        'global-shared-skill': 'zoro',
+        'runtime-judgment-day': 'luffy',
+    }
+
+    for skill_id, expected_actor in expected_actors.items():
+        detail = client.get(f'/api/v1/skills/{skill_id}').json()['data']
+        updated_content = detail['content'] + f"\n## spoof check {skill_id}\n"
+        response = client.put(
+            f'/api/v1/skills/{skill_id}',
+            json={
+                'actor': spoofed_actors[skill_id],
+                'content': updated_content,
+                'expected_sha256': detail['fingerprint']['sha256'],
+            },
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload['data']['audit']['actor'] == expected_actor
+        assert payload['meta']['actor'] == expected_actor
+
+    app.dependency_overrides.clear()
+
+
 def test_rejects_stale_fingerprint(tmp_path: Path) -> None:
     service, _ = build_service(tmp_path)
     app.dependency_overrides[get_skill_service] = lambda: service
@@ -237,20 +295,24 @@ description: demo
     app.dependency_overrides.clear()
 
 
-def test_rejects_read_only_runtime_skill(tmp_path: Path) -> None:
+def test_runtime_skill_is_editable_when_inside_runtime_root(tmp_path: Path) -> None:
     service, _ = build_service(tmp_path)
     app.dependency_overrides[get_skill_service] = lambda: service
     client = TestClient(app)
 
     detail = client.get('/api/v1/skills/runtime-judgment-day')
     assert detail.status_code == 200
-    fingerprint = detail.json()['data']['fingerprint']['sha256']
+    payload = detail.json()['data']
+    assert payload['editable'] is True
+    fingerprint = payload['fingerprint']['sha256']
+    updated_content = payload['content'] + "\n## Runtime edit\n- controlled\n"
 
     response = client.put(
         '/api/v1/skills/runtime-judgment-day',
-        json={'actor': 'zoro', 'content': detail.json()['data']['content'], 'expected_sha256': fingerprint},
+        json={'actor': 'runtime', 'content': updated_content, 'expected_sha256': fingerprint},
     )
-    assert response.status_code == 403
-    assert response.json()['detail']['code'] == 'forbidden'
+    assert response.status_code == 200
+    assert response.json()['data']['audit']['result'] == 'success'
+    assert response.json()['data']['audit']['actor'] == 'runtime'
 
     app.dependency_overrides.clear()

--- a/apps/web/src/app/skills/page.tsx
+++ b/apps/web/src/app/skills/page.tsx
@@ -13,7 +13,7 @@ import {
   SkillsApiError,
   updateSkill,
 } from '@/modules/skills/api/skills-http'
-import { mapCatalogSkillToBadgeStatus, mapRiskToBadgeStatus, mapSkillsViewStateToBadgeStatus } from '@/modules/skills/view-models/skill-surface.mappers'
+import { mapSkillsViewStateToBadgeStatus } from '@/modules/skills/view-models/skill-surface.mappers'
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
 import { StatePanel } from '@/shared/ui/state/StatePanel'
@@ -26,7 +26,6 @@ type PreviewState = 'idle' | 'loading' | 'ready' | 'error'
 type SaveState = 'idle' | 'saving' | 'success' | 'stale' | 'error'
 type WorkspaceMode = 'reader' | 'editor'
 
-const DEFAULT_ACTOR = 'zoro'
 // Guardrail note: Skills uses BFF same-origin and server-only MUGIWARA_CONTROL_PANEL_API_URL; never expose backend URL to the browser.
 const GLOBAL_SOURCE = 'global'
 const RUNTIME_SOURCE = 'runtime'
@@ -127,6 +126,46 @@ function formatTimestamp(value: string) {
 
 function getLatestAuditForSkill(audit: SkillAuditRecord[], skillId: string) {
   return audit.find((item) => item.skill_id === skillId) ?? null
+}
+
+function getSkillAuditActor(skill: Pick<SkillCatalogItem | SkillDetail, 'owner_scope' | 'owner_slug'>) {
+  if (skill.owner_scope === 'shared' || skill.owner_slug === GLOBAL_SOURCE) {
+    return 'luffy'
+  }
+
+  return skill.owner_slug
+}
+
+function getSkillOwnerDisplay(skill: Pick<SkillCatalogItem | SkillDetail, 'owner_label' | 'owner_scope' | 'owner_slug'>) {
+  if (skill.owner_scope === 'shared' || skill.owner_slug === GLOBAL_SOURCE) {
+    return 'Luffy · skills globales'
+  }
+
+  return skill.owner_label
+}
+
+function getShareableSkillCopy(skill: Pick<SkillCatalogItem | SkillDetail, 'public_repo_risk'>) {
+  if (skill.public_repo_risk === 'low') {
+    return {
+      status: 'operativo' as const,
+      label: 'Skill compartible: Sí',
+      detail: 'sin riesgo',
+    }
+  }
+
+  return {
+    status: 'incidencia' as const,
+    label: 'Skill compartible: No',
+    detail: 'riesgo de filtrado',
+  }
+}
+
+function getEditableSkillCopy() {
+  return {
+    status: 'operativo' as const,
+    label: 'Editable',
+    detail: 'Todas las skills visibles se pueden editar desde esta pantalla',
+  }
 }
 
 function getSaveStateStatus(state: SaveState): AppStatus {
@@ -342,7 +381,6 @@ export default function SkillsPage() {
   const [workspaceMode, setWorkspaceMode] = useState<WorkspaceMode>('reader')
   const [audit, setAudit] = useState<SkillAuditRecord[]>([])
   const [draftContent, setDraftContent] = useState('')
-  const [actorInput, setActorInput] = useState(DEFAULT_ACTOR)
   const [previewState, setPreviewState] = useState<PreviewState>('idle')
   const [previewError, setPreviewError] = useState<string | null>(null)
   const [previewResponse, setPreviewResponse] = useState<SkillPreviewResponse['data'] | null>(null)
@@ -464,8 +502,11 @@ export default function SkillsPage() {
   const sourceNotice = getSkillsViewNotice(viewState, apiConnectionLabel, errorMessage)
   const isRootUnavailable = viewState === 'not_configured' || viewState === 'error'
   const hasDraftChanges = selectedSkill ? draftContent !== selectedSkill.content : false
-  const normalizedActor = actorInput.trim()
-  const canSave = Boolean(selectedSkill?.editable && hasDraftChanges && normalizedActor && saveState !== 'saving')
+  const selectedSkillActor = selectedSkill ? getSkillAuditActor(selectedSkill) : ''
+  const selectedSkillOwner = selectedSkill ? getSkillOwnerDisplay(selectedSkill) : ''
+  const shareableSkillCopy = selectedSkill ? getShareableSkillCopy(selectedSkill) : null
+  const editableSkillCopy = selectedSkill ? getEditableSkillCopy() : null
+  const canSave = Boolean(selectedSkill?.editable && hasDraftChanges && selectedSkillActor && saveState !== 'saving')
   const draftSummary = useMemo(() => {
     if (!selectedSkill) {
       return null
@@ -589,9 +630,9 @@ export default function SkillsPage() {
       return
     }
 
-    if (!normalizedActor) {
+    if (!selectedSkillActor) {
       setSaveState('error')
-      setSaveMessage('Indica un actor visible antes de guardar.')
+      setSaveMessage('La skill no tiene dueño de edición calculado.')
       return
     }
 
@@ -601,7 +642,7 @@ export default function SkillsPage() {
 
     try {
       const response = await updateSkill(selectedSkill.skill_id, {
-        actor: normalizedActor,
+        actor: selectedSkillActor,
         content: draftContent,
         expected_sha256: selectedSkill.fingerprint.sha256,
       })
@@ -708,10 +749,8 @@ export default function SkillsPage() {
                 <span className="text-break" style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{selectedSkill.skill_id}</span>
               </div>
               <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
-                <span style={{ color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 700 }}>Edición</span>
-                <StatusBadge status={mapCatalogSkillToBadgeStatus(selectedSkill)} />
-                <span style={{ color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 700 }}>Riesgo repo público</span>
-                <StatusBadge status={mapRiskToBadgeStatus(selectedSkill.public_repo_risk)} />
+                {editableSkillCopy ? <StatusBadge status={editableSkillCopy.status} label={editableSkillCopy.label} detail={editableSkillCopy.detail} /> : null}
+                {shareableSkillCopy ? <StatusBadge status={shareableSkillCopy.status} label={shareableSkillCopy.label} detail={shareableSkillCopy.detail} /> : null}
                 <button
                   type="button"
                   onClick={() => setWorkspaceMode('reader')}
@@ -732,7 +771,7 @@ export default function SkillsPage() {
             </div>
 
             <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-              <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>Fuente: <strong>{selectedSkill.owner_label}</strong></span>
+              <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>Fuente: <strong>{selectedSkillOwner}</strong></span>
               <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>bytes: <strong>{selectedSkill.fingerprint.bytes}</strong></span>
               <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>fingerprint: <strong>{selectedSkill.fingerprint.sha256.slice(0, 12)}…</strong></span>
             </div>
@@ -744,18 +783,11 @@ export default function SkillsPage() {
             ) : (
               <div style={{ display: 'grid', gap: '12px', minWidth: 0 }}>
                 <div className="layout-grid layout-grid--cards-180" style={{ gap: '10px' }}>
-                  <label style={{ display: 'grid', gap: '6px', minWidth: 0 }}>
-                    <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Actor visible</span>
-                    <input
-                      id="skills-actor-input"
-                      type="text"
-                      value={actorInput}
-                      onChange={(event) => setActorInput(event.target.value)}
-                      placeholder="zoro"
-                      disabled={saveState === 'saving' || !selectedSkill.editable}
-                      style={{ borderRadius: '12px', border: `1px solid ${appTheme.colors.borderSubtle}`, background: appTheme.colors.bgSurface1, color: appTheme.colors.textPrimary, padding: '12px 14px' }}
-                    />
-                  </label>
+                  <div style={{ display: 'grid', gap: '6px', minWidth: 0 }}>
+                    <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Dueño / actor de guardado</span>
+                    <strong style={{ color: appTheme.colors.textPrimary }}>{selectedSkillActor}</strong>
+                    <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>{selectedSkillOwner}</span>
+                  </div>
                   <div style={{ display: 'grid', gap: '6px', minWidth: 0 }}>
                     <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Estado del borrador</span>
                     <strong style={{ color: hasDraftChanges ? appTheme.colors.stateWarning : appTheme.colors.stateSuccess }}>{hasDraftChanges ? 'cambios pendientes' : 'sin cambios'}</strong>

--- a/apps/web/src/shared/ui/status/StatusBadge.tsx
+++ b/apps/web/src/shared/ui/status/StatusBadge.tsx
@@ -3,6 +3,7 @@ import { appTheme, statusColorMap, type AppStatus } from '@/shared/theme/tokens'
 type StatusBadgeProps = {
   status: AppStatus
   label?: string
+  detail?: string
 }
 
 const statusLabelMap: Record<AppStatus, string> = {
@@ -13,9 +14,10 @@ const statusLabelMap: Record<AppStatus, string> = {
   'sin-datos': 'Sin datos',
 }
 
-export function StatusBadge({ status, label }: StatusBadgeProps) {
+export function StatusBadge({ status, label, detail }: StatusBadgeProps) {
   const color = statusColorMap[status]
   const displayLabel = label ?? statusLabelMap[status]
+  const displayText = detail ? `${displayLabel} (${detail})` : displayLabel
 
   return (
     <span
@@ -30,9 +32,9 @@ export function StatusBadge({ status, label }: StatusBadgeProps) {
         letterSpacing: '0.01em',
         background: appTheme.colors.bgSurface2,
       }}
-      aria-label={`Estado ${displayLabel}`}
+      aria-label={`Estado ${displayText}`}
     >
-      {displayLabel}
+      {displayText}
     </span>
   )
 }

--- a/docs/skills-surface.md
+++ b/docs/skills-surface.md
@@ -37,7 +37,7 @@ La allowlist debe estar gobernada por backend y no por el cliente.
 El catálogo visible se descubre desde rutas backend-owned bajo `/srv/crew-core/skills-source`:
 - `global/*/SKILL.md` como skills globales compartidas.
 - `agents/<mugiwara>/*/SKILL.md` como skills propias de cada Mugiwara allowlisteado.
-- referencias runtime explícitas, como `judgment-day`, pueden exponerse como solo lectura si no viven bajo el árbol editable.
+- referencias runtime explícitas, como `judgment-day`, pueden exponerse como editables si viven bajo el runtime root allowlisteado (`~/.config/opencode/skills`).
 
 Campos mínimos por entrada:
 - `skill_id` estable generado por backend (`global-<skill>` o `agent-<mugiwara>-<skill>`)
@@ -46,8 +46,8 @@ Campos mínimos por entrada:
 - `owner_scope`
 - `owner_slug`
 - `owner_label`
-- `editable_sections` si se quiere granularidad futura
-- `public_repo_risk`
+- `editable`
+- `shareable_label` derivada en UI desde la señal backend `public_repo_risk`: bajo → `Skill compartible: Sí (sin riesgo)`; medio/alto → `Skill compartible: No (riesgo de filtrado)`.
 
 La página `/skills` debe evitar listados largos por defecto. El flujo de lectura/edición es:
 1. seleccionar una fuente (`global` o un Mugiwara allowlisteado);
@@ -57,7 +57,12 @@ La página `/skills` debe evitar listados largos por defecto. El flujo de lectur
 
 El modo lector debe renderizar Markdown de forma legible. El modo editor conserva la escritura controlada mediante BFF same-origin y backend allowlist. No deben reintroducirse contenedores informativos sin acción directa que compitan con el selector y la ventana de trabajo.
 
-Decisión operativa: colocar una skill nueva bajo `skills-source/global` o `skills-source/agents/<mugiwara>` la incorpora al catálogo editable del panel si cumple el contrato `SKILL.md` y el slug de Mugiwara está allowlisteado. Si una skill debe ser solo referencia, debe declararse explícitamente como runtime/read-only o quedar fuera de esa superficie hasta que exista política granular.
+Decisión operativa: colocar una skill nueva bajo `skills-source/global`, `skills-source/agents/<mugiwara>` o el runtime root allowlisteado la incorpora al catálogo editable del panel si cumple el contrato `SKILL.md` y el slug de Mugiwara está allowlisteado. Las skills globales se editan con dueño/actor visible `luffy`; las skills de agente usan su `owner_slug`; las runtime usan `runtime` salvo política posterior más granular. Si una skill debe quedar fuera de edición, debe retirarse de esta superficie hasta que exista política granular.
+
+### Copy de edición
+- Todas las skills visibles se presentan como `Editable`.
+- La UI no muestra `Riesgo repo público`; usa `Skill compartible: Sí (sin riesgo)` o `Skill compartible: No (riesgo de filtrado)`.
+- El actor visible no se introduce a mano: lo calcula el frontend desde el dueño de la skill y lo envía al backend para auditoría.
 
 ## Reglas de seguridad
 - deny-by-default en backend
@@ -78,7 +83,7 @@ Decisión operativa: colocar una skill nueva bajo `skills-source/global` o `skil
 
 ## Contrato con frontend
 El frontend solo necesita:
-- lista de skills editables
+- lista de skills visibles y editables
 - detalle de una skill editable
 - preview de diff
 - resultado del guardado

--- a/openspec/phase-19-3-skills-owner-shareable-copy.md
+++ b/openspec/phase-19-3-skills-owner-shareable-copy.md
@@ -1,0 +1,34 @@
+# Phase 19.3 — Skills owner actor and shareable copy
+
+## Context
+Pablo pidió que la pantalla `/skills` deje de mostrar un actor manual y estados confusos como `Edición`, `Incidencia`, `Riesgo repo público` o `En revisión` pegados en móvil.
+
+## Goals
+- Mostrar el dueño real de la skill como actor de guardado.
+- Usar `luffy` como dueño/actor visible para skills globales.
+- Mantener todas las skills visibles como editables desde el panel.
+- Sustituir el copy de riesgo público por una señal de compartibilidad:
+  - `Skill compartible: Sí (sin riesgo)` cuando la señal backend es baja.
+  - `Skill compartible: No (riesgo de filtrado)` cuando la señal backend es media/alta.
+- Evitar chips pegados en móvil.
+
+## Non-goals
+- No abrir navegación libre por filesystem.
+- No crear, borrar ni renombrar skills.
+- No exponer backend URL ni rutas arbitrarias desde el navegador.
+- No cambiar la política de validación de contenido `SKILL.md`.
+
+## Implementation notes
+- El backend normaliza el catálogo a `editable=true` para entradas visibles y valida escritura solo dentro de raíces allowlisteadas: `skills-source` y runtime root explícito.
+- La UI calcula el actor de auditoría desde `owner_slug`: global/shared → `luffy`; agente → su slug; runtime → `runtime`.
+- La UI elimina el input manual de actor y presenta `Dueño / actor de guardado` como dato calculado.
+- `StatusBadge` acepta `detail` para renderizar chips autocontenidos y legibles.
+
+## Verification
+- `npm --prefix apps/web run typecheck`
+- `npm --prefix apps/web run build`
+- `PYTHONPATH=. pytest apps/api/tests/test_skills_api.py apps/api/tests/test_mugiwaras_api.py -q`
+- `npm run verify:skills-server-only`
+- `npm run verify:visual-baseline`
+- `git diff --check`
+- Browser smoke local en `/skills?mugiwara=franky`: consola limpia, chips `Editable` y `Skill compartible` separados, sin `Riesgo repo público` visible.


### PR DESCRIPTION
## Qué cambia
- Calcula el actor de guardado desde el dueño de la skill: global/shared → `luffy`, agente → su `owner_slug`.
- Marca todas las skills visibles como editables, incluyendo runtime root allowlisteado.
- Sustituye el copy `Riesgo repo público` por `Skill compartible: Sí/No` con detalle de riesgo.
- Separa chips móviles y elimina el input manual `Actor visible`.
- Documenta Phase 19.3 y actualiza `docs/skills-surface.md`.

## Verificación
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build`
- `PYTHONPATH=. pytest apps/api/tests/test_skills_api.py apps/api/tests/test_mugiwaras_api.py -q` → 12 passed
- `npm run verify:skills-server-only`
- `npm run verify:visual-baseline`
- `git diff --check`
- Browser smoke local `/skills?mugiwara=franky`: consola limpia; sin `Riesgo repo público` ni `Actor visible`; `Skill compartible` visible; sin overflow horizontal.

## Riesgo
- Bajo-medio: toca UI visible y allowlist de edición de skills. La escritura sigue limitada a raíces backend allowlisteadas y BFF same-origin.

## Review solicitada
- Chopper: seguridad/allowlist/filesystem/runtime root.
- Usopp: UX/copy/responsive móvil de chips.