### PR TITLE
fix: align mugiwaras roster status

### DIFF
--- a/.engram/issue-102-mugiwaras-roster-status-closeout.md
+++ b/.engram/issue-102-mugiwaras-roster-status-closeout.md
@@ -1,0 +1,29 @@
+# Issue #102 closeout — Mugiwaras roster status
+
+## Resultado
+`/mugiwaras` deja de mostrar Usopp/Brook como `En revisión` y Jinbe/Sanji como `Sin datos`. La semántica queda fijada: el status principal representa estado operativo/canónico del Mugiwara en el roster, no disponibilidad de skills/memory ni standby parcial.
+
+## Root cause
+Los estados venían de allowlists estáticas antiguas:
+- `apps/api/src/modules/mugiwaras/service.py` (`CREW_CARDS`)
+- `apps/web/src/modules/mugiwaras/view-models/mugiwara-card.fixture.ts`
+
+No era un dato derivado de healthcheck, runtime ni memoria.
+
+## Cambios
+- Backend y fixture frontend alineados con los 10 Mugiwara activos del canon.
+- Brook conserva el matiz de Postgres MCP en standby en la descripción, sin degradar status.
+- Jinbe/Sanji actualizados como perfiles activos con copy/roles visibles más cercanos al AGENTS canónico.
+- Guardrail `verify:mugiwaras-server-only` ampliado para bloquear regresiones de status/fixture/links y roles obsoletos.
+- Docs `api-modules` y `read-models` documentan la semántica.
+
+## Verify
+- `PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py -q` ✅
+- `npm --prefix apps/web run typecheck` ✅
+- `npm --prefix apps/web run build` ✅
+- `npm run verify:mugiwaras-server-only` ✅
+- `git diff --check` ✅
+- Browser smoke local `/mugiwaras` contra API/Next locales: consola limpia, sin `En revisión`, sin `Sin datos`, sin overflow horizontal ✅
+
+## Riesgo residual
+Bajo. La fuente sigue siendo allowlist estática backend-owned y fallback frontend saneado; no se abre nueva lectura host ni nueva escritura.

