### PR TITLE
fix: simplify skills status badges

### DIFF
--- a/apps/web/src/app/skills/page.tsx
+++ b/apps/web/src/app/skills/page.tsx
@@ -144,27 +144,10 @@ function getSkillOwnerDisplay(skill: Pick<SkillCatalogItem | SkillDetail, 'owner
   return skill.owner_label
 }
 
-function getShareableSkillCopy(skill: Pick<SkillCatalogItem | SkillDetail, 'public_repo_risk'>) {
-  if (skill.public_repo_risk === 'low') {
-    return {
-      status: 'operativo' as const,
-      label: 'Skill compartible: Sí',
-      detail: 'sin riesgo',
-    }
-  }
-
-  return {
-    status: 'incidencia' as const,
-    label: 'Skill compartible: No',
-    detail: 'riesgo de filtrado',
-  }
-}
-
 function getEditableSkillCopy() {
   return {
     status: 'operativo' as const,
     label: 'Editable',
-    detail: 'Todas las skills visibles se pueden editar desde esta pantalla',
   }
 }
 
@@ -504,7 +487,6 @@ export default function SkillsPage() {
   const hasDraftChanges = selectedSkill ? draftContent !== selectedSkill.content : false
   const selectedSkillActor = selectedSkill ? getSkillAuditActor(selectedSkill) : ''
   const selectedSkillOwner = selectedSkill ? getSkillOwnerDisplay(selectedSkill) : ''
-  const shareableSkillCopy = selectedSkill ? getShareableSkillCopy(selectedSkill) : null
   const editableSkillCopy = selectedSkill ? getEditableSkillCopy() : null
   const canSave = Boolean(selectedSkill?.editable && hasDraftChanges && selectedSkillActor && saveState !== 'saving')
   const draftSummary = useMemo(() => {
@@ -749,8 +731,7 @@ export default function SkillsPage() {
                 <span className="text-break" style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{selectedSkill.skill_id}</span>
               </div>
               <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
-                {editableSkillCopy ? <StatusBadge status={editableSkillCopy.status} label={editableSkillCopy.label} detail={editableSkillCopy.detail} /> : null}
-                {shareableSkillCopy ? <StatusBadge status={shareableSkillCopy.status} label={shareableSkillCopy.label} detail={shareableSkillCopy.detail} /> : null}
+                {editableSkillCopy ? <StatusBadge status={editableSkillCopy.status} label={editableSkillCopy.label} /> : null}
                 <button
                   type="button"
                   onClick={() => setWorkspaceMode('reader')}

--- a/docs/skills-surface.md
+++ b/docs/skills-surface.md
@@ -47,7 +47,7 @@ Campos mínimos por entrada:
 - `owner_slug`
 - `owner_label`
 - `editable`
-- `shareable_label` derivada en UI desde la señal backend `public_repo_risk`: bajo → `Skill compartible: Sí (sin riesgo)`; medio/alto → `Skill compartible: No (riesgo de filtrado)`.
+- `public_repo_risk` puede mantenerse como señal backend interna, pero la UI no muestra copy de compartibilidad porque el panel no usa `/skills` para decidir publicación externa.
 
 La página `/skills` debe evitar listados largos por defecto. El flujo de lectura/edición es:
 1. seleccionar una fuente (`global` o un Mugiwara allowlisteado);
@@ -61,7 +61,8 @@ Decisión operativa: colocar una skill nueva bajo `skills-source/global`, `skill
 
 ### Copy de edición
 - Todas las skills visibles se presentan como `Editable`.
-- La UI no muestra `Riesgo repo público`; usa `Skill compartible: Sí (sin riesgo)` o `Skill compartible: No (riesgo de filtrado)`.
+- La UI muestra solo el badge verde `Editable`, sin explicación larga.
+- La UI no muestra `Riesgo repo público` ni `Skill compartible`, porque no hay flujo de compartir/publicar skills desde esta pantalla.
 - El actor visible no se introduce a mano: lo calcula el frontend desde el dueño de la skill y lo envía al backend para auditoría.
 
 ## Reglas de seguridad

--- a/openspec/phase-19-3-skills-owner-shareable-copy.md
+++ b/openspec/phase-19-3-skills-owner-shareable-copy.md
@@ -7,9 +7,7 @@ Pablo pidió que la pantalla `/skills` deje de mostrar un actor manual y estados
 - Mostrar el dueño real de la skill como actor de guardado.
 - Usar `luffy` como dueño/actor visible para skills globales.
 - Mantener todas las skills visibles como editables desde el panel.
-- Sustituir el copy de riesgo público por una señal de compartibilidad:
-  - `Skill compartible: Sí (sin riesgo)` cuando la señal backend es baja.
-  - `Skill compartible: No (riesgo de filtrado)` cuando la señal backend es media/alta.
+- Eliminar el copy de riesgo público sin sustituirlo por una señal de compartibilidad visible; no hay flujo de compartir/publicar skills desde esta pantalla.
 - Evitar chips pegados en móvil.
 
 ## Non-goals
@@ -22,7 +20,7 @@ Pablo pidió que la pantalla `/skills` deje de mostrar un actor manual y estados
 - El backend normaliza el catálogo a `editable=true` para entradas visibles y valida escritura solo dentro de raíces allowlisteadas: `skills-source` y runtime root explícito.
 - La UI calcula el actor de auditoría desde `owner_slug`: global/shared → `luffy`; agente → su slug; runtime → `runtime`.
 - La UI elimina el input manual de actor y presenta `Dueño / actor de guardado` como dato calculado.
-- `StatusBadge` acepta `detail` para renderizar chips autocontenidos y legibles.
+- `StatusBadge` se usa en `/skills` con el copy mínimo `Editable`, sin detalle largo ni badge de compartibilidad.
 
 ## Verification
 - `npm --prefix apps/web run typecheck`
@@ -31,4 +29,4 @@ Pablo pidió que la pantalla `/skills` deje de mostrar un actor manual y estados
 - `npm run verify:skills-server-only`
 - `npm run verify:visual-baseline`
 - `git diff --check`
-- Browser smoke local en `/skills?mugiwara=franky`: consola limpia, chips `Editable` y `Skill compartible` separados, sin `Riesgo repo público` visible.
+- Browser smoke local en `/skills?mugiwara=franky`: consola limpia, badge `Editable` visible, sin `Skill compartible` ni `Riesgo repo público` visible.


### PR DESCRIPTION
## Resumen
- deja /skills con un único badge verde `Editable` sin explicación larga
- elimina el badge/copy `Skill compartible` de la UI
- actualiza docs/openspec para reflejar que esta pantalla no decide publicación externa

## Verify
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build`
- `git diff --check`
- smoke visual local en `/skills?mugiwara=franky`: `Editable` visible; sin `Skill compartible`, sin explicación larga, sin `Riesgo repo público`, sin overflow horizontal

## Riesgo
Bajo: cambio de copy/UI localizado y documentación alineada.