### PR TITLE
fix: simplify usage activity presentation

### DIFF
--- a/apps/api/src/modules/usage/service.py
+++ b/apps/api/src/modules/usage/service.py
@@ -307,6 +307,7 @@ class UsageService:
             profile_summary = self._load_hermes_profile_activity(profile=profile, state_db=state_db, start_at=start_at, end_at=end_at)
             profiles.append(profile_summary if profile_summary is not None else self._empty_profile_activity(profile))
 
+        self._assign_relative_activity_levels(profiles)
         profiles.sort(key=lambda item: (-item['tokens_count'], -item['messages_count'], -item['tool_calls_count'], -item['sessions_count'], item['profile']))
         totals = self._activity_totals(profiles)
         return {
@@ -605,13 +606,34 @@ class UsageService:
         }
 
     @staticmethod
-    def _activity_level(messages_count: int, tool_calls_count: int) -> str:
-        score = messages_count + (tool_calls_count * 2)
-        if score >= 40:
-            return 'high'
-        if score >= 10:
-            return 'medium'
-        return 'low'
+    def _activity_score(profile: dict[str, Any]) -> int:
+        return int(profile['messages_count']) + (int(profile['tool_calls_count']) * 2) + (int(profile['sessions_count']) * 3)
+
+    @classmethod
+    def _assign_relative_activity_levels(cls, profiles: list[dict[str, Any]]) -> None:
+        active_profiles = [profile for profile in profiles if cls._activity_score(profile) > 0]
+        if not active_profiles:
+            for profile in profiles:
+                profile['activity_level'] = 'low'
+            return
+
+        ranked_profiles = sorted(
+            active_profiles,
+            key=lambda profile: (-cls._activity_score(profile), -int(profile['tokens_count']), profile['profile']),
+        )
+        denominator = max(len(ranked_profiles) - 1, 1)
+        for index, profile in enumerate(ranked_profiles):
+            percentile = index / denominator
+            if percentile <= 1 / 3:
+                profile['activity_level'] = 'high'
+            elif percentile <= 2 / 3:
+                profile['activity_level'] = 'medium'
+            else:
+                profile['activity_level'] = 'low'
+
+        for profile in profiles:
+            if cls._activity_score(profile) <= 0:
+                profile['activity_level'] = 'low'
 
     @staticmethod
     def _activity_totals(profiles: list[dict[str, Any]]) -> dict[str, Any]:
@@ -697,7 +719,7 @@ class UsageService:
             'total_tokens_count': total_tokens_count,
             'first_activity_at': datetime.fromtimestamp(first_epoch, timezone.utc).isoformat() if first_epoch is not None else None,
             'last_activity_at': datetime.fromtimestamp(last_epoch, timezone.utc).isoformat() if last_epoch is not None else None,
-            'activity_level': self._activity_level(messages_count, tool_calls_count),
+            'activity_level': 'low',
         }
 
     def _load_latest_snapshot(self) -> UsageSnapshot | None:

--- a/apps/api/tests/test_usage_api.py
+++ b/apps/api/tests/test_usage_api.py
@@ -584,6 +584,12 @@ def test_usage_hermes_activity_aggregates_profile_sessions_without_leaking_sensi
             {'id': 'franky-session-1', 'started_at': '2026-04-24T10:00:00+00:00', 'message_count': 5, 'tool_call_count': 1},
         ],
     )
+    _create_hermes_state_db(
+        profiles_root / 'nami' / 'state.db',
+        [
+            {'id': 'nami-session-1', 'started_at': '2026-04-24T11:00:00+00:00', 'message_count': 9, 'tool_call_count': 1},
+        ],
+    )
     _override_usage_service(UsageService(db_path=tmp_path / 'missing-codex.sqlite', hermes_profiles_root=profiles_root, now=lambda: '2026-04-27T10:00:00+00:00'))
 
     response = TestClient(app).get('/api/v1/usage/hermes-activity?range=7d')
