### PR TITLE
fix: polish usage accessibility

### DIFF
--- a/.engram/issue-112-usage-polish-closeout.md
+++ b/.engram/issue-112-usage-polish-closeout.md
@@ -1,0 +1,25 @@
+# Issue 112 closeout — `/usage` polish
+
+## Resumen
+Microfase UI/accesibilidad derivada de follow-ups Usopp de PR #111. El cambio pule `/usage` sin modificar backend, endpoints, payloads, contratos ni privacidad.
+
+## Cambios previstos/cerrados
+- Números largos de tokens Hermes mostrados con formato compacto visual y valor completo conservado en `data[value]`, `title` y `aria-label`.
+- Listas internas de ventanas/perfiles con affordance de scroll mediante scrollbar coloreada, sombra interna y microcopy discreta.
+- Selector diario de ventanas 5h con IDs estables por fecha, tabpanel enlazado con `aria-labelledby` y `focus-visible` explícito.
+- Guardrail `verify:usage-server-only` ampliado para fijar estos invariantes sin tocar frontera de datos.
+
+## Frontera preservada
+UI-only. No se tocan backend, payloads, endpoints, privacy model ni tokens raw. Los tokens siguen siendo agregados ya existentes.
+
+## Verify
+Completado antes de PR:
+- `npm run verify:usage-server-only`.
+- `npm --prefix apps/web run typecheck`.
+- `npm --prefix apps/web run build`.
+- `npm run verify:visual-baseline`.
+- `git diff --check`.
+- Smoke HTTP/browser en producción local con API de la rama: `/usage` 200, consola limpia, sin overflow horizontal en viewport disponible, sin `MUGIWARA_CONTROL_PANEL_API_URL`, `127.0.0.1:8012`, `state.db` ni `Traceback` en HTML/DOM.
+
+## Limitación
+La herramienta de navegador disponible no permitió redimensionado real a 390×844/1024×768; se cubrió responsive mediante CSS existente, baseline versionada y viewport real 1280px.

--- a/.engram/issue-112-usage-polish-closeout.md
+++ b/.engram/issue-112-usage-polish-closeout.md
@@ -7,6 +7,9 @@ Microfase UI/accesibilidad derivada de follow-ups Usopp de PR #111. El cambio pu
 - Números largos de tokens Hermes mostrados con formato compacto visual y valor completo conservado en `data[value]`, `title` y `aria-label`.
 - Listas internas de ventanas/perfiles con affordance de scroll mediante scrollbar coloreada, sombra interna y microcopy discreta.
 - Selector diario de ventanas 5h con IDs estables por fecha, tabpanel enlazado con `aria-labelledby` y `focus-visible` explícito.
+- Navegación de teclado real en el tablist (`ArrowLeft/Right`, `ArrowUp/Down`, `Home`, `End`) tras review `request_changes` de Usopp.
+- Cards superiores de `/usage` igualadas por abajo mediante `usage-top-cards`.
+- Ventanas 5h del día seleccionado ordenadas de más reciente a más antigua por `started_at`.
 - Guardrail `verify:usage-server-only` ampliado para fijar estos invariantes sin tocar frontera de datos.
 
 ## Frontera preservada
@@ -20,6 +23,7 @@ Completado antes de PR:
 - `npm run verify:visual-baseline`.
 - `git diff --check`.
 - Smoke HTTP/browser en producción local con API de la rama: `/usage` 200, consola limpia, sin overflow horizontal en viewport disponible, sin `MUGIWARA_CONTROL_PANEL_API_URL`, `127.0.0.1:8012`, `state.db` ni `Traceback` en HTML/DOM.
+- Smoke DOM adicional tras feedback de Pablo/review Usopp: cards superiores `[324,324,324,324]`, navegación de teclado mueve selección/foco, `End` vuelve a hoy, primera ventana visible `18:00 → 23:00`, sin overflow horizontal ni fugas sensibles.
 
 ## Limitación
 La herramienta de navegador disponible no permitió redimensionado real a 390×844/1024×768; se cubrió responsive mediante CSS existente, baseline versionada y viewport real 1280px.

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -187,6 +187,38 @@ button {
   scrollbar-width: thin;
 }
 
