### PR TITLE
fix: localize Usage Hermes activity status

### DIFF
--- a/apps/web/src/app/usage/page.tsx
+++ b/apps/web/src/app/usage/page.tsx
@@ -23,6 +23,13 @@ type UsageNotice = {
   sourceStateItems: Array<{ label: string; tone: 'connected' | 'fallback' | 'snapshot' | 'not-realtime' | 'not-configured' | 'degraded' }>
 }
 
+type HermesActivityNotice = {
+  status: AppStatus
+  title: string
+  description: string
+  detail: string
+}
+
 type UsagePageData = {
   usage: UsageCurrent
   calendar: UsageCalendar
@@ -30,6 +37,7 @@ type UsagePageData = {
   hermesActivity: UsageHermesActivity
   resourceStatus: ResourceStatus | 'fallback'
   notice: UsageNotice | null
+  hermesActivityNotice: HermesActivityNotice | null
   isSnapshotMode: boolean
 }
 
@@ -76,23 +84,24 @@ async function getInitialUsageData(): Promise<UsagePageData> {
     const fiveHourWindows = fiveHourWindowsResponse.data
     const hermesActivity = hermesActivityResponse.data
 
-    const responseStatus = currentResponse.status !== 'ready'
+    const usageCoreStatus = currentResponse.status !== 'ready'
       ? currentResponse.status
       : calendarResponse.status !== 'ready'
         ? calendarResponse.status
         : fiveHourWindowsResponse.status !== 'ready'
           ? fiveHourWindowsResponse.status
-          : hermesActivityResponse.status
+          : 'ready'
 
-    if (responseStatus !== 'ready') {
+    if (usageCoreStatus !== 'ready') {
       return {
         usage,
         calendar,
         fiveHourWindows,
         hermesActivity,
-        resourceStatus: responseStatus,
-        isSnapshotMode: responseStatus === 'stale',
-        notice: noticeFromResourceStatus(responseStatus),
+        resourceStatus: usageCoreStatus,
+        isSnapshotMode: usageCoreStatus === 'stale',
+        notice: noticeFromResourceStatus(usageCoreStatus),
+        hermesActivityNotice: noticeFromHermesActivityStatus(hermesActivityResponse.status),
       }
     }
 
@@ -103,6 +112,7 @@ async function getInitialUsageData(): Promise<UsagePageData> {
       hermesActivity,
       resourceStatus: currentResponse.status,
       notice: null,
+      hermesActivityNotice: noticeFromHermesActivityStatus(hermesActivityResponse.status),
       isSnapshotMode: false,
     }
   } catch (error) {
@@ -115,6 +125,7 @@ async function getInitialUsageData(): Promise<UsagePageData> {
       hermesActivity: usageHermesActivityFixture,
       resourceStatus: 'fallback',
       isSnapshotMode: true,
+      hermesActivityNotice: null,
       notice: {
         status: apiError?.code === 'not_configured' ? 'revision' : 'incidencia',
         title:
@@ -179,6 +190,37 @@ function noticeFromResourceStatus(status: ResourceStatus): UsageNotice | null {
       { label: 'Error/degradado', tone: 'degraded' },
       { label: 'No tiempo real', tone: 'not-realtime' },
     ],
+  }
+}
+
+function noticeFromHermesActivityStatus(status: ResourceStatus): HermesActivityNotice | null {
+  if (status === 'ready') {
+    return null
+  }
+
+  if (status === 'not_configured') {
+    return {
+      status: 'revision',
+      title: 'Actividad Hermes no configurada',
+      description: 'La fuente agregada de actividad Hermes no está disponible. Usage Codex sigue conectado si el snapshot principal, el calendario y las ventanas 5h están listos.',
+      detail: 'Estado técnico de hermes-activity: not_configured',
+    }
+  }
+
+  if (status === 'stale') {
+    return {
+      status: 'stale',
+      title: 'Actividad Hermes con datos antiguos',
+      description: 'La correlación Hermes puede estar desactualizada. La lectura Codex principal mantiene su propio estado independiente.',
+      detail: 'Estado técnico de hermes-activity: stale',
+    }
+  }
+
+  return {
+    status: 'revision',
+    title: 'Actividad Hermes degradada',
+    description: 'La sección Hermes no está lista. Se mantiene localizada para no ocultar el estado real de Usage Codex.',
+    detail: `Estado técnico de hermes-activity: ${status}`,
   }
 }
 
@@ -482,7 +524,7 @@ function formatProfileName(profile: string | null) {
   return profile.charAt(0).toUpperCase() + profile.slice(1)
 }
 
-function UsageHermesActivityPanel({ activity, isSnapshotMode }: { activity: UsageHermesActivity; isSnapshotMode: boolean }) {
+function UsageHermesActivityPanel({ activity, notice, isSnapshotMode }: { activity: UsageHermesActivity; notice: HermesActivityNotice | null; isSnapshotMode: boolean }) {
   const profiles = activity.profiles.slice(0, 8)
   const dominantProfile = formatProfileName(activity.totals.dominant_profile)
 
@@ -496,6 +538,17 @@ function UsageHermesActivityPanel({ activity, isSnapshotMode }: { activity: Usag
           <p style={{ margin: 0, color: appTheme.colors.brandGold400, lineHeight: 1.5 }}>
             Actividad mostrada desde fallback saneado: valida composición visual, no representa lectura real.
           </p>
+        ) : null}
+        {notice ? (
+          <StatePanel
+            status={notice.status}
+            title={notice.title}
+            description={notice.description}
+            detail={notice.detail}
+            eyebrow="Estado de actividad Hermes"
+            ariaRole="region"
+            ariaLabel="Estado localizado de actividad Hermes"
+          />
         ) : null}
         <dl className="usage-hermes-activity-summary" aria-label="Resumen agregado de actividad Hermes">
           <div>
@@ -569,7 +622,7 @@ function UsageHermesActivityPanel({ activity, isSnapshotMode }: { activity: Usag
 }
 
 export default async function UsagePage() {
-  const { usage, calendar, fiveHourWindows, hermesActivity, notice, isSnapshotMode } = await getInitialUsageData()
+  const { usage, calendar, fiveHourWindows, hermesActivity, notice, hermesActivityNotice, isSnapshotMode } = await getInitialUsageData()
   const recommendationStatus = recommendationStatusMap[usage.recommendation.state]
 
   return (
@@ -642,7 +695,7 @@ export default async function UsagePage() {
       </section>
 
       <section className="section-block" aria-label="Actividad Hermes Usage">
-        <UsageHermesActivityPanel activity={hermesActivity} isSnapshotMode={isSnapshotMode} />
+        <UsageHermesActivityPanel activity={hermesActivity} notice={hermesActivityNotice} isSnapshotMode={isSnapshotMode} />
       </section>
 
       <section className="section-block layout-grid layout-grid--content-aside">

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "verify:cronjobs-status-runner": "node scripts/check-cronjobs-status-runner.mjs",
     "verify:statepanel-aria": "node scripts/check-statepanel-aria.mjs",
     "verify:usage-server-only": "node scripts/check-usage-server-only.mjs",
+    "test:usage-partial-hermes-status": "node scripts/check-usage-partial-hermes-status.mjs",
     "write:project-health-status": "python3 scripts/write-project-health-status.py",
     "write:gateway-status": "python3 scripts/write-gateway-status.py",
     "write:cronjobs-status": "python3 scripts/write-cronjobs-status.py",

--- a/scripts/check-usage-partial-hermes-status.mjs
+++ b/scripts/check-usage-partial-hermes-status.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/** Regression check for Issue #99: Hermes activity partial status must not own global Usage state. */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = process.cwd()
+const pagePath = join(repoRoot, 'apps/web/src/app/usage/page.tsx')
+const page = readFileSync(pagePath, 'utf8')
+const failures = []
+
+function expectIncludes(fragment, message) {
+  if (!page.includes(fragment)) failures.push(message)
+}
+
+function expectNotIncludes(fragment, message) {
+  if (page.includes(fragment)) failures.push(message)
+}
+
+expectIncludes('const usageCoreStatus = currentResponse.status', 'Usage page must compute a dedicated core status from Codex endpoints')
+expectIncludes("? fiveHourWindowsResponse.status\n          : 'ready'", 'Usage core status must resolve to ready after current/calendar/five-hour-windows are ready')
+expectNotIncludes(': hermesActivityResponse.status', 'Hermes activity status must not be the fallback/global Usage status')
+expectIncludes('hermesActivityNotice: noticeFromHermesActivityStatus(hermesActivityResponse.status)', 'Hermes activity status must become a localized section notice')
+expectIncludes('function noticeFromHermesActivityStatus(status: ResourceStatus): HermesActivityNotice | null', 'Usage page must model Hermes activity notice separately')
+expectIncludes("title: 'Actividad Hermes no configurada'", 'Mixed ready core + Hermes not_configured must show localized Hermes copy')
+expectIncludes('Usage Codex sigue conectado si el snapshot principal, el calendario y las ventanas 5h están listos.', 'Localized Hermes notice must explicitly preserve ready Codex/core state')
+expectIncludes('Estado de actividad Hermes', 'Localized Hermes notice must render inside the Hermes activity section')
+expectIncludes('Estado localizado de actividad Hermes', 'Localized Hermes notice must have scoped accessibility label')
+expectIncludes('<UsageHermesActivityPanel activity={hermesActivity} notice={hermesActivityNotice}', 'Usage page must pass localized Hermes notice to the activity panel')
+
+const globalNoticeBlock = page.slice(page.indexOf('function noticeFromResourceStatus'), page.indexOf('function noticeFromHermesActivityStatus'))
+if (!globalNoticeBlock.includes("title: 'Usage sin fuente configurada'")) {
+  failures.push('Global Usage not_configured notice must remain available for core/source failures')
+}
+if (globalNoticeBlock.includes('Actividad Hermes no configurada')) {
+  failures.push('Global Usage notice must not contain localized Hermes activity copy')
+}
+
+for (const forbidden of ['state.db', 'MUGIWARA_HERMES_PROFILES_ROOT', 'tokens por sesión', 'tokens por conversación']) {
+  if (page.includes(forbidden)) failures.push(`Usage UI must not render sensitive Hermes internals: ${forbidden}`)
+}
+
+if (failures.length > 0) {
+  console.error('Usage partial Hermes status regression check failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log('Usage partial Hermes status regression check passed')

--- a/scripts/check-usage-server-only.mjs
+++ b/scripts/check-usage-server-only.mjs
@@ -57,6 +57,12 @@ if (!page.includes('Ventanas 5h históricas') || !page.includes('usage-windows-l
 if (!page.includes('Actividad Hermes agregada') || !page.includes('usage-hermes-activity-list') || !page.includes('correlación orientativa')) {
   failures.push('usage page must render Hermes aggregated activity as orientative correlation without generic table overflow')
 }
+if (!page.includes('const usageCoreStatus = currentResponse.status') || page.includes(': hermesActivityResponse.status')) {
+  failures.push('usage page must not promote Hermes activity status to global Usage core status')
+}
+if (!page.includes('noticeFromHermesActivityStatus(hermesActivityResponse.status)') || !page.includes('Actividad Hermes no configurada')) {
+  failures.push('usage page must localize Hermes activity not_configured in its own section')
+}
 for (const forbidden of ['state.db', 'MUGIWARA_HERMES_PROFILES_ROOT', 'conversaciones', 'prompts crudos', 'tokens por sesión', 'tokens por conversación']) {
   if (page.includes(forbidden)) {
     failures.push(`usage page must not render Hermes sensitive internals: ${forbidden}`)


### PR DESCRIPTION
## Resumen

Corrige `/usage` para que `usage.hermes_activity: not_configured` no degrade toda la página a “Usage sin fuente configurada” cuando el core Codex está listo.

## Cambios

- Separa el estado global/core de Usage (`current`, `calendar`, `five-hour-windows`) del estado parcial de Hermes activity.
- Mantiene el estado global ready cuando el core Codex está ready, aunque Hermes activity esté `not_configured`.
- Añade aviso localizado en la sección “Actividad Hermes agregada”: “Actividad Hermes no configurada”.
- Refuerza `verify:usage-server-only` para detectar regresiones donde Hermes vuelva a gobernar el estado global.
- Añade test/regression script específico para el caso mixto core ready + Hermes activity not_configured.

## Seguridad / privacidad

- No se añaden rutas ni parámetros nuevos.
- Se mantiene frontend server page y adapter `server-only` existente.
- No se exponen rutas host, envs, perfiles internos, prompts, conversaciones, tokens ni payloads crudos.
- El aviso nuevo solo muestra estado técnico saneado `hermes-activity: not_configured`.

## Verificación de Zoro

- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` → 12 passed.
- `npm run test:usage-partial-hermes-status` → passed.
- `npm run verify:usage-server-only` → passed.
- `npm --prefix apps/web run typecheck` → passed.
- `npm --prefix apps/web run build` → passed.
- `git diff --check` → passed.
- Smoke HTTP build local `/usage`: 200, sin “Usage sin fuente configurada”, con “Actividad Hermes no configurada” localizada.
- Smoke visual browser `/usage`: Codex/Usage operativo, aviso Hermes localizado en la sección Actividad Hermes.

## Review solicitada

- **Chopper**: seguridad/privacy, confirmar que no hay nueva exposición de rutas/env/perfiles/prompts/conversaciones/tokens/payloads crudos.
- **Usopp**: UX/UI, confirmar que la jerarquía comunica core Usage operativo y degradación localizada de Hermes activity.

Closes #99
