### PR TITLE
fix: configure Hermes activity runtime source

### DIFF
--- a/apps/api/src/modules/usage/service.py
+++ b/apps/api/src/modules/usage/service.py
@@ -321,7 +321,7 @@ class UsageService:
                     'logs_crudos',
                 ],
             },
-            'empty_reason': None if totals['sessions_count'] > 0 else 'not_configured',
+            'empty_reason': None if totals['sessions_count'] > 0 else 'no_activity',
         }
 
     @staticmethod
@@ -330,8 +330,10 @@ class UsageService:
             return 'not_configured'
         if payload.get('empty_reason') == 'unknown':
             return 'unknown'
+        if payload.get('empty_reason') == 'no_activity':
+            return 'empty'
         if payload.get('totals', {}).get('sessions_count', 0) <= 0:
-            return 'not_configured'
+            return 'empty'
         return 'ready'
 
     @staticmethod

--- a/apps/api/tests/test_usage_api.py
+++ b/apps/api/tests/test_usage_api.py
@@ -573,6 +573,28 @@ def test_usage_hermes_activity_aggregates_profile_sessions_without_leaking_sensi
     _assert_no_usage_activity_leakage(payload)
 
 
+def test_usage_hermes_activity_returns_empty_when_profiles_are_configured_but_have_no_activity(tmp_path):
+    profiles_root = tmp_path / 'profiles'
+    _create_hermes_state_db(profiles_root / 'zoro' / 'state.db', [])
+    _override_usage_service(UsageService(db_path=tmp_path / 'missing-codex.sqlite', hermes_profiles_root=profiles_root, now=lambda: '2026-04-27T10:00:00+00:00'))
+
+    response = TestClient(app).get('/api/v1/usage/hermes-activity?range=7d')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['status'] == 'empty'
+    assert payload['data']['empty_reason'] == 'no_activity'
+    assert payload['data']['profiles'] == []
+    assert payload['data']['totals'] == {
+        'profiles_count': 0,
+        'sessions_count': 0,
+        'messages_count': 0,
+        'tool_calls_count': 0,
+        'dominant_profile': None,
+    }
+    _assert_no_usage_activity_leakage(payload)
+
+
 def test_usage_hermes_activity_degrades_when_profiles_root_is_not_configured(tmp_path):
     _override_usage_service(UsageService(db_path=tmp_path / 'missing-codex.sqlite', hermes_profiles_root=None, now=lambda: '2026-04-27T10:00:00+00:00'))
 

--- a/apps/web/src/app/usage/page.tsx
+++ b/apps/web/src/app/usage/page.tsx
@@ -207,6 +207,15 @@ function noticeFromHermesActivityStatus(status: ResourceStatus): HermesActivityN
     }
   }
 