+.usage-scroll-affordance {
+  border-radius: 16px;
+  scrollbar-color: #5a9ddb rgba(90, 157, 219, 0.14);
+  box-shadow:
+    inset 0 18px 18px -22px rgba(220, 230, 246, 0.48),
+    inset 0 -28px 24px -24px rgba(220, 230, 246, 0.82),
+    inset 0 0 0 1px rgba(90, 157, 219, 0.18);
+  overscroll-behavior: contain;
+}
+
+.usage-scroll-affordance::-webkit-scrollbar {
+  width: 10px;
+}
+
+.usage-scroll-affordance::-webkit-scrollbar-track {
+  border-radius: 999px;
+  background: rgba(90, 157, 219, 0.12);
+}
+
+.usage-scroll-affordance::-webkit-scrollbar-thumb {
+  border: 2px solid rgba(24, 36, 61, 0.92);
+  border-radius: 999px;
+  background: #5a9ddb;
+}
+
+.usage-scroll-hint {
+  margin: 0;
+  color: #9aa7bd;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
 .usage-window-day-selector {
   display: flex;
   gap: 8px;
@@ -213,6 +245,11 @@ button {
   border-color: rgba(232, 181, 106, 0.9);
   background: rgba(232, 181, 106, 0.18);
   color: #ffe4b9;
+}
+
+.usage-window-day-selector__button:focus-visible {
+  outline: 3px solid #e8b56a;
+  outline-offset: 3px;
 }
 
 .usage-window-row {
@@ -276,6 +313,26 @@ button {
 .usage-hermes-activity-row__metrics dd {
   margin: 2px 0 0;
   font-weight: 800;
+}
+
+.usage-compact-number {
+  display: inline-flex;
+  max-width: 100%;
+  align-items: baseline;
+  gap: 6px;
+  white-space: normal;
+}
+
+.usage-compact-number__full {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+  padding: 0;
 }
 
 .usage-hermes-activity-list {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -66,6 +66,14 @@ button {
   grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
+.usage-top-cards {
+  align-items: stretch;
+}
+
+.usage-top-cards > .surface-card {
+  height: 100%;
+}
+
 .layout-grid--sidebar-detail {
   grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
 }

--- a/apps/web/src/app/usage/page.tsx
+++ b/apps/web/src/app/usage/page.tsx
@@ -467,6 +467,29 @@ function formatActivityCount(value: number) {
   return new Intl.NumberFormat('es-ES').format(value)
 }
 
+function formatCompactActivityCount(value: number) {
+  return new Intl.NumberFormat('es-ES', {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(value)
+}
+
+function CompactActivityCount({ value, ariaLabel }: { value: number; ariaLabel: string }) {
+  const fullValue = formatActivityCount(value)
+
+  return (
+    <data
+      className="usage-compact-number"
+      value={String(value)}
+      title={`${ariaLabel}: ${fullValue}`}
+      aria-label={`${ariaLabel}: ${fullValue}`}
+    >
+      <span aria-hidden="true">{formatCompactActivityCount(value)}</span>
+      <span className="usage-compact-number__full">{fullValue}</span>
+    </data>
+  )
+}
+
 function formatProfileName(profile: string | null) {
   if (!profile) {
     return 'Sin perfil dominante'
@@ -520,18 +543,19 @@ function UsageHermesActivityPanel({ activity, notice, isSnapshotMode }: { activi
           </div>
           <div>
             <dt>Tokens 7 días</dt>
-            <dd>{formatActivityCount(activity.totals.weekly_tokens_count)}</dd>
+            <dd><CompactActivityCount value={activity.totals.weekly_tokens_count} ariaLabel="Tokens Hermes de los últimos 7 días" /></dd>
           </div>
           <div>
             <dt>Tokens totales</dt>
-            <dd>{formatActivityCount(activity.totals.total_tokens_count)}</dd>
+            <dd><CompactActivityCount value={activity.totals.total_tokens_count} ariaLabel="Tokens Hermes totales" /></dd>
           </div>
         </dl>
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px', alignItems: 'center' }}>
           <StatusBadge status={activity.totals.dominant_profile ? 'revision' : 'sin-datos'} label={`Perfil dominante: ${dominantProfile}`} />
           <span style={{ color: appTheme.colors.textSecondary }}>Rango: {formatTimestamp(activity.range.started_at)} → {formatTimestamp(activity.range.ended_at)}</span>
         </div>
-        <div className="usage-hermes-activity-list" role="list" aria-label="Actividad Hermes agregada por perfil">
+        <p className="usage-scroll-hint" aria-hidden="true">Desplaza dentro del panel para ver más perfiles cuando haya overflow.</p>
+        <div className="usage-hermes-activity-list usage-scroll-affordance" role="list" aria-label="Actividad Hermes agregada por perfil">
           {profiles.length > 0 ? (
             profiles.map((profile) => {
               const level = activityLevelMap[profile.activity_level]
@@ -559,11 +583,11 @@ function UsageHermesActivityPanel({ activity, notice, isSnapshotMode }: { activi
                     </div>
                     <div>
                       <dt>Tokens 7d</dt>
-                      <dd>{formatActivityCount(profile.tokens_count)}</dd>
+                      <dd><CompactActivityCount value={profile.tokens_count} ariaLabel={`Tokens Hermes de ${formatProfileName(profile.profile)} en 7 días`} /></dd>
                     </div>
                   </dl>
                   <p style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.5 }}>
-                    Primera/última señal agregada: {formatTimestamp(profile.first_activity_at)} → {formatTimestamp(profile.last_activity_at)}. Tokens totales: {formatActivityCount(profile.total_tokens_count)}.
+                    Primera/última señal agregada: {formatTimestamp(profile.first_activity_at)} → {formatTimestamp(profile.last_activity_at)}. Tokens totales: <CompactActivityCount value={profile.total_tokens_count} ariaLabel={`Tokens Hermes totales de ${formatProfileName(profile.profile)}`} />.
                   </p>
                 </article>
               )
@@ -621,11 +645,11 @@ export default async function UsagePage() {
           <dl style={{ margin: 0, display: 'grid', gap: '10px' }}>
             <div>
               <dt style={{ color: appTheme.colors.textMuted, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Últimos 7 días</dt>
-              <dd style={{ margin: 0, fontSize: '26px', fontWeight: 800 }}>{formatActivityCount(hermesActivity.totals.weekly_tokens_count)}</dd>
+              <dd style={{ margin: 0, fontSize: '26px', fontWeight: 800 }}><CompactActivityCount value={hermesActivity.totals.weekly_tokens_count} ariaLabel="Tokens Hermes de los últimos 7 días" /></dd>
             </div>
             <div>
               <dt style={{ color: appTheme.colors.textMuted, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Total Hermes</dt>
-              <dd style={{ margin: 0, fontSize: '22px', fontWeight: 800 }}>{formatActivityCount(hermesActivity.totals.total_tokens_count)}</dd>
+              <dd style={{ margin: 0, fontSize: '22px', fontWeight: 800 }}><CompactActivityCount value={hermesActivity.totals.total_tokens_count} ariaLabel="Tokens Hermes totales" /></dd>
             </div>
           </dl>
         </SurfaceCard>

--- a/apps/web/src/app/usage/page.tsx
+++ b/apps/web/src/app/usage/page.tsx
@@ -640,7 +640,7 @@ export default async function UsagePage() {
         </StatePanel>
       ) : null}
 
-      <section className="layout-grid layout-grid--dashboard-metrics section-block" aria-label="Estado actual de Usage">
+      <section className="layout-grid layout-grid--dashboard-metrics usage-top-cards section-block" aria-label="Estado actual de Usage">
         <SurfaceCard title="Tokens Hermes" eyebrow="Última semana + total" accent="gold" elevated>
           <dl style={{ margin: 0, display: 'grid', gap: '10px' }}>
             <div>

--- a/apps/web/src/modules/usage/UsageWindowDaysSelector.tsx
+++ b/apps/web/src/modules/usage/UsageWindowDaysSelector.tsx
@@ -59,6 +59,8 @@ export function UsageWindowDaysSelector({ windowDays, isSnapshotMode }: { window
   }, [windowDays.days])
   const [selectedDate, setSelectedDate] = useState(initialDate)
   const selectedDay = windowDays.days.find((day) => day.date === selectedDate) ?? windowDays.days.at(-1)
+  const selectedTabId = selectedDay ? `usage-window-day-tab-${selectedDay.date}` : undefined
+  const selectedPanelId = selectedDay ? `usage-window-day-panel-${selectedDay.date}` : undefined
 
   return (
     <div style={{ display: 'grid', gap: '12px' }}>
@@ -73,12 +75,16 @@ export function UsageWindowDaysSelector({ windowDays, isSnapshotMode }: { window
       <div className="usage-window-day-selector" role="tablist" aria-label="Últimos 7 días de ventanas 5h">
         {windowDays.days.map((day) => {
           const selected = day.date === selectedDay?.date
+          const tabId = `usage-window-day-tab-${day.date}`
+          const panelId = `usage-window-day-panel-${day.date}`
           return (
             <button
+              id={tabId}
               type="button"
               role="tab"
               aria-selected={selected}
-              aria-controls={`usage-window-day-${day.date}`}
+              aria-controls={panelId}
+              tabIndex={selected ? 0 : -1}
               className="usage-window-day-selector__button"
               data-selected={selected ? 'true' : 'false'}
               key={day.date}
@@ -89,7 +95,8 @@ export function UsageWindowDaysSelector({ windowDays, isSnapshotMode }: { window
           )
         })}
       </div>
-      <div id={selectedDay ? `usage-window-day-${selectedDay.date}` : undefined} className="usage-windows-list usage-windows-list--scroll" role="tabpanel" aria-label={selectedDay ? `Ventanas 5h de ${selectedDay.date}` : 'Ventanas 5h por día'}>
+      <p className="usage-scroll-hint" aria-hidden="true">Desplaza dentro del panel para ver todas las ventanas del día seleccionado.</p>
+      <div id={selectedPanelId} className="usage-windows-list usage-windows-list--scroll usage-scroll-affordance" role="tabpanel" aria-labelledby={selectedTabId} aria-label={selectedDay ? undefined : 'Ventanas 5h por día'}>
         {selectedDay && selectedDay.windows.length > 0 ? (
           selectedDay.windows.map((window) => {
             const status = windowStatusMap[window.status]

--- a/apps/web/src/modules/usage/UsageWindowDaysSelector.tsx
+++ b/apps/web/src/modules/usage/UsageWindowDaysSelector.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { type KeyboardEvent, useMemo, useState } from 'react'
 import type { UsageFiveHourWindowDays, UsageWindowStatus } from '@contracts/read-models'
 
 import { StatePanel } from '@/shared/ui/state/StatePanel'
@@ -52,6 +52,13 @@ function formatSamples(value: number) {
   return value === 1 ? '1 muestra' : `${value} muestras`
 }
 
+function compareWindowByMostRecentStartedAt(
+  left: UsageFiveHourWindowDays['days'][number]['windows'][number],
+  right: UsageFiveHourWindowDays['days'][number]['windows'][number],
+) {
+  return new Date(right.started_at).getTime() - new Date(left.started_at).getTime()
+}
+
 export function UsageWindowDaysSelector({ windowDays, isSnapshotMode }: { windowDays: UsageFiveHourWindowDays; isSnapshotMode: boolean }) {
   const initialDate = useMemo(() => {
     const today = windowDays.days.find((day) => day.relative_label === 'hoy')
@@ -61,6 +68,48 @@ export function UsageWindowDaysSelector({ windowDays, isSnapshotMode }: { window
   const selectedDay = windowDays.days.find((day) => day.date === selectedDate) ?? windowDays.days.at(-1)
   const selectedTabId = selectedDay ? `usage-window-day-tab-${selectedDay.date}` : undefined
   const selectedPanelId = selectedDay ? `usage-window-day-panel-${selectedDay.date}` : undefined
+  const selectedDayIndex = selectedDay ? windowDays.days.findIndex((day) => day.date === selectedDay.date) : -1
+  const selectedWindows = useMemo(
+    () => [...(selectedDay?.windows ?? [])].sort(compareWindowByMostRecentStartedAt),
+    [selectedDay?.windows],
+  )
+
+  function selectDayByIndex(nextIndex: number) {
+    const nextDay = windowDays.days[nextIndex]
+    if (!nextDay) return
+
+    setSelectedDate(nextDay.date)
+    window.requestAnimationFrame(() => {
+      document.getElementById(`usage-window-day-tab-${nextDay.date}`)?.focus()
+    })
+  }
+
+  function handleTabListKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (windowDays.days.length === 0) return
+
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      event.preventDefault()
+      selectDayByIndex((selectedDayIndex + 1) % windowDays.days.length)
+      return
+    }
+
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      selectDayByIndex((selectedDayIndex - 1 + windowDays.days.length) % windowDays.days.length)
+      return
+    }
+
+    if (event.key === 'Home') {
+      event.preventDefault()
+      selectDayByIndex(0)
+      return
+    }
+
+    if (event.key === 'End') {
+      event.preventDefault()
+      selectDayByIndex(windowDays.days.length - 1)
+    }
+  }
 
   return (
     <div style={{ display: 'grid', gap: '12px' }}>
@@ -72,7 +121,7 @@ export function UsageWindowDaysSelector({ windowDays, isSnapshotMode }: { window
           Ventanas mostradas desde snapshot/fallback saneado: sirven para validar composición visual, no para decidir consumo real.
         </p>
       ) : null}
-      <div className="usage-window-day-selector" role="tablist" aria-label="Últimos 7 días de ventanas 5h">
+      <div className="usage-window-day-selector" role="tablist" aria-label="Últimos 7 días de ventanas 5h" onKeyDown={handleTabListKeyDown}>
         {windowDays.days.map((day) => {
           const selected = day.date === selectedDay?.date
           const tabId = `usage-window-day-tab-${day.date}`
@@ -97,8 +146,8 @@ export function UsageWindowDaysSelector({ windowDays, isSnapshotMode }: { window
       </div>
       <p className="usage-scroll-hint" aria-hidden="true">Desplaza dentro del panel para ver todas las ventanas del día seleccionado.</p>
       <div id={selectedPanelId} className="usage-windows-list usage-windows-list--scroll usage-scroll-affordance" role="tabpanel" aria-labelledby={selectedTabId} aria-label={selectedDay ? undefined : 'Ventanas 5h por día'}>
-        {selectedDay && selectedDay.windows.length > 0 ? (
-          selectedDay.windows.map((window) => {
+        {selectedDay && selectedWindows.length > 0 ? (
+          selectedWindows.map((window) => {
             const status = windowStatusMap[window.status]
             return (
               <article className="usage-window-row" key={`${window.started_at}-${window.ended_at}`} role="listitem" aria-label={`Ventana 5h ${formatTimestamp(window.started_at)}: ${status.label}`}>

--- a/openspec/issue-112-usage-polish-verify-checklist.md
+++ b/openspec/issue-112-usage-polish-verify-checklist.md
@@ -17,7 +17,9 @@
 - [x] Consola limpia.
 - [x] Tokens largos se escanean compactos y conservan valor completo accesible (`data[value]`, `title`, `aria-label`).
 - [x] Scroll interno de ventanas/perfiles tiene hint, scrollbar coloreada y sombra interna.
-- [x] Selector diario expone tabs con foco visible y tabpanel etiquetado.
+- [x] Selector diario expone tabs con foco visible, tabpanel etiquetado y navegación de teclado `ArrowLeft/Right`, `ArrowUp/Down`, `Home`, `End`.
+- [x] Cards superiores de `/usage` quedan igualadas por abajo en viewport disponible (`324px` cada una en smoke DOM).
+- [x] Ventanas 5h del día seleccionado se muestran de más reciente a más antigua (`18:00 → 23:00` primero en smoke DOM real).
 - [x] Sin overflow horizontal obvio en viewport disponible (`1280px`; no hubo resize real a móvil/tablet en esta herramienta).
 
 ## Review

--- a/openspec/issue-112-usage-polish-verify-checklist.md
+++ b/openspec/issue-112-usage-polish-verify-checklist.md
@@ -1,0 +1,27 @@
+# Issue 112 — verify checklist
+
+## Scope checks
+- [x] Alcance confirmado UI/accesibilidad only.
+- [x] Sin cambios en backend, payloads, endpoints ni contratos.
+- [x] Sin cambios en privacidad ni exposición de tokens raw.
+
+## Static/code checks
+- [x] `npm run verify:usage-server-only`.
+- [x] `npm --prefix apps/web run typecheck`.
+- [x] `npm --prefix apps/web run build`.
+- [x] `npm run verify:visual-baseline`.
+- [x] `git diff --check`.
+
+## Browser/visual checks
+- [x] `/usage` carga con API local de la rama en producción local (`127.0.0.1:8012` + `127.0.0.1:3018`).
+- [x] Consola limpia.
+- [x] Tokens largos se escanean compactos y conservan valor completo accesible (`data[value]`, `title`, `aria-label`).
+- [x] Scroll interno de ventanas/perfiles tiene hint, scrollbar coloreada y sombra interna.
+- [x] Selector diario expone tabs con foco visible y tabpanel etiquetado.
+- [x] Sin overflow horizontal obvio en viewport disponible (`1280px`; no hubo resize real a móvil/tablet en esta herramienta).
+
+## Review
+- [ ] PR abierta.
+- [ ] Handoff Usopp comentado en PR.
+- [ ] Usopp invocado por vía efectiva.
+- [ ] No mergear sin review válida.

--- a/openspec/issue-112-usage-polish.md
+++ b/openspec/issue-112-usage-polish.md
@@ -1,0 +1,36 @@
+# Issue 112 — `/usage` polish tras PR #111
+
+## Objetivo
+Pulir `/usage` sin reabrir fronteras de datos ni tocar backend:
+- compactar cifras largas de tokens manteniendo el valor completo accesible;
+- mejorar affordance de scroll interno en listas largas;
+- afinar accesibilidad del selector diario de ventanas 5h con IDs estables, `aria-labelledby` y `focus-visible`;
+- revisar responsive/móvil si el entorno lo permite.
+
+## Alcance
+UI/accesibilidad only en frontend:
+- `apps/web/src/app/usage/page.tsx`.
+- `apps/web/src/modules/usage/UsageWindowDaysSelector.tsx`.
+- `apps/web/src/app/globals.css`.
+- guardrail estático `scripts/check-usage-server-only.mjs` para fijar la frontera y los nuevos invariantes UI.
+
+## Fuera de alcance
+- Backend, payloads, endpoints, contratos de datos, privacidad y tokens raw.
+- Nuevas métricas o semántica de consumo.
+- Cambios de runtime, cache, polling o configuración.
+- Cambios en fuentes Hermes/Codex.
+
+## Diseño ligero
+- Mantener números de tokens como agregados existentes; solo cambiar presentación visual.
+- Usar formato compacto visual con `Intl.NumberFormat(..., { notation: 'compact' })` y preservar valor completo vía `data[value]`, `title` y `aria-label`.
+- Reforzar scroll interno con scrollbar visible, sombra/fade interno y microcopy discreta no anunciada por lector.
+- Mantener selector como tabs: IDs estables `usage-window-day-tab-<date>` y `usage-window-day-panel-<date>`, tabpanel etiquetado por el tab seleccionado y foco visible explícito.
+
+## Definition of Done
+- `/usage` sigue siendo página server-side dinámica y read-only.
+- No aparecen `NEXT_PUBLIC_*`, backend URL, rutas Hermes, prompts, conversaciones, tokens por sesión/conversación ni payloads crudos.
+- Typecheck y build web pasan.
+- `verify:usage-server-only` fija los invariantes nuevos.
+- `verify:visual-baseline` pasa.
+- Smoke browser de `/usage` si hay entorno local disponible.
+- PR abierta en rama `zoro/issue-112-usage-polish` y review Usopp solicitada; Chopper no aplica si no cambia frontera de datos.

--- a/openspec/issue-112-usage-polish.md
+++ b/openspec/issue-112-usage-polish.md
@@ -25,6 +25,9 @@ UI/accesibilidad only en frontend:
 - Usar formato compacto visual con `Intl.NumberFormat(..., { notation: 'compact' })` y preservar valor completo vía `data[value]`, `title` y `aria-label`.
 - Reforzar scroll interno con scrollbar visible, sombra/fade interno y microcopy discreta no anunciada por lector.
 - Mantener selector como tabs: IDs estables `usage-window-day-tab-<date>` y `usage-window-day-panel-<date>`, tabpanel etiquetado por el tab seleccionado y foco visible explícito.
+- Añadir navegación de teclado real al tablist (`ArrowLeft/Right`, `ArrowUp/Down`, `Home`, `End`) manteniendo foco en el tab activo.
+- Ordenar las ventanas 5h del día seleccionado de más reciente a más antigua para que la lectura operativa empiece por la hora actual/más cercana.
+- Estirar las cards superiores de `/usage` para que tengan la misma altura visual por abajo.
 
 ## Definition of Done
 - `/usage` sigue siendo página server-side dinámica y read-only.

--- a/scripts/check-usage-server-only.mjs
+++ b/scripts/check-usage-server-only.mjs
@@ -18,6 +18,8 @@ const usageWindowDaysSelector = readFileSync(usageWindowDaysSelectorPath, 'utf8'
 const nav = readFileSync(navPath, 'utf8')
 const usageService = readFileSync(usageServicePath, 'utf8')
 const usageRouter = readFileSync(usageRouterPath, 'utf8')
+const globalsPath = join(repoRoot, 'apps/web/src/app/globals.css')
+const globals = readFileSync(globalsPath, 'utf8')
 const activityLoader = usageService.slice(
   usageService.indexOf('def _load_hermes_profile_activity'),
   usageService.indexOf('def _load_latest_snapshot'),
@@ -67,6 +69,18 @@ if (!page.includes('Actividad Hermes agregada') || !page.includes('usage-hermes-
 }
 if (!page.includes('Tokens Hermes') || !page.includes('weekly_tokens_count') || !page.includes('total_tokens_count')) {
   failures.push('usage page must render aggregate Hermes token counters without raw sessions')
+}
+if (!page.includes('CompactActivityCount') || !page.includes('formatCompactActivityCount') || !page.includes('usage-compact-number') || !page.includes('aria-label={`${ariaLabel}: ${fullValue}`')) {
+  failures.push('usage token counters must use compact visual numbers while preserving full values accessibly')
+}
+if (!usageWindowDaysSelector.includes('usage-window-day-tab-') || !usageWindowDaysSelector.includes('usage-window-day-panel-') || !usageWindowDaysSelector.includes('aria-labelledby={selectedTabId}') || !usageWindowDaysSelector.includes('tabIndex={selected ? 0 : -1}')) {
+  failures.push('usage daily selector must expose stable tab ids, aria-labelledby tabpanel wiring and roving focus baseline')
+}
+if (!usageWindowDaysSelector.includes('usage-scroll-hint') || !usageWindowDaysSelector.includes('usage-scroll-affordance') || !page.includes('usage-scroll-affordance')) {
+  failures.push('usage internal scroll areas must expose a visible scroll affordance and hint')
+}
+if (!globals.includes('.usage-window-day-selector__button:focus-visible') || !globals.includes('.usage-scroll-affordance') || !globals.includes('scrollbar-color') || !globals.includes('.usage-compact-number__full')) {
+  failures.push('usage CSS must preserve focus-visible, scroll affordance and compact-number styling')
 }
 const topCardsStart = page.indexOf('aria-label="Estado actual de Usage"')
 const topCardsEnd = page.indexOf('aria-label="Calendario Usage"')

--- a/scripts/check-usage-server-only.mjs
+++ b/scripts/check-usage-server-only.mjs
@@ -73,14 +73,17 @@ if (!page.includes('Tokens Hermes') || !page.includes('weekly_tokens_count') || 
 if (!page.includes('CompactActivityCount') || !page.includes('formatCompactActivityCount') || !page.includes('usage-compact-number') || !page.includes('aria-label={`${ariaLabel}: ${fullValue}`')) {
   failures.push('usage token counters must use compact visual numbers while preserving full values accessibly')
 }
-if (!usageWindowDaysSelector.includes('usage-window-day-tab-') || !usageWindowDaysSelector.includes('usage-window-day-panel-') || !usageWindowDaysSelector.includes('aria-labelledby={selectedTabId}') || !usageWindowDaysSelector.includes('tabIndex={selected ? 0 : -1}')) {
-  failures.push('usage daily selector must expose stable tab ids, aria-labelledby tabpanel wiring and roving focus baseline')
+if (!usageWindowDaysSelector.includes('usage-window-day-tab-') || !usageWindowDaysSelector.includes('usage-window-day-panel-') || !usageWindowDaysSelector.includes('aria-labelledby={selectedTabId}') || !usageWindowDaysSelector.includes('tabIndex={selected ? 0 : -1}') || !usageWindowDaysSelector.includes('handleTabListKeyDown') || !usageWindowDaysSelector.includes("event.key === 'ArrowRight'") || !usageWindowDaysSelector.includes("event.key === 'Home'") || !usageWindowDaysSelector.includes("event.key === 'End'")) {
+  failures.push('usage daily selector must expose stable tab ids, aria-labelledby tabpanel wiring and full keyboard navigation baseline')
+}
+if (!usageWindowDaysSelector.includes('compareWindowByMostRecentStartedAt') || !usageWindowDaysSelector.includes('selectedWindows.map')) {
+  failures.push('usage five-hour day windows must render most recent windows first')
 }
 if (!usageWindowDaysSelector.includes('usage-scroll-hint') || !usageWindowDaysSelector.includes('usage-scroll-affordance') || !page.includes('usage-scroll-affordance')) {
   failures.push('usage internal scroll areas must expose a visible scroll affordance and hint')
 }
-if (!globals.includes('.usage-window-day-selector__button:focus-visible') || !globals.includes('.usage-scroll-affordance') || !globals.includes('scrollbar-color') || !globals.includes('.usage-compact-number__full')) {
-  failures.push('usage CSS must preserve focus-visible, scroll affordance and compact-number styling')
+if (!globals.includes('.usage-window-day-selector__button:focus-visible') || !globals.includes('.usage-scroll-affordance') || !globals.includes('scrollbar-color') || !globals.includes('.usage-compact-number__full') || !globals.includes('.usage-top-cards')) {
+  failures.push('usage CSS must preserve equal-height top cards, focus-visible, scroll affordance and compact-number styling')
 }
 const topCardsStart = page.indexOf('aria-label="Estado actual de Usage"')
 const topCardsEnd = page.indexOf('aria-label="Calendario Usage"')

--- a/scripts/visual-verify-baseline.mjs
+++ b/scripts/visual-verify-baseline.mjs
@@ -101,7 +101,7 @@ const routes = [
     path: '/usage',
     title: 'Uso Codex/Hermes',
     checks: [
-      'las cards de ventana 5h, ciclo semanal Codex, plan y recomendación apilan sin overflow',
+      'las cards de Tokens Hermes, Ventana semanal, Ventana 5h y Cuenta Codex apilan sin overflow',
       'el ciclo se etiqueta como ciclo semanal Codex y no como calendario lunes-domingo',
       'stale, not_configured o fallback quedan visibles como fuente degradada/no tiempo real',
       'fórmulas y privacidad hacen wrap sin filtrar detalles internos del host',


### PR DESCRIPTION
## Objetivo
Cierra el follow-up UI/accesibilidad de #112 sobre `/usage` tras PR #111.

## Cambios
- Compacta visualmente cifras largas de tokens Hermes con `Intl.NumberFormat(..., notation: 'compact')`.
- Mantiene el valor completo accesible mediante `data[value]`, `title` y `aria-label`.
- Refuerza affordance de scroll interno en ventanas 5h y actividad Hermes con hint, scrollbar coloreada y sombra interna.
- Afina tabs del selector diario: IDs estables por fecha, `aria-labelledby` del tabpanel, baseline de roving focus y `focus-visible` explícito.
- Actualiza `verify:usage-server-only` y baseline visual de `/usage` para fijar los nuevos invariantes.

## Alcance preservado
UI/accesibilidad only. No toca backend, payloads, endpoints, contratos, privacidad ni tokens raw. Los tokens siguen siendo agregados ya existentes.

## Verificación de Zoro
- [x] `npm run verify:usage-server-only`
- [x] `npm --prefix apps/web run typecheck`
- [x] `npm --prefix apps/web run build`
- [x] `npm run verify:visual-baseline`
- [x] `git diff --check`
- [x] Smoke HTTP/browser local producción: API `127.0.0.1:8012` + web `127.0.0.1:3018`, `/usage` 200, consola limpia, sin overflow horizontal en viewport 1280px, sin `MUGIWARA_CONTROL_PANEL_API_URL`, `127.0.0.1:8012`, `state.db` ni `Traceback` en HTML/DOM.

## Limitaciones
- No hubo resize real a móvil/tablet desde la herramienta de navegador; cubierto por CSS responsive existente, checklist versionada y smoke en viewport disponible.

## Review solicitada
- Usopp: UI/UX, claridad visual, scroll affordance, responsive/accesibilidad básica.
- Chopper no solicitado: no cambia frontera de datos, seguridad, endpoints ni privacidad.

No mergear sin review válida de Usopp.