@@ -601,11 +607,11 @@ def test_usage_hermes_activity_aggregates_profile_sessions_without_leaking_sensi
     assert payload['data']['range']['name'] == '7d'
     assert payload['data']['totals'] == {
         'profiles_count': 10,
-        'sessions_count': 3,
-        'messages_count': 17,
-        'tool_calls_count': 5,
-        'weekly_tokens_count': 555,
-        'total_tokens_count': 740,
+        'sessions_count': 4,
+        'messages_count': 26,
+        'tool_calls_count': 6,
+        'weekly_tokens_count': 740,
+        'total_tokens_count': 925,
         'dominant_profile': 'zoro',
     }
     profiles = payload['data']['profiles']
@@ -618,11 +624,14 @@ def test_usage_hermes_activity_aggregates_profile_sessions_without_leaking_sensi
         'total_tokens_count': 555,
         'first_activity_at': '2026-04-25T12:00:00+00:00',
         'last_activity_at': '2026-04-26T09:00:00+00:00',
-        'activity_level': 'medium',
+        'activity_level': 'high',
     }
-    assert profiles[1]['profile'] == 'franky'
+    assert profiles[1]['profile'] == 'nami'
     assert profiles[1]['tokens_count'] == 185
-    assert profiles[1]['activity_level'] == 'low'
+    assert profiles[1]['activity_level'] == 'medium'
+    assert profiles[2]['profile'] == 'franky'
+    assert profiles[2]['tokens_count'] == 185
+    assert profiles[2]['activity_level'] == 'low'
     assert len(profiles) == 10
     assert profiles[-1]['sessions_count'] == 0
     assert profiles[-1]['first_activity_at'] is None