+  if (status === 'empty') {
+    return {
+      status: 'sin-datos',
+      title: 'Actividad Hermes sin sesiones en el rango',
+      description: 'La fuente agregada de Hermes está configurada, pero no hay actividad allowlisted para el rango actual. No se muestran rutas ni datos internos.',
+      detail: 'Estado técnico de hermes-activity: empty',
+    }
+  }
+
   if (status === 'stale') {
     return {
       status: 'stale',

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -36,6 +36,8 @@ Instalación:
 scripts/install-control-panel-user-services.sh
 ```
 
+El instalador copia las units, escribe la configuración local privada de API, ejecuta `daemon-reload` y reinicia API/Web para que los cambios de configuración server-only apliquen inmediatamente.
+
 URL privada actual:
 
 ```text
@@ -46,10 +48,11 @@ http://<magicdns-host>:3017
 Contrato de seguridad:
 
 1. La API no se expone por Tailscale ni por LAN; escucha solo en loopback.
-2. La web consume `MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011` solo server-side.
-3. El runner web detecta la IPv4 de Tailscale y rechaza bind wildcard (`0.0.0.0`/`::`).
-4. Esto sigue siendo `internet-public: unsupported`: no usa Tailscale Funnel, no abre puertos públicos ni añade auth pública/rate-limit.
-5. Si Tailscale no está disponible, el servicio web falla y systemd reintenta, en vez de caer silenciosamente a exposición pública.
+2. La unidad API carga configuración local server-only desde un `EnvironmentFile` no versionado y creado por el instalador; ahí vive la raíz de perfiles Hermes para `usage.hermes_activity`.
+3. La web consume `MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011` solo server-side.
+4. El runner web detecta la IPv4 de Tailscale y rechaza bind wildcard (`0.0.0.0`/`::`).
+5. Esto sigue siendo `internet-public: unsupported`: no usa Tailscale Funnel, no abre puertos públicos ni añade auth pública/rate-limit.
+6. Si Tailscale no está disponible, el servicio web falla y systemd reintenta, en vez de caer silenciosamente a exposición pública.
 
 Guardarraíl:
 
@@ -82,7 +85,7 @@ Si cambia la IP Tailscale del host, actualizar este documento, `openspec/control
 | --- | --- | --- | --- |
 | `MUGIWARA_CONTROL_PANEL_API_URL` | `/memory`, `/mugiwaras`, `/skills` BFF/server loaders, `/vault`, `/dashboard`, `/healthcheck` | Server-only | Base URL del backend para superficies que deben resolver datos desde servidor o frontera BFF. Debe apuntar a loopback, red privada o Tailscale/private hostname; no es configuración pública de navegador. |
 | `MUGIWARA_CONTROL_PANEL_TRUSTED_ORIGINS` | `/skills` BFF write routes | Server-only | Allowlist separada por comas de orígenes exactos `http:`/`https:` permitidos para `POST`/`PUT` de Skills. Debe contener solo orígenes privados/locales/Tailscale; si falta, las escrituras BFF devuelven `403 trusted_origins_not_configured`. |
-| `MUGIWARA_HERMES_PROFILES_ROOT` | Backend `usage.hermes_activity` | Server-only | Raíz local de perfiles Hermes usada solo por el backend para agregados read-only. Si falta, el endpoint degrada a `not_configured`; el valor runtime y las rutas de bases de datos no se serializan en API ni UI. |
+| `MUGIWARA_HERMES_PROFILES_ROOT` | Backend `usage.hermes_activity` | Server-only | Raíz local de perfiles Hermes cargada por el servicio API desde configuración local no versionada para agregados read-only. Si falta, el endpoint degrada a `not_configured`; si existe pero no hay sesiones en el rango, responde `empty`/`no_activity`; el valor runtime y las rutas de bases de datos no se serializan en API ni UI. |
 
 ## Usage
 `/usage` usa fuentes server-side/read-only desde Phase 17:
@@ -90,7 +93,7 @@ Si cambia la IP Tailscale del host, actualizar este documento, `openspec/control
 1. El frontend consume el backend mediante adapter `server-only` y `MUGIWARA_CONTROL_PANEL_API_URL`, sin `NEXT_PUBLIC_*` ni lectura directa de env en la página.
 2. `GET /api/v1/usage/current`, `calendar` y `five-hour-windows` leen únicamente la SQLite saneada de Codex usage.
 3. `GET /api/v1/usage/hermes-activity` lee actividad Hermes solo si `MUGIWARA_HERMES_PROFILES_ROOT` está configurado en el backend; abre perfiles allowlisted en modo lectura y serializa únicamente agregados por perfil/rango.
-4. La actividad Hermes no devuelve rutas, prompts, conversaciones, payloads de herramientas, tokens por sesión/conversación, identificadores, secrets, cabeceras, cookies ni logs; si la fuente falta o falla, degrada a `not_configured`.
+4. La actividad Hermes no devuelve rutas, prompts, conversaciones, payloads de herramientas, tokens por sesión/conversación, identificadores, secrets, cabeceras, cookies ni logs; si la fuente falta degrada a `not_configured`, y si está configurada pero no hay sesiones en el rango devuelve un vacío explícito `empty`/`no_activity`.
 5. La UI consume `hermes-activity?range=7d` mediante el mismo adapter server-only y muestra solo agregados por perfil/rango como correlación orientativa, sin valores internos de configuración ni rutas.
 
 Antes de cerrar cambios que toquen Usage config, ejecutar:

--- a/openspec/control-panel-tailscale-service.md
+++ b/openspec/control-panel-tailscale-service.md
@@ -31,11 +31,13 @@ Runtime Tailscale detectado:
 2. **Web Tailscale-only por defecto**: el runner web exige una IP Tailscale salvo override explícito. No cae silenciosamente a `0.0.0.0`.
 3. **Production Next**: el servicio web usa `next start`, no `next dev`; el installer construye `apps/web/.next` antes de arrancar.
 4. **systemd user-level**: evita `User=`/`Group=` y sigue el patrón operativo ya usado por los runners Healthcheck.
-5. **Fail closed**: si Tailscale no está disponible y no hay override, la web falla y systemd reintenta, en vez de abrir en todas las interfaces.
+5. **Config API local server-only**: la unidad API carga un `EnvironmentFile` no versionado creado por el instalador para habilitar fuentes backend-only como Hermes activity sin poner valores runtime en el repo.
+6. **Fail closed**: si Tailscale no está disponible y no hay override, la web falla y systemd reintenta, en vez de abrir en todas las interfaces.
 
 ## Definition of Done
 - Units versionadas en `ops/systemd/user/`.
 - Scripts runner e installer versionados en `scripts/`.
+- Installer crea configuración local server-only para la fuente Hermes activity sin versionar valores runtime.
 - Guardrail `verify:control-panel-service-runner` pasa.
 - `systemd-analyze --user verify` acepta ambas units.
 - Installer instala, habilita y arranca ambos servicios.

--- a/ops/systemd/user/mugiwara-control-panel-api.service
+++ b/ops/systemd/user/mugiwara-control-panel-api.service
@@ -11,6 +11,8 @@ RestartSec=5s
 TimeoutStartSec=30s
 
 # Private v1 contract: API remains loopback-only. The web service is the Tailscale-facing surface.
+# Hermes profile activity root is loaded from a local, non-versioned env file created by the installer.
+EnvironmentFile=-%h/.config/mugiwara-control-panel/api.env
 Environment=MUGIWARA_CONTROL_PANEL_API_HOST=127.0.0.1
 Environment=MUGIWARA_CONTROL_PANEL_API_PORT=8011
 

--- a/packages/contracts/src/read-models.ts
+++ b/packages/contracts/src/read-models.ts
@@ -312,7 +312,7 @@ export type UsageHermesActivity = {
     correlation: 'orientativa'
     exclusions: string[]
   }
-  empty_reason: 'not_configured' | 'unknown' | null
+  empty_reason: 'not_configured' | 'unknown' | 'no_activity' | null
 }
 
 

--- a/scripts/check-control-panel-service-runner.mjs
+++ b/scripts/check-control-panel-service-runner.mjs
@@ -71,6 +71,7 @@ mustInclude(webRunner, 'npm --prefix apps/web run start -- --hostname "$web_host
 mustNotInclude(stripHelp(webRunner), /--hostname\s+0\.0\.0\.0|NEXT_PUBLIC|tailscale\s+(funnel|serve)|--reload/i, 'web runner', 'wildcard bind, browser env, Tailscale Funnel/Serve or dev reload')
 
 mustInclude(apiService, 'ExecStart=/usr/bin/env bash scripts/run-control-panel-api.sh', 'API service')
+mustInclude(apiService, 'EnvironmentFile=-%h/.config/mugiwara-control-panel/api.env', 'API service')
 mustInclude(apiService, 'Environment=MUGIWARA_CONTROL_PANEL_API_HOST=127.0.0.1', 'API service')
 mustInclude(apiService, 'Environment=MUGIWARA_CONTROL_PANEL_API_PORT=8011', 'API service')
 mustInclude(apiService, 'Restart=on-failure', 'API service')
@@ -87,10 +88,16 @@ mustInclude(webService, 'Restart=on-failure', 'web service')
 mustInclude(webService, 'WantedBy=default.target', 'web service')
 mustNotInclude(stripComments(webService), /User=|Group=|0\.0\.0\.0|NEXT_PUBLIC|funnel|serve/i, 'web service', 'system user/group, wildcard bind or public exposure')
 
+mustInclude(installer, 'api_env_file="$config_root/api.env"', 'installer')
+mustInclude(installer, 'hermes_profiles_root="${MUGIWARA_HERMES_PROFILES_ROOT:-$HOME/.hermes/profiles}"', 'installer')
+mustInclude(installer, 'MUGIWARA_HERMES_PROFILES_ROOT=%q', 'installer')
+mustInclude(installer, 'chmod 0600 "$api_env_file"', 'installer')
 mustInclude(installer, 'npm --prefix apps/web run build', 'installer')
 mustInclude(installer, 'tailscale ip -4', 'installer')
-mustInclude(installer, 'systemctl --user enable --now "$api_service"', 'installer')
-mustInclude(installer, 'systemctl --user enable --now "$web_service"', 'installer')
+mustInclude(installer, 'systemctl --user enable "$api_service"', 'installer')
+mustInclude(installer, 'systemctl --user enable "$web_service"', 'installer')
+mustInclude(installer, 'systemctl --user restart "$api_service"', 'installer')
+mustInclude(installer, 'systemctl --user restart "$web_service"', 'installer')
 mustNotInclude(stripHelp(installer), /0\.0\.0\.0|funnel|serve|NEXT_PUBLIC|--host\s+0/i, 'installer', 'public exposure or browser env')
 
 for (const [text, label] of [[runtimeConfig, 'runtime config docs'], [openspec, 'OpenSpec']]) {

--- a/scripts/check-usage-server-only.mjs
+++ b/scripts/check-usage-server-only.mjs
@@ -63,6 +63,9 @@ if (!page.includes('const usageCoreStatus = currentResponse.status') || page.inc
 if (!page.includes('noticeFromHermesActivityStatus(hermesActivityResponse.status)') || !page.includes('Actividad Hermes no configurada')) {
   failures.push('usage page must localize Hermes activity not_configured in its own section')
 }
+if (!page.includes('Actividad Hermes sin sesiones en el rango') || !page.includes('hermes-activity: empty')) {
+  failures.push('usage page must distinguish configured Hermes activity with no sessions from not_configured')
+}
 for (const forbidden of ['state.db', 'MUGIWARA_HERMES_PROFILES_ROOT', 'conversaciones', 'prompts crudos', 'tokens por sesión', 'tokens por conversación']) {
   if (page.includes(forbidden)) {
     failures.push(`usage page must not render Hermes sensitive internals: ${forbidden}`)
@@ -106,6 +109,9 @@ if (!usageService.includes('HERMES_ACTIVITY_PROFILES =') || !usageService.includ
 }
 if (!usageService.includes("file:{state_db}?mode=ro")) {
   failures.push('usage hermes activity must open Hermes profile state read-only')
+}
+if (!usageService.includes("'no_activity'") || !usageService.includes("return 'empty'")) {
+  failures.push('usage hermes activity must distinguish configured empty activity from missing configuration')
 }
 for (const forbidden of ['SELECT *', 'system_prompt', 'model_config', 'user_id', 'token_count', 'input_tokens', 'output_tokens', 'reasoning_tokens', 'estimated_cost_usd', 'actual_cost_usd', 'billing_base_url', 'title']) {
   if (activityLoader.includes(forbidden)) {

--- a/scripts/install-control-panel-user-services.sh
+++ b/scripts/install-control-panel-user-services.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 repo_root="/srv/crew-core/projects/mugiwara-control-panel"
 unit_source_dir="$repo_root/ops/systemd/user"
+config_root="${XDG_CONFIG_HOME:-$HOME/.config}/mugiwara-control-panel"
+api_env_file="$config_root/api.env"
 unit_target_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
 api_service="mugiwara-control-panel-api.service"
 web_service="mugiwara-control-panel-web.service"
@@ -23,6 +25,7 @@ Contract:
   - API binds only to 127.0.0.1:8011
   - Web binds to the current Tailscale IPv4 on port 3017 by default
   - Web uses MUGIWARA_CONTROL_PANEL_API_URL=http://127.0.0.1:8011 server-side
+  - creates a local server-only API env file for Hermes activity aggregates
   - does not use wildcard bind, Tailscale Funnel, public internet exposure or alternate backend URL
 USAGE
   exit 0
@@ -46,16 +49,31 @@ if [[ -z "$tailscale_ip" ]]; then
   exit 1
 fi
 
+hermes_profiles_root="${MUGIWARA_HERMES_PROFILES_ROOT:-$HOME/.hermes/profiles}"
+if [[ ! -d "$hermes_profiles_root" || ! -r "$hermes_profiles_root" || ! -x "$hermes_profiles_root" ]]; then
+  echo "Hermes profiles root is not readable; set MUGIWARA_HERMES_PROFILES_ROOT before installing" >&2
+  exit 1
+fi
+
 cd "$repo_root"
 npm --prefix apps/web run build
+
+install -d -m 0750 "$config_root"
+{
+  printf '# Local private config for mugiwara-control-panel-api.service\n'
+  printf 'MUGIWARA_HERMES_PROFILES_ROOT=%q\n' "$hermes_profiles_root"
+} >"$api_env_file"
+chmod 0600 "$api_env_file"
 
 install -d -m 0750 "$unit_target_dir"
 install -m 0644 "$unit_source_dir/$api_service" "$unit_target_dir/$api_service"
 install -m 0644 "$unit_source_dir/$web_service" "$unit_target_dir/$web_service"
 
 systemctl --user daemon-reload
-systemctl --user enable --now "$api_service"
-systemctl --user enable --now "$web_service"
+systemctl --user enable "$api_service"
+systemctl --user enable "$web_service"
+systemctl --user restart "$api_service"
+systemctl --user restart "$web_service"
 systemctl --user --no-pager --full status "$api_service" "$web_service" || true
 printf 'Control Panel private URL: http://%s:3017
 ' "$tailscale_ip"


### PR DESCRIPTION
## Objetivo
Configurar de forma segura la fuente server-only de Hermes activity para que `/usage` deje de mostrar `hermes-activity: not_configured` cuando existen perfiles Hermes legibles.

Closes #109

## Cambios
- Añade `EnvironmentFile=-%h/.config/mugiwara-control-panel/api.env` a la unit API user-level.
- Actualiza el instalador para crear un env file local no versionado con `MUGIWARA_HERMES_PROFILES_ROOT`, permisos `0600`, y reiniciar API/Web tras copiar units.
- Mantiene API loopback-only y web por Tailscale; no añade discovery arbitrario ni proxy genérico.
- Mantiene perfiles Mugiwara allowlisted y lectura SQLite `mode=ro`.
- Distingue fuente configurada pero sin sesiones en rango como `status=empty` + `empty_reason=no_activity`, evitando confundirlo con `not_configured`.
- Actualiza contratos, UI copy mínima, guardrails y docs runtime/OpenSpec.

## Privacidad / no-leakage
- No se serializan rutas host, valores de env, `state.db`, prompts, conversaciones, tokens, chat IDs, delivery targets, headers, cookies, logs ni payloads crudos.
- El smoke runtime devuelve solo agregados por perfil allowlisted.

## Verificación de Zoro
- `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` → 13 passed.
- `npm run verify:usage-server-only` → passed.
- `npm run verify:control-panel-service-runner` → passed.
- `systemd-analyze --user verify ops/systemd/user/mugiwara-control-panel-api.service ops/systemd/user/mugiwara-control-panel-web.service` → passed.
- `npm --prefix apps/web run typecheck` → passed.
- `npm --prefix apps/web run build` → passed; `/usage` sigue dinámica (`ƒ`).
- `git diff --check` → passed.
- Installer ejecutado en runtime privado; services API/Web activos tras restart.
- Smoke API `GET http://127.0.0.1:8011/api/v1/usage/hermes-activity?range=7d` → `status=ready`, `profiles_count=10`, `sessions_count=1245`, `sanitized=true`, sin marcadores sensibles buscados.
- Smoke visual `/usage` en producción privada Tailscale → sección `Actividad Hermes agregada` visible con agregados reales; consola del navegador sin errores.

## Review solicitada
- Chopper obligatorio: privacidad/no-leakage, frontera filesystem/env y datos Hermes.
- Franky obligatorio: systemd/runner/runtime config, instalador, restart semantics y operabilidad.

No mergear sin review de Chopper y Franky.