--- a/apps/api/src/modules/mugiwaras/service.py
+++ b/apps/api/src/modules/mugiwaras/service.py
@@ -55,7 +55,7 @@ CREW_CARDS: tuple[MugiwaraCard, ...] = (
     MugiwaraCard(
         'usopp',
         'Usopp',
-        'revision',
+        'operativo',
         'Convierte ideas en marca, copy, diseño, campañas y experiencia de interfaz.',
         ['usopp-pr-design-review', 'frontend-spec-usopp'],
         'Diseño activo',
@@ -82,28 +82,28 @@ CREW_CARDS: tuple[MugiwaraCard, ...] = (
     MugiwaraCard(
         'brook',
         'Brook',
-        'revision',
-        'Analiza datos, modelos, métricas y pipelines cuando el sistema necesite lectura cuantitativa.',
+        'operativo',
+        'Analiza datos, modelos, métricas y pipelines; el Postgres MCP permanece en standby hasta disponer de una base analítica real.',
         ['data-analysis', 'analytics-standby'],
-        'Datos en standby',
+        'Gateway operativo',
         _crew_links('brook'),
     ),
     MugiwaraCard(
         'jinbe',
         'Jinbe',
-        'sin-datos',
+        'operativo',
         'Aporta criterio legal, contexto normativo y lectura prudente de riesgos jurídicos.',
         ['legal-context'],
-        'Definido en canon',
+        'Perfil activo',
         _crew_links('jinbe'),
     ),
     MugiwaraCard(
         'sanji',
         'Sanji',
-        'sin-datos',
-        'Cuida operaciones físicas, logística personal y soporte de alto contacto cuando aplique.',
-        ['physical-ops'],
-        'Definido en canon',
+        'operativo',
+        'Rastrea compras, reservas, servicios, viajes, restaurantes, caducidades y avisos prácticos.',
+        ['shopping-travel-watch', 'google-workspace-ops'],
+        'Perfil activo',
         _crew_links('sanji'),
     ),
 )
@@ -117,8 +117,8 @@ PROFILE_META: dict[str, dict[str, str]] = {
     'nami': {'role': 'CFO y directora financiera', 'accent_color': '#f97316'},
     'robin': {'role': 'Directora de research e inteligencia', 'accent_color': '#7c3aed'},
     'brook': {'role': 'CDO y data scientist', 'accent_color': '#64748b'},
-    'jinbe': {'role': 'CLO y asesor legal', 'accent_color': '#2563eb'},
-    'sanji': {'role': 'COO físico y concierge personal', 'accent_color': '#eab308'},
+    'jinbe': {'role': 'CLO y asesor legal-burocrático', 'accent_color': '#2563eb'},
+    'sanji': {'role': 'Scout de compras, reservas y servicios', 'accent_color': '#eab308'},
 }
 
 

--- a/apps/api/tests/test_mugiwaras_api.py
+++ b/apps/api/tests/test_mugiwaras_api.py
@@ -46,6 +46,15 @@ def test_mugiwaras_catalog_returns_safe_cards_and_canonical_agents_document(tmp_
         'markdown': '# AGENTS.md\n\nCanon Mugiwara saneado.\n',
     }
 
+    active_roster = {'luffy', 'zoro', 'franky', 'nami', 'robin', 'usopp', 'jinbe', 'sanji', 'chopper', 'brook'}
+    assert set(cards_by_slug) == active_roster
+    assert {slug: cards_by_slug[slug]['status'] for slug in active_roster} == {slug: 'operativo' for slug in active_roster}
+    assert cards_by_slug['brook']['memory_badge'] != 'Datos en standby'
+    assert cards_by_slug['jinbe']['memory_badge'] != 'Definido en canon'
+    assert cards_by_slug['sanji']['memory_badge'] != 'Definido en canon'
+    assert 'Postgres MCP' in cards_by_slug['brook']['description']
+    assert 'standby' in cards_by_slug['brook']['description']
+
     app.dependency_overrides.clear()
 
 

--- a/apps/web/src/modules/mugiwaras/view-models/mugiwara-card.fixture.ts
+++ b/apps/web/src/modules/mugiwaras/view-models/mugiwara-card.fixture.ts
@@ -10,7 +10,7 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
     memory_badge: 'Capitán operativo',
     links: [
       { label: 'Ver Memory', href: '/memory' },
-      { label: 'Ver Skills', href: '/skills' },
+      { label: 'Ver Skills', href: '/skills?mugiwara=luffy' },
     ],
   },
   {
@@ -22,7 +22,7 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
     memory_badge: 'Continuidad fuerte',
     links: [
       { label: 'Ver Memory', href: '/memory' },
-      { label: 'Ver Skills', href: '/skills' },
+      { label: 'Ver Skills', href: '/skills?mugiwara=zoro' },
     ],
   },
   {
@@ -34,7 +34,7 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
     memory_badge: 'Runtime vigilado',
     links: [
       { label: 'Ver Memory', href: '/memory' },
-      { label: 'Ver Skills', href: '/skills' },
+      { label: 'Ver Skills', href: '/skills?mugiwara=franky' },
     ],
   },
   {
@@ -46,19 +46,19 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
     memory_badge: 'Riesgo controlado',
     links: [
       { label: 'Ver Memory', href: '/memory' },
-      { label: 'Ver Skills', href: '/skills' },
+      { label: 'Ver Skills', href: '/skills?mugiwara=chopper' },
     ],
   },
   {
     slug: 'usopp',
     name: 'Usopp',
-    status: 'revision',
+    status: 'operativo',
     description: 'Convierte ideas en marca, copy, diseño, campañas y experiencia de interfaz.',
     skills: ['usopp-pr-design-review', 'frontend-spec-usopp'],
     memory_badge: 'Diseño activo',
     links: [
       { label: 'Ver Memory', href: '/memory' },
-      { label: 'Ver Skills', href: '/skills' },
+      { label: 'Ver Skills', href: '/skills?mugiwara=usopp' },
     ],
   },
   {
@@ -70,7 +70,7 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
     memory_badge: 'Señales estables',
     links: [
       { label: 'Ver Memory', href: '/memory' },
-      { label: 'Ver Skills', href: '/skills' },
+      { label: 'Ver Skills', href: '/skills?mugiwara=nami' },
     ],
   },
   {
@@ -82,43 +82,43 @@ export const mugiwaraCardFixture: MugiwaraCard[] = [
     memory_badge: 'Canon consultable',
     links: [
       { label: 'Ver Memory', href: '/memory' },
-      { label: 'Ver Skills', href: '/skills' },
+      { label: 'Ver Skills', href: '/skills?mugiwara=robin' },
     ],
   },
   {
     slug: 'brook',
     name: 'Brook',
-    status: 'revision',
-    description: 'Analiza datos, modelos, métricas y pipelines cuando el sistema necesite lectura cuantitativa.',
+    status: 'operativo',
+    description: 'Analiza datos, modelos, métricas y pipelines; el Postgres MCP permanece en standby hasta disponer de una base analítica real.',
     skills: ['data-analysis', 'analytics-standby'],
-    memory_badge: 'Datos en standby',
+    memory_badge: 'Gateway operativo',
     links: [
       { label: 'Ver Memory', href: '/memory' },
-      { label: 'Ver Skills', href: '/skills' },
+      { label: 'Ver Skills', href: '/skills?mugiwara=brook' },
     ],
   },
   {
     slug: 'jinbe',
     name: 'Jinbe',
-    status: 'sin-datos',
+    status: 'operativo',
     description: 'Aporta criterio legal, contexto normativo y lectura prudente de riesgos jurídicos.',
     skills: ['legal-context'],
-    memory_badge: 'Definido en canon',
+    memory_badge: 'Perfil activo',
     links: [
       { label: 'Ver Memory', href: '/memory' },
-      { label: 'Ver Skills', href: '/skills' },
+      { label: 'Ver Skills', href: '/skills?mugiwara=jinbe' },
     ],
   },
   {
     slug: 'sanji',
     name: 'Sanji',
-    status: 'sin-datos',
-    description: 'Cuida operaciones físicas, logística personal y soporte de alto contacto cuando aplique.',
-    skills: ['physical-ops'],
-    memory_badge: 'Definido en canon',
+    status: 'operativo',
+    description: 'Rastrea compras, reservas, servicios, viajes, restaurantes, caducidades y avisos prácticos.',
+    skills: ['shopping-travel-watch', 'google-workspace-ops'],
+    memory_badge: 'Perfil activo',
     links: [
       { label: 'Ver Memory', href: '/memory' },
-      { label: 'Ver Skills', href: '/skills' },
+      { label: 'Ver Skills', href: '/skills?mugiwara=sanji' },
     ],
   },
 ]

--- a/apps/web/src/shared/mugiwara/crest-map.ts
+++ b/apps/web/src/shared/mugiwara/crest-map.ts
@@ -68,14 +68,14 @@ export const MUGIWARA_PROFILES: Record<MugiwaraSlug, MugiwaraProfile> = {
   jinbe: {
     slug: 'jinbe',
     name: 'Jinbe',
-    role: 'CLO y Asesor Legal',
+    role: 'CLO y Asesor Legal-burocrático',
     crestSvgSrc: '/assets/mugiwaras/crests/jinbe.svg',
     crestPngSrc: '/assets/mugiwaras/crests-png/jinbe.png',
   },
   sanji: {
     slug: 'sanji',
     name: 'Sanji',
-    role: 'COO Físico y Concierge Personal',
+    role: 'Scout de Compras, Reservas y Servicios',
     crestSvgSrc: '/assets/mugiwaras/crests/sanji.svg',
     crestPngSrc: '/assets/mugiwaras/crests-png/sanji.png',
   },

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -20,7 +20,9 @@
 
 ### `mugiwaras`
 - componer ficha por agente
-- agregar estado, identidad, built-in memory resumida y skills relacionadas
+- agregar estado operativo/canónico del Mugiwara, identidad, built-in memory resumida y skills relacionadas
+- el `status` principal de `/mugiwaras` representa pertenencia activa al roster operativo/canónico; no debe degradarse por disponibilidad parcial de skills, memory, MCPs o madurez de una capacidad concreta
+- las capacidades parciales o en standby se explican en descripción o badges secundarios allowlisted, sin convertir al agente activo en `revision` o `sin-datos`
 - exponer `GET /api/v1/mugiwaras` y `GET /api/v1/mugiwaras/{slug}` como superficies read-only
 - mostrar `/srv/crew-core/AGENTS.md` como documento canónico de reglas operativas en la sección Mugiwara; esta lectura pertenece al control plane privado y no debe exponerse fuera de la frontera operativa/autenticada del despliegue
 - no listar ni resolver por separado `/home/agentops/.hermes/hermes-agent/AGENTS.md`, porque es symlink al canon

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -11,6 +11,17 @@ Todos los recursos usan la envoltura común:
 - `meta`
 
 ## Modelos por recurso
+### `mugiwaras.catalog`
+Campos esperados:
+- `items[]` con `slug`, `name`, `status`, `description`, `skills`, `memory_badge` y `links[]` allowlisted
+- `crew_rules_document` con el AGENTS canónico read-only servido desde la ruta backend-owned
+
+Uso:
+- representar el roster operativo/canónico actual de Mugiwara en `/mugiwaras`
+- el `status` principal de una card expresa si el Mugiwara está operativo en el canon del roster, no si tiene todos los MCPs, skills, memoria o capacidades maduras disponibles
+- si una capacidad concreta está en standby, debe aparecer como copy descriptivo saneado o badge secundario, no como degradación del estado principal del agente
+- el frontend mantiene un fixture fallback saneado que debe conservar la misma semántica que `CREW_CARDS`
+
 ### `dashboard.summary`
 Campos esperados:
 - `sections[]` con `id`, `label` y estado saneado (`healthy`, `warning`, `degraded`)

--- a/openspec/issue-102-mugiwaras-roster-status.md
+++ b/openspec/issue-102-mugiwaras-roster-status.md
@@ -1,0 +1,24 @@
+# Issue #102 — Mugiwaras roster status canon
+
+## Objetivo
+Alinear `/mugiwaras` con el canon actual del roster definido en `/srv/crew-core/AGENTS.md`.
+
+## Semántica fijada
+- El `status` principal de una `MugiwaraCard` representa el estado operativo/canónico del Mugiwara como miembro activo del roster.
+- No representa disponibilidad de datos de panel, skills, memory, MCPs ni madurez parcial de una capacidad.
+- Las capacidades parciales o en standby deben expresarse en `description` o badges secundarios allowlisted, no degradando el status del agente activo a `revision` o `sin-datos`.
+
+## Cambio técnico
+- Backend `CREW_CARDS`: Usopp, Brook, Jinbe y Sanji quedan `operativo`.
+- Brook mantiene el matiz de `Postgres MCP` en standby dentro de la descripción, no como status principal.
+- Jinbe/Sanji actualizan copy y roles visibles hacia el canon actual.
+- Fixture frontend fallback se alinea con backend, incluidos links `Ver Skills` slug-scoped.
+- `verify:mugiwaras-server-only` pasa a fijar la semántica de roster activo, fixture alineado y roles Jinbe/Sanji no obsoletos.
+
+## Verify esperado
+- `PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py -q`
+- `npm --prefix apps/web run typecheck`
+- `npm --prefix apps/web run build`
+- `npm run verify:mugiwaras-server-only`
+- `git diff --check`
+- Smoke visual de `/mugiwaras` contra API y Next locales: sin `En revisión`, sin `Sin datos`, consola limpia y sin overflow horizontal.

--- a/scripts/check-mugiwaras-server-only.mjs
+++ b/scripts/check-mugiwaras-server-only.mjs
@@ -12,9 +12,15 @@ import { join } from 'node:path'
 const repoRoot = process.cwd()
 const mugiwarasHttpPath = join(repoRoot, 'apps/web/src/modules/mugiwaras/api/mugiwaras-http.ts')
 const mugiwarasPagePath = join(repoRoot, 'apps/web/src/app/mugiwaras/page.tsx')
+const mugiwarasFixturePath = join(repoRoot, 'apps/web/src/modules/mugiwaras/view-models/mugiwara-card.fixture.ts')
+const mugiwarasBackendServicePath = join(repoRoot, 'apps/api/src/modules/mugiwaras/service.py')
+const mugiwaraCrestMapPath = join(repoRoot, 'apps/web/src/shared/mugiwara/crest-map.ts')
 
 const mugiwarasHttp = readFileSync(mugiwarasHttpPath, 'utf8')
 const mugiwarasPage = readFileSync(mugiwarasPagePath, 'utf8')
+const mugiwarasFixture = readFileSync(mugiwarasFixturePath, 'utf8')
+const mugiwarasBackendService = readFileSync(mugiwarasBackendServicePath, 'utf8')
+const mugiwaraCrestMap = readFileSync(mugiwaraCrestMapPath, 'utf8')
 
 const failures = []
 
@@ -44,6 +50,37 @@ if (!mugiwarasPage.includes('MUGIWARA_CONTROL_PANEL_API_URL')) {
 
 if (mugiwarasPage.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL')) {
   failures.push('mugiwaras/page.tsx must not instruct operators to use the public env var')
+}
+
+const activeRoster = ['luffy', 'zoro', 'franky', 'nami', 'robin', 'usopp', 'jinbe', 'sanji', 'chopper', 'brook']
+
+for (const slug of activeRoster) {
+  const backendCardPattern = new RegExp(`MugiwaraCard\\(\\s*'${slug}'[\\s\\S]*?\\n\\s*'operativo'`, 'm')
+  const fixtureCardPattern = new RegExp(`slug: '${slug}',[\\s\\S]*?status: 'operativo'`, 'm')
+  if (!backendCardPattern.test(mugiwarasBackendService)) {
+    failures.push(`backend CREW_CARDS must mark active Mugiwara ${slug} as operativo`)
+  }
+  if (!fixtureCardPattern.test(mugiwarasFixture)) {
+    failures.push(`frontend fixture must mark active Mugiwara ${slug} as operativo`)
+  }
+  if (!mugiwarasBackendService.includes("SafeLink('Ver Skills', f'/skills?mugiwara={slug}')")) {
+    failures.push('backend CREW_CARDS must generate slug-scoped skills links')
+  }
+  if (!mugiwarasFixture.includes(`href: '/skills?mugiwara=${slug}'`)) {
+    failures.push(`frontend fixture must expose a slug-scoped skills link for ${slug}`)
+  }
+}
+
+if (mugiwarasBackendService.includes("'Datos en standby'") || mugiwarasFixture.includes("'Datos en standby'")) {
+  failures.push('Mugiwaras cards must not use data/skills standby as the primary operational status badge')
+}
+
+if (mugiwarasBackendService.includes("'Definido en canon'") || mugiwarasFixture.includes("'Definido en canon'")) {
+  failures.push('Mugiwaras cards must not describe active canon members as only defined in canon')
+}
+
+if (mugiwaraCrestMap.includes('COO Físico y Concierge Personal') || mugiwaraCrestMap.includes('CLO y Asesor Legal\',')) {
+  failures.push('frontend crest map roles for Jinbe/Sanji must stay aligned with current AGENTS.md roster canon')
 }
 
 if (failures.length > 0) {


### PR DESCRIPTION
## Objetivo
Alinear `/mugiwaras` con el canon actual del roster: todos los Mugiwara activos en `/srv/crew-core/AGENTS.md` deben aparecer `Operativo` en la card principal.

Closes #102

## Cambios
- Backend `CREW_CARDS`: Usopp, Brook, Jinbe y Sanji pasan a `operativo`.
- Se fija la semántica: el `status` principal representa estado operativo/canónico del Mugiwara, no disponibilidad de skills/memory/MCPs ni madurez parcial.
- Brook mantiene el matiz de `Postgres MCP` en standby dentro de la descripción, no degradando el agente.
- Jinbe/Sanji actualizan copy/rol visible hacia el canon actual.
- Fixture frontend fallback alineada con backend, incluidos links `Ver Skills` con `mugiwara=<slug>`.
- `verify:mugiwaras-server-only` bloquea regresiones de status, fixture, links y roles obsoletos.
- Docs/OpenSpec/Engram actualizados.

## Seguridad / privacidad
- Sin endpoints nuevos.
- Sin escritura.
- Sin input nuevo del cliente.
- Sin exposición de datos sensibles ni lectura host adicional.
- Se mantiene la fuente backend-owned/read-only y el fixture fallback saneado.

## Verify de Zoro
- [x] TDD rojo inicial: `PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py -q` falló por Usopp/Brook/Jinbe/Sanji no `operativo`.
- [x] `PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py apps/api/tests/test_shared_contracts.py -q`
- [x] `npm --prefix apps/web run typecheck`
- [x] `npm --prefix apps/web run build`
- [x] `npm run verify:mugiwaras-server-only`
- [x] `git diff --check`
- [x] Smoke visual local `/mugiwaras` contra API/Next locales: sin `En revisión`, sin `Sin datos`, consola limpia, sin overflow horizontal.

## Review solicitada
- Chopper: seguridad/no-leakage/read-only/server-only y que el ajuste no abra superficie nueva.
- Usopp: claridad de status/copy visible, percepción de roster activo y UX de `/mugiwaras`.
