### PR TITLE
fix: reorder usage top cards

### DIFF
--- a/apps/web/src/app/usage/page.tsx
+++ b/apps/web/src/app/usage/page.tsx
@@ -50,15 +50,6 @@ const windowStatusMap: Record<UsageWindowStatus, { appStatus: AppStatus; label: 
   unknown: { appStatus: 'sin-datos', label: 'Sin datos', accent: 'sky' },
 }
 
-const recommendationStatusMap: Record<UsageCurrent['recommendation']['state'], AppStatus> = {
-  normal: 'operativo',
-  alto: 'revision',
-  critico: 'incidencia',
-  limite_alcanzado: 'incidencia',
-  datos_antiguos: 'stale',
-  sin_datos: 'sin-datos',
-}
-
 const calendarStatusMap: Record<UsageCalendarDayStatus, { appStatus: AppStatus; label: string; accent: 'sky' | 'success' | 'warning' | 'danger' }> = {
   normal: { appStatus: 'operativo', label: 'Normal', accent: 'success' },
   high: { appStatus: 'revision', label: 'Alto', accent: 'warning' },
@@ -595,7 +586,6 @@ function UsageHermesActivityPanel({ activity, notice, isSnapshotMode }: { activi
 
 export default async function UsagePage() {
   const { usage, calendar, fiveHourWindowDays, hermesActivity, notice, hermesActivityNotice, isSnapshotMode } = await getInitialUsageData()
-  const recommendationStatus = recommendationStatusMap[usage.recommendation.state]
 
   return (
     <>
@@ -627,8 +617,21 @@ export default async function UsagePage() {
       ) : null}
 
       <section className="layout-grid layout-grid--dashboard-metrics section-block" aria-label="Estado actual de Usage">
+        <SurfaceCard title="Tokens Hermes" eyebrow="Última semana + total" accent="gold" elevated>
+          <dl style={{ margin: 0, display: 'grid', gap: '10px' }}>
+            <div>
+              <dt style={{ color: appTheme.colors.textMuted, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Últimos 7 días</dt>
+              <dd style={{ margin: 0, fontSize: '26px', fontWeight: 800 }}>{formatActivityCount(hermesActivity.totals.weekly_tokens_count)}</dd>
+            </div>
+            <div>
+              <dt style={{ color: appTheme.colors.textMuted, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Total Hermes</dt>
+              <dd style={{ margin: 0, fontSize: '22px', fontWeight: 800 }}>{formatActivityCount(hermesActivity.totals.total_tokens_count)}</dd>
+            </div>
+          </dl>
+        </SurfaceCard>
+        <WindowCard title="Ventana semanal" window={usage.secondary_cycle} emphasis />
         <WindowCard title="Ventana 5h" window={usage.primary_window} />
-        <SurfaceCard title="Plan" eyebrow="Cuenta Codex" accent="sky">
+        <SurfaceCard title="Cuenta Codex" eyebrow="Plan" accent="sky">
           <dl style={{ margin: 0, display: 'grid', gap: '10px' }}>
             <div>
               <dt style={{ color: appTheme.colors.textMuted, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Tipo</dt>
@@ -643,25 +646,6 @@ export default async function UsagePage() {
               <dd style={{ margin: 0 }}>{formatBoolean(usage.plan.limit_reached)}</dd>
             </div>
           </dl>
-        </SurfaceCard>
-        <SurfaceCard title="Tokens Hermes" eyebrow="Última semana + total" accent="gold" elevated>
-          <dl style={{ margin: 0, display: 'grid', gap: '10px' }}>
-            <div>
-              <dt style={{ color: appTheme.colors.textMuted, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Últimos 7 días</dt>
-              <dd style={{ margin: 0, fontSize: '26px', fontWeight: 800 }}>{formatActivityCount(hermesActivity.totals.weekly_tokens_count)}</dd>
-            </div>
-            <div>
-              <dt style={{ color: appTheme.colors.textMuted, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Total Hermes</dt>
-              <dd style={{ margin: 0, fontSize: '22px', fontWeight: 800 }}>{formatActivityCount(hermesActivity.totals.total_tokens_count)}</dd>
-            </div>
-          </dl>
-        </SurfaceCard>
-        <SurfaceCard title="Recomendación actual" eyebrow="Prioridad" accent={recommendationStatus === 'incidencia' ? 'danger' : recommendationStatus === 'revision' ? 'warning' : 'success'} elevated>
-          <p style={{ margin: '0 0 10px', fontSize: '24px', fontWeight: 800 }}>{usage.recommendation.label}</p>
-          <p style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.5 }}>{usage.recommendation.message}</p>
-          <div style={{ marginTop: '12px' }}>
-            <StatusBadge status={recommendationStatus} />
-          </div>
         </SurfaceCard>
       </section>
 

--- a/scripts/check-usage-server-only.mjs
+++ b/scripts/check-usage-server-only.mjs
@@ -68,6 +68,17 @@ if (!page.includes('Actividad Hermes agregada') || !page.includes('usage-hermes-
 if (!page.includes('Tokens Hermes') || !page.includes('weekly_tokens_count') || !page.includes('total_tokens_count')) {
   failures.push('usage page must render aggregate Hermes token counters without raw sessions')
 }
+const topCardsStart = page.indexOf('aria-label="Estado actual de Usage"')
+const topCardsEnd = page.indexOf('aria-label="Calendario Usage"')
+const topCards = topCardsStart >= 0 && topCardsEnd > topCardsStart ? page.slice(topCardsStart, topCardsEnd) : ''
+const expectedTopCards = ['Tokens Hermes', 'Ventana semanal', 'Ventana 5h', 'Cuenta Codex']
+const topCardPositions = expectedTopCards.map((label) => topCards.indexOf(label))
+if (topCardPositions.some((position) => position < 0) || topCardPositions.some((position, index) => index > 0 && position <= topCardPositions[index - 1])) {
+  failures.push('usage top cards must be ordered as Tokens Hermes, Ventana semanal, Ventana 5h and Cuenta Codex')
+}
+if (topCards.includes('Recomendación actual')) {
+  failures.push('usage top cards must not render the Recomendación actual card')
+}
 if (page.includes('eyebrow="Metodología"') || page.includes('Alcance Phase 17.4d') || page.includes('Deny by default')) {
   failures.push('usage page must remove heavy methodology/scope/security explainer containers')
 }


### PR DESCRIPTION
## Summary
- reorders `/usage` top cards as requested: `Tokens Hermes`, `Ventana semanal`, `Ventana 5h`, `Cuenta Codex`
- removes the top-level `Recomendación actual` card
- restores the weekly Codex usage window as a top-level card
- extends `verify:usage-server-only` to lock the requested top-card order and prevent `Recomendación actual` returning to that block

## Scope
- UI-only / guardrail-only change.
- No backend payload changes.
- No Hermes privacy/data surface changes.
- No new endpoint, polling, runtime or dependency changes.

## Verify
- `npm run verify:usage-server-only` → passed
- `npm --prefix apps/web run typecheck` → passed
- `npm --prefix apps/web run build` → passed
- `git diff --check` → passed
- Branch production smoke on `http://127.0.0.1:3018/usage` with API `127.0.0.1:8011`:
  - top-card order confirmed in HTML and browser accessibility snapshot: `Tokens Hermes` → `Ventana semanal` → `Ventana 5h` → `Cuenta Codex`
  - `Recomendación actual` absent from top-card block / HTML
  - browser console clean

## Review needed
- Usopp: UI/UX review of `/usage` top-card hierarchy and order.

Chopper not requested because this does not alter backend, payload, Hermes data, privacy boundary or server-only adapters.