--- a/apps/web/src/app/usage/page.tsx
+++ b/apps/web/src/app/usage/page.tsx
@@ -406,9 +406,6 @@ function UsageCalendarPanel({ calendar, isSnapshotMode }: { calendar: UsageCalen
   return (
     <SurfaceCard title="Calendario por fecha natural" eyebrow={`Ciclo semanal Codex · ${calendar.timezone}`} accent="gold" elevated>
       <div style={{ display: 'grid', gap: '12px' }}>
-        <p style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
-          Primera lectura histórica saneada: agrupa por fecha natural Europe/Madrid, sin contenido privado ni actividad Hermes. El delta diario se calcula por segmentos continuos del ciclo semanal Codex para no contar resets como consumo.
-        </p>
         {isSnapshotMode ? (
           <p style={{ margin: 0, color: appTheme.colors.brandGold400, lineHeight: 1.5 }}>
             Calendario mostrado desde snapshot/fallback saneado: útil para validar composición visual, no para decidir consumo real.
@@ -505,9 +502,6 @@ function UsageHermesActivityPanel({ activity, notice, isSnapshotMode }: { activi
   return (
     <SurfaceCard title="Actividad Hermes agregada" eyebrow="Últimos 7 días · correlación orientativa" accent="gold" elevated>
       <div style={{ display: 'grid', gap: '14px' }}>
-        <p style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
-          Lectura read-only de actividad local Hermes por perfiles Mugiwara allowlisted. Es una correlación orientativa con el ritmo Codex: no atribuye causalidad exacta ni muestra actividad por sesión.
-        </p>
         {isSnapshotMode ? (
           <p style={{ margin: 0, color: appTheme.colors.brandGold400, lineHeight: 1.5 }}>
             Actividad mostrada desde fallback saneado: valida composición visual, no representa lectura real.

--- a/apps/web/src/modules/usage/UsageWindowDaysSelector.tsx
+++ b/apps/web/src/modules/usage/UsageWindowDaysSelector.tsx
@@ -113,9 +113,6 @@ export function UsageWindowDaysSelector({ windowDays, isSnapshotMode }: { window
 
   return (
     <div style={{ display: 'grid', gap: '12px' }}>
-      <p style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
-        Elige un día natural en Europe/Madrid y revisa solo las ventanas 5h asignadas a ese día. Si una ventana cruza medianoche, queda en el día donde aporta más duración.
-      </p>
       {isSnapshotMode ? (
         <p style={{ margin: 0, color: appTheme.colors.brandGold400, lineHeight: 1.5 }}>
           Ventanas mostradas desde snapshot/fallback saneado: sirven para validar composición visual, no para decidir consumo real.

--- a/scripts/check-usage-server-only.mjs
+++ b/scripts/check-usage-server-only.mjs
@@ -58,11 +58,13 @@ if (!page.includes('Calendario por fecha natural') || !page.includes('Europe/Mad
 if (!page.includes('usage-calendar-grid') || !page.includes('primary_windows_count')) {
   failures.push('usage page must render a responsive calendar grid without generic table overflow')
 }
+for (const removedCopy of ['Primera lectura histórica saneada', 'Elige un día natural en Europe/Madrid', 'Lectura read-only de actividad local Hermes']) {
+  if (page.includes(removedCopy) || usageWindowDaysSelector.includes(removedCopy)) {
+    failures.push(`usage page must not render removed explanatory copy: ${removedCopy}`)
+  }
+}
 if (!page.includes('Ventanas 5h por día') || !usageWindowDaysSelector.includes('usage-window-day-selector') || !usageWindowDaysSelector.includes('role="tablist"') || !usageWindowDaysSelector.includes('delta_percent')) {
   failures.push('usage page must render selectable five-hour window days without generic table overflow')
-}
-if (!usageWindowDaysSelector.includes('Europe/Madrid') || !usageWindowDaysSelector.includes('más duración')) {
-  failures.push('usage window day selector must explain local-day assignment')
 }
 if (!page.includes('Actividad Hermes agregada') || !page.includes('usage-hermes-activity-list') || !page.includes('correlación orientativa')) {
   failures.push('usage page must render Hermes aggregated activity as orientative correlation without generic table overflow')
@@ -160,6 +162,9 @@ if (!usageService.includes("'no_activity'") || !usageService.includes("return 'e
 }
 if (!usageService.includes('weekly_tokens_count') || !usageService.includes('total_tokens_count')) {
   failures.push('usage hermes activity must expose only aggregate token counters')
+}
+if (!usageService.includes('def _assign_relative_activity_levels') || !usageService.includes('percentile <= 1 / 3') || !usageService.includes("profile['activity_level'] = 'medium'")) {
+  failures.push('usage hermes activity must distribute activity levels relatively across Mugiwara profiles')
 }
 if (!usageService.includes('def _assign_usage_window_date') || !usageService.includes('USAGE_CALENDAR_TIMEZONE')) {
   failures.push('usage backend must assign five-hour windows to Europe/Madrid natural days')


### PR DESCRIPTION
## Objetivo
Ajuste rápido pedido por Pablo en `/usage`.

## Cambios
- Retira tres párrafos explicativos pesados:
  - Calendario: “Primera lectura histórica saneada...”
  - Ventanas 5h: “Elige un día natural...”
  - Actividad Hermes: “Lectura read-only...”
- Cambia `activity_level` Hermes de umbrales absolutos fijos a distribución relativa por terciles entre perfiles Mugiwara activos.
  - Score: `messages + 2*tool_calls + 3*sessions`.
  - Perfiles activos se reparten en `high` / `medium` / `low` por percentil relativo.
  - Perfiles sin actividad quedan `low`.
- Actualiza tests y guardrail `verify:usage-server-only`.

## Verificación
- [x] `PYTHONPATH=. pytest apps/api/tests/test_usage_api.py -q` → 14 passed.
- [x] `npm run verify:usage-server-only`.
- [x] `npm --prefix apps/web run typecheck`.
- [x] `npm --prefix apps/web run build`.
- [x] `npm run verify:visual-baseline`.
- [x] `git diff --check`.
- [x] Smoke local con API de rama: textos retirados ausentes, niveles `Actividad Alta`, `Actividad Media`, `Actividad Baja` presentes, sin overflow horizontal ni fugas sensibles.

## Alcance
Toca UI copy y clasificación agregada backend read-only. No añade endpoints, payload raw, secretos, rutas, tokens por sesión/conversación ni inputs nuevos.