### PR TITLE
fix: clarify Healthcheck review cause

### DIFF
--- a/.engram/issue-104-healthcheck-review-clarity-closeout.md
+++ b/.engram/issue-104-healthcheck-review-clarity-closeout.md
@@ -1,0 +1,25 @@
+# Issue #104 — Healthcheck review clarity closeout
+
+## Qué cambia
+- Healthcheck separa contrato y UI entre estado actual, causa actual y bitácora histórica.
+- El backend añade `summary_bar.current_cause`, derivado solo de registros vivos, y `events[].kind = historical`.
+- `/healthcheck` muestra `En revisión por <fuente>` cuando hay degradación actual y reetiqueta la bitácora como histórica.
+
+## Decisiones
+- `En revisión` sigue representando `warn`, no se cambia la lógica operativa de Project health ni de fuentes.
+- La causa actual se calcula en backend para evitar que eventos históricos contaminen visual o semánticamente el diagnóstico.
+- Los eventos históricos permanecen visibles, pero con copy secundario y etiquetas `Incidencia histórica` / `Evento histórico`.
+
+## No cambia
+- No se añaden fuentes nuevas.
+- No se ejecutan comandos host nuevos desde backend.
+- No se exponen logs crudos, stdout/stderr, paths internos, manifests, tokens, prompts ni secrets.
+
+## Verify previsto
+- Backend Healthcheck tests.
+- `verify:healthcheck-source-policy`.
+- `verify:healthcheck-review-clarity`.
+- Typecheck/build web, visual baseline, `git diff --check` y smoke `/healthcheck`.
+
+## Review
+Usopp debe revisar claridad visual/copy; Chopper debe revisar contrato/saneado/no-leakage. Franky no es obligatorio salvo que los reviewers detecten impacto operativo, porque no se tocan producers/timers/runtime.

--- a/apps/api/src/modules/healthcheck/domain.py
+++ b/apps/api/src/modules/healthcheck/domain.py
@@ -170,12 +170,24 @@ class HealthcheckRecord:
 
 
 @dataclass(frozen=True)
+class HealthcheckCurrentCause:
+    source_id: str
+    label: str
+    status: str
+    severity: str
+    summary: str
+    warning_text: str
+    freshness_state: str
+
+
+@dataclass(frozen=True)
 class HealthcheckSummaryBar:
     overall_status: str
     checks_total: int
     warnings: int
     incidents: int
     updated_at: str | None
+    current_cause: HealthcheckCurrentCause | None
 
 
 @dataclass(frozen=True)
@@ -195,6 +207,7 @@ class HealthcheckEvent:
     status: str
     timestamp: str
     detail: str
+    kind: str = 'historical'
 
 
 @dataclass(frozen=True)

--- a/apps/api/src/modules/healthcheck/service.py
+++ b/apps/api/src/modules/healthcheck/service.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from .domain import (
+    HealthcheckCurrentCause,
     HealthcheckEvent,
     HealthcheckFreshness,
     HealthcheckModuleCard,
@@ -32,10 +33,10 @@ SAFE_HEALTHCHECK_RECORDS: tuple[HealthcheckRecord, ...] = (
 )
 
 SAFE_EVENTS: tuple[HealthcheckEvent, ...] = (
-    HealthcheckEvent('evt-cron-nightly', 'cronjobs', 'warn', '2026-04-24T01:33:40+02:00', 'Ejecución nocturna completada con advertencia saneada pendiente de revisión.'),
-    HealthcheckEvent('evt-gateway-latency', 'hermes-gateways', 'warn', '2026-04-24T07:44:00Z', 'Latencia sostenida por encima del umbral objetivo durante la última ventana de observación.'),
-    HealthcheckEvent('evt-zoro-gateway-capacity', 'gateway.zoro', 'fail', '2026-04-24T07:39:00Z', 'Capacidad degradada en un componente operativo; se ha marcado como incidencia para revisión.'),
-    HealthcheckEvent('evt-backup-checksum', 'backup-health', 'pass', '2026-04-24T07:35:00Z', 'Backup reciente validado con checksum sin desviaciones visibles.'),
+    HealthcheckEvent('evt-cron-nightly', 'cronjobs', 'warn', '2026-04-24T01:33:40+02:00', 'Ejecución nocturna completada con advertencia saneada pendiente de revisión histórica.'),
+    HealthcheckEvent('evt-gateway-latency', 'hermes-gateways', 'warn', '2026-04-24T07:44:00Z', 'Latencia registrada en una ventana anterior; no representa por sí sola el estado activo.'),
+    HealthcheckEvent('evt-zoro-gateway-capacity', 'gateway.zoro', 'fail', '2026-04-24T07:39:00Z', 'Incidencia saneada registrada en una revisión anterior; no representa por sí sola el estado activo.'),
+    HealthcheckEvent('evt-backup-checksum', 'backup-health', 'pass', '2026-04-24T07:35:00Z', 'Backup validado en una revisión anterior sin desviaciones visibles.'),
 )
 
 SAFE_PRINCIPLES: tuple[str, ...] = (
@@ -101,12 +102,27 @@ class HealthcheckService:
 
     def _summary_bar(self, modules: list[HealthcheckModuleCard]) -> HealthcheckSummaryBar:
         if not modules:
-            return HealthcheckSummaryBar('stale', 0, 0, 0, None)
+            return HealthcheckSummaryBar('stale', 0, 0, 0, None, None)
         incidents = sum(1 for module in modules if module.status == 'fail')
         warnings = sum(1 for module in modules if module.status in {'warn', 'stale', 'unknown', 'not_configured'})
-        overall = max(modules, key=lambda module: _STATUS_ORDER[module.status]).status
+        overall_record = max(self._records, key=lambda record: _STATUS_ORDER[record.status])
+        overall = overall_record.status
         updated_at = self._latest_updated_at(modules)
-        return HealthcheckSummaryBar(overall, len(modules), warnings, incidents, updated_at)
+        current_cause = self._current_cause(overall_record) if overall != 'pass' else None
+        return HealthcheckSummaryBar(overall, len(modules), warnings, incidents, updated_at, current_cause)
+
+    def _current_cause(self, record: HealthcheckRecord) -> HealthcheckCurrentCause:
+        freshness_state = self._freshness_state_by_module.get(record.module_id, 'stale' if record.status == 'stale' else 'fresh')
+        validate_healthcheck_freshness_state(freshness_state)
+        return HealthcheckCurrentCause(
+            source_id=record.module_id,
+            label=record.label,
+            status=record.status,
+            severity=record.severity,
+            summary=record.summary,
+            warning_text=record.warning_text,
+            freshness_state=freshness_state,
+        )
 
     def _latest_updated_at(self, modules: list[HealthcheckModuleCard]) -> str | None:
         latest: tuple[datetime, str] | None = None

--- a/apps/api/tests/test_healthcheck_dashboard_api.py
+++ b/apps/api/tests/test_healthcheck_dashboard_api.py
@@ -12,6 +12,7 @@ from apps.api.src.modules.healthcheck.domain import (
     HEALTHCHECK_SOURCE_LABELS,
     HEALTHCHECK_SOURCE_MANIFEST_POLICIES,
     HEALTHCHECK_STATUS_VALUES,
+    HealthcheckEvent,
     HealthcheckRecord,
 )
 from apps.api.src.modules.healthcheck.registry import HealthcheckSourceRegistry
@@ -33,6 +34,16 @@ def _record(module_id, label, status, severity, updated_at):
         warning_text='Synthetic safe warning.',
         source_label='Synthetic safe source',
         freshness_label='Synthetic freshness',
+    )
+
+
+def _record_event(event_id, source, status, timestamp):
+    return HealthcheckEvent(
+        event_id=event_id,
+        source=source,
+        status=status,
+        timestamp=timestamp,
+        detail='Synthetic historical event.',
     )
 
 
@@ -747,9 +758,58 @@ def test_healthcheck_empty_source_is_not_configured():
 
     assert service.workspace_status() == 'not_configured'
     assert service.get_workspace()['summary_bar']['checks_total'] == 0
+    assert service.get_workspace()['summary_bar']['current_cause'] is None
     assert service.get_workspace()['modules'] == []
     assert service.get_workspace()['events'] == []
     assert service.get_workspace()['signals'] == []
+
+
+def test_healthcheck_current_cause_is_derived_from_current_records_not_historical_events():
+    service = HealthcheckService(
+        records=(
+            _record('project-health', 'Project health', 'warn', 'medium', '2026-04-24T07:30:00Z'),
+            _record('hermes-gateways', 'Gateways', 'pass', 'low', '2026-04-24T07:45:00Z'),
+        ),
+        events=(
+            # Historical fail must remain visible in bitacora but cannot become the current cause.
+            _record_event('evt-old-gateway-fail', 'gateway.zoro', 'fail', '2026-04-23T07:39:00Z'),
+        ),
+    )
+
+    payload = service.get_workspace()
+
+    assert payload['summary_bar']['overall_status'] == 'warn'
+    assert payload['summary_bar']['incidents'] == 0
+    assert payload['summary_bar']['current_cause'] == {
+        'source_id': 'project-health',
+        'label': 'Project health',
+        'status': 'warn',
+        'severity': 'medium',
+        'summary': 'Project health safe summary',
+        'warning_text': 'Synthetic safe warning.',
+        'freshness_state': 'fresh',
+    }
+    assert payload['events'][0]['kind'] == 'historical'
+    assert payload['events'][0]['status'] == 'fail'
+    _assert_no_sensitive_host_output(payload)
+
+
+def test_healthcheck_pass_state_has_no_current_cause_even_with_historical_warning():
+    service = HealthcheckService(
+        records=(
+            _record('project-health', 'Project health', 'pass', 'low', '2026-04-24T07:30:00Z'),
+            _record('hermes-gateways', 'Gateways', 'pass', 'low', '2026-04-24T07:45:00Z'),
+        ),
+        events=(_record_event('evt-old-warning', 'cronjobs', 'warn', '2026-04-23T01:33:40+02:00'),),
+    )
+
+    payload = service.get_workspace()
+
+    assert payload['summary_bar']['overall_status'] == 'pass'
+    assert payload['summary_bar']['warnings'] == 0
+    assert payload['summary_bar']['incidents'] == 0
+    assert payload['summary_bar']['current_cause'] is None
+    assert payload['events'][0]['kind'] == 'historical'
 
 
 def test_healthcheck_degraded_source_state_is_visible(tmp_path):

--- a/apps/web/src/app/healthcheck/page.tsx
+++ b/apps/web/src/app/healthcheck/page.tsx
@@ -9,6 +9,7 @@ import {
 import { fetchHealthcheckWorkspace, HealthcheckApiError } from '@/modules/healthcheck/api/healthcheck-http'
 import {
   healthcheckWorkspaceFixture,
+  type HealthcheckCurrentCause,
   type HealthcheckModuleCard,
   type HealthcheckSummaryItem,
   type HealthcheckWorkspace,
@@ -111,7 +112,7 @@ function getHealthcheckCardTone(status: HealthcheckModuleCard['status'], severit
   }
 }
 
-function sortByHealthcheckTriage<T extends { status: HealthcheckModuleCard['status']; severity: HealthcheckModuleCard['severity']; updated_at?: string; freshness?: { updated_at: string } }>(items: T[]) {
+function sortByHealthcheckTriage<T extends { status: HealthcheckModuleCard['status']; severity: HealthcheckModuleCard['severity']; updated_at?: string | null; freshness?: { updated_at: string | null } }>(items: T[]): T[] {
   return [...items].sort((left, right) => {
     const rankDelta = getHealthcheckTriageRank(right.status, right.severity) - getHealthcheckTriageRank(left.status, left.severity)
 
@@ -124,6 +125,23 @@ function sortByHealthcheckTriage<T extends { status: HealthcheckModuleCard['stat
 
     return (Number.isNaN(rightDate) ? 0 : rightDate) - (Number.isNaN(leftDate) ? 0 : leftDate)
   })
+}
+
+function getCurrentCauseCopy(cause: HealthcheckCurrentCause | null) {
+  if (!cause) {
+    return null
+  }
+
+  const status = mapHealthcheckStatusToBadgeStatus(cause.status)
+  const causeLabel = cause.status === 'warn' ? `En revisión por ${cause.label}` : `${getHealthcheckStatusLabel(cause.status)} por ${cause.label}`
+  const reason = cause.warning_text && cause.warning_text !== 'Sin alerta activa.' ? cause.warning_text : cause.summary
+
+  return {
+    status,
+    title: causeLabel,
+    description: reason,
+    detail: `Causa del estado actual · Severidad ${getHealthcheckSeverityLabel(cause.severity)} · No procede de la bitácora histórica`,
+  }
 }
 
 function getPriorityCopy(module: HealthcheckModuleCard | null) {
@@ -178,6 +196,19 @@ function HealthcheckStatusBadges({ status, severity, isSnapshotMode = false }: P
   )
 }
 
+function getHistoricalEventBadgeLabel(status: HealthcheckModuleCard['status']) {
+  const map: Record<HealthcheckModuleCard['status'], string> = {
+    pass: 'Evento histórico: operativo',
+    warn: 'Evento histórico: en revisión',
+    fail: 'Incidencia histórica',
+    stale: 'Evento histórico: desactualizado',
+    not_configured: 'Evento histórico: fuente no configurada',
+    unknown: 'Evento histórico: estado desconocido',
+  }
+
+  return map[status]
+}
+
 function formatTimestamp(value: string | null) {
   if (!value) {
     return 'Sin actualización'
@@ -200,7 +231,8 @@ export default async function HealthcheckPage() {
   const isSnapshotMode = Boolean(apiNotice)
   const sortedModules = sortByHealthcheckTriage(workspace.modules)
   const sortedSignals = sortByHealthcheckTriage(workspace.signals)
-  const priorityNotice = getPriorityCopy(sortedModules[0] ?? null)
+  const currentCauseNotice = getCurrentCauseCopy(workspace.summary_bar.current_cause)
+  const priorityNotice = currentCauseNotice ?? getPriorityCopy(sortedModules[0] ?? null)
   const healthSummaryNotice =
     workspace.summary_bar.incidents > 0
       ? {
@@ -223,7 +255,7 @@ export default async function HealthcheckPage() {
       <PageHeader
         eyebrow="Healthcheck"
         title="Salud del sistema"
-        subtitle="Resumen operativo del perímetro: estado general, módulos, eventos recientes y señales saneadas sin exponer metadata sensible del host."
+        subtitle="Resumen operativo del perímetro: estado actual, causa visible y bitácora histórica separada sin exponer metadata sensible del host."
         mugiwaraSlug="chopper"
         detailPills={['Perímetro', 'Señales saneadas', 'Respuesta priorizada']}
       />
@@ -246,7 +278,7 @@ export default async function HealthcheckPage() {
         </StatePanel>
       ) : null}
 
-      <SurfaceCard title="Resumen de salud" elevated eyebrow="Puesto médico" accent="danger">
+      <SurfaceCard title="Estado actual del Healthcheck" elevated eyebrow="Puesto médico" accent="danger">
         <div style={{ display: 'grid', gap: '14px' }}>
           <div className="layout-grid layout-grid--cards-180" style={{ gap: '12px' }}>
             <div style={{ display: 'grid', gap: '8px' }}>
@@ -291,9 +323,9 @@ export default async function HealthcheckPage() {
               title={priorityNotice.title}
               description={priorityNotice.description}
               detail={priorityNotice.detail}
-              eyebrow="Acción requerida"
+              eyebrow={currentCauseNotice ? 'Causa actual' : 'Acción requerida'}
               ariaRole={priorityNotice.status === 'incidencia' ? 'alert' : 'region'}
-              ariaLabel="Prioridad actual de Healthcheck"
+              ariaLabel={currentCauseNotice ? 'Causa actual de Healthcheck' : 'Prioridad actual de Healthcheck'}
             />
           ) : healthSummaryNotice ? (
             <StatePanel
@@ -339,7 +371,10 @@ export default async function HealthcheckPage() {
       </section>
 
       <section className="section-block layout-grid layout-grid--content-aside">
-        <SurfaceCard title={isSnapshotMode ? 'Eventos del snapshot' : 'Eventos recientes'} elevated eyebrow="Bitácora" accent="gold">
+        <SurfaceCard title="Bitácora histórica" elevated eyebrow={isSnapshotMode ? 'Snapshot histórico' : 'Histórico'} accent="gold">
+          <p style={{ margin: '0 0 14px', color: appTheme.colors.textMuted, fontSize: '13px' }}>
+            Eventos anteriores saneados. No representan necesariamente el estado activo ni participan en la causa actual.
+          </p>
           {workspace.events.length > 0 ? (
             <div style={{ display: 'grid', gap: '10px' }}>
               {workspace.events.map((event) => (
@@ -357,14 +392,10 @@ export default async function HealthcheckPage() {
                     <strong>{event.source}</strong>
                     <StatusBadge
                       status={mapHealthcheckStatusToBadgeStatus(event.status)}
-                      label={
-                        isSnapshotMode && mapHealthcheckStatusToBadgeStatus(event.status) === 'operativo'
-                          ? 'Operativo en último corte'
-                          : undefined
-                      }
+                      label={getHistoricalEventBadgeLabel(event.status)}
                     />
                   </div>
-                  <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>{formatTimestamp(event.timestamp)}</span>
+                  <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>Histórico · {formatTimestamp(event.timestamp)}</span>
                   <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>{event.detail}</p>
                 </article>
               ))}
@@ -372,8 +403,8 @@ export default async function HealthcheckPage() {
           ) : (
             <StatePanel
               status="sin-datos"
-              title="Sin eventos recientes"
-              description="No hay eventos saneados visibles para esta ventana de observación. La ausencia de eventos debe expresarse explícitamente en vez de dejar un panel vacío."
+              title="Sin eventos históricos"
+              description="No hay eventos saneados visibles en la bitácora histórica. La ausencia de eventos debe expresarse explícitamente en vez de dejar un panel vacío."
               eyebrow="Estado vacío"
             />
           )}

--- a/apps/web/src/modules/healthcheck/view-models/healthcheck-mappers.ts
+++ b/apps/web/src/modules/healthcheck/view-models/healthcheck-mappers.ts
@@ -8,6 +8,8 @@ export function mapHealthcheckStatusToBadgeStatus(status: HealthcheckStatus): Ap
     warn: 'revision',
     fail: 'incidencia',
     stale: 'stale',
+    not_configured: 'revision',
+    unknown: 'sin-datos',
   }
 
   return map[status]
@@ -19,6 +21,7 @@ export function mapHealthcheckSeverityToBadgeStatus(severity: HealthcheckSeverit
     medium: 'revision',
     high: 'incidencia',
     critical: 'incidencia',
+    unknown: 'sin-datos',
   }
 
   return map[severity]
@@ -26,10 +29,12 @@ export function mapHealthcheckSeverityToBadgeStatus(severity: HealthcheckSeverit
 
 export function getHealthcheckStatusLabel(status: HealthcheckStatus): string {
   const map: Record<HealthcheckStatus, string> = {
-    pass: 'Pass',
-    warn: 'Warn',
-    fail: 'Fail',
-    stale: 'Stale',
+    pass: 'Operativo',
+    warn: 'En revisión',
+    fail: 'Incidencia',
+    stale: 'Desactualizado',
+    not_configured: 'Fuente no configurada',
+    unknown: 'Estado desconocido',
   }
 
   return map[status]
@@ -41,6 +46,7 @@ export function getHealthcheckSeverityLabel(severity: HealthcheckSeverity): stri
     medium: 'Media',
     high: 'Alta',
     critical: 'Crítica',
+    unknown: 'Desconocida',
   }
 
   return map[severity]
@@ -52,6 +58,8 @@ const statusTriageRank: Record<HealthcheckStatus, number> = {
   stale: 55,
   warn: 50,
   pass: 10,
+  not_configured: 40,
+  unknown: 35,
 }
 
 const severityTriageRank: Record<HealthcheckSeverity, number> = {
@@ -59,6 +67,7 @@ const severityTriageRank: Record<HealthcheckSeverity, number> = {
   high: 80,
   medium: 45,
   low: 5,
+  unknown: 30,
 }
 
 export function getHealthcheckTriageRank(status: HealthcheckStatus, severity: HealthcheckSeverity): number {

--- a/apps/web/src/modules/healthcheck/view-models/healthcheck-summary.fixture.ts
+++ b/apps/web/src/modules/healthcheck/view-models/healthcheck-summary.fixture.ts
@@ -1,9 +1,20 @@
-export type HealthcheckSeverity = 'low' | 'medium' | 'high' | 'critical'
-export type HealthcheckStatus = 'pass' | 'warn' | 'fail' | 'stale'
+export type HealthcheckSeverity = 'low' | 'medium' | 'high' | 'critical' | 'unknown'
+export type HealthcheckStatus = 'pass' | 'warn' | 'fail' | 'stale' | 'not_configured' | 'unknown'
 
 export type HealthcheckFreshness = {
-  updated_at: string
+  updated_at: string | null
   label: string
+  state?: 'fresh' | 'stale' | 'unknown'
+}
+
+export type HealthcheckCurrentCause = {
+  source_id: string
+  label: string
+  status: HealthcheckStatus
+  severity: HealthcheckSeverity
+  summary: string
+  warning_text: string | null
+  freshness_state: 'fresh' | 'stale' | 'unknown'
 }
 
 export type HealthcheckSummaryBar = {
@@ -11,7 +22,8 @@ export type HealthcheckSummaryBar = {
   checks_total: number
   warnings: number
   incidents: number
-  updated_at: string
+  updated_at: string | null
+  current_cause: HealthcheckCurrentCause | null
 }
 
 export type HealthcheckModuleCard = {
@@ -29,6 +41,7 @@ export type HealthcheckEvent = {
   status: HealthcheckStatus
   timestamp: string
   detail: string
+  kind: 'historical'
 }
 
 export type HealthcheckSummaryItem = {
@@ -51,11 +64,20 @@ export type HealthcheckWorkspace = {
 
 export const healthcheckWorkspaceFixture: HealthcheckWorkspace = {
   summary_bar: {
-    overall_status: 'warn',
+    overall_status: 'fail',
     checks_total: 6,
     warnings: 2,
     incidents: 1,
     updated_at: '2026-04-24T07:46:00Z',
+    current_cause: {
+      source_id: 'system',
+      label: 'System',
+      status: 'fail',
+      severity: 'high',
+      summary: 'Se detectó una incidencia abierta de capacidad que requiere revisión prioritaria.',
+      warning_text: 'Causa principal del snapshot saneado; no representa lectura real.',
+      freshness_state: 'stale',
+    },
   },
   modules: [
     {
@@ -113,28 +135,32 @@ export const healthcheckWorkspaceFixture: HealthcheckWorkspace = {
       source: 'cronjobs',
       status: 'warn',
       timestamp: '2026-04-24T01:33:40+02:00',
-      detail: 'Ejecución nocturna completada con salida OK, pero quedaron referencias de skills a normalizar.',
+      detail: 'Ejecución nocturna completada con advertencia saneada pendiente de revisión.',
+      kind: 'historical',
     },
     {
       event_id: 'evt-gateway-latency',
       source: 'gateways',
       status: 'warn',
       timestamp: '2026-04-24T07:44:00Z',
-      detail: 'Latencia sostenida por encima del umbral objetivo durante la última ventana de observación.',
+      detail: 'Latencia sostenida por encima del umbral objetivo durante una ventana de observación anterior.',
+      kind: 'historical',
     },
     {
       event_id: 'evt-system-capacity',
       source: 'system',
       status: 'fail',
       timestamp: '2026-04-24T07:39:00Z',
-      detail: 'Capacidad degradada en un componente del host; se ha marcado como incidencia para revisión.',
+      detail: 'Incidencia saneada registrada en una revisión anterior; no representa por sí sola el estado activo.',
+      kind: 'historical',
     },
     {
       event_id: 'evt-backup-checksum',
       source: 'backups',
       status: 'pass',
       timestamp: '2026-04-24T07:35:00Z',
-      detail: 'Backup reciente validado con checksum sin desviaciones.',
+      detail: 'Backup validado en una revisión anterior sin desviaciones visibles.',
+      kind: 'historical',
     },
   ],
   principles: [

--- a/docs/frontend-states.md
+++ b/docs/frontend-states.md
@@ -46,8 +46,11 @@ Cada vista del frontend debe contemplar al menos:
 ### Healthcheck
 - `stale`: healthchecks o cron con frescura fuera del umbral
 - `error`: fuente de estado no disponible
+- La vista debe separar explícitamente `Estado actual`, `Causa actual` y `Bitácora histórica`.
+- Cuando haya `En revisión`, el usuario debe ver la causa primaria (`summary_bar.current_cause`, por ejemplo `Project health`) antes de la bitácora.
+- La bitácora muestra eventos históricos saneados y no debe presentarlos como incidencias activas.
 - La vista debe priorizar visualmente `fail`, `high` y `critical` antes que checks sanos.
-- Cuando haya degradación, debe existir una señal superior de `Acción requerida` o prioridad actual sin añadir controles operativos.
+- Cuando haya degradación, debe existir una señal superior de `Causa actual`, `Acción requerida` o prioridad actual sin añadir controles operativos.
 - Los badges de estado/severidad no deben duplicar el mismo significado visual; si coinciden, se muestra un solo badge y la severidad queda como texto de apoyo.
 
 ## Contratos frontend esperados del backend

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -37,11 +37,16 @@ Uso:
 
 ### `healthcheck.workspace`
 Campos esperados:
-- `summary_bar`
-- `modules[]`
-- `events[]`
+- `summary_bar` con `overall_status`, contadores, `updated_at` y `current_cause` saneado cuando el estado actual no es `pass`.
+- `modules[]` como estado vivo/current de cada fuente allowlisted.
+- `events[]` como eventos históricos saneados (`kind: historical`); no participan en `overall_status`, `warnings`, `incidents` ni `current_cause`.
 - `principles[]`
-- `signals[]`
+- `signals[]` como motivos/causas actuales degradadas derivados de módulos vivos.
+
+Semántica issue #104:
+- `En revisión` (`warn`) significa que una fuente actual requiere atención, normalmente por estado operativo revisable, freshness próxima/stale, severidad media, fuente parcial/no configurada o manifiesto desconocido. La causa visible debe salir de `summary_bar.current_cause`/`signals`, no de la bitácora.
+- `current_cause` apunta al registro vivo de mayor prioridad y expone solo `source_id`, `label`, `status`, `severity`, `summary`, `warning_text` y `freshness_state` saneados.
+- La bitácora histórica puede contener eventos `fail` antiguos, pero esos eventos no elevan el estado actual ni deben mostrarse como incidencia activa.
 
 ### `healthcheck.summary[]`
 Campos esperados:

--- a/docs/visual-verify-baseline.md
+++ b/docs/visual-verify-baseline.md
@@ -34,7 +34,7 @@ Este comando imprime la checklist canónica por **viewport** y por **ruta**.
 - cards con ritmo visual consistente
 - estados vacíos/error/stale sin colapsar el layout
 - cuando haya fallback visible, las pills `Modo fallback local`, `Snapshot saneado` y/o `No tiempo real` deben aclarar que el contenido no es API real
-- en `/healthcheck`, la prioridad actual debe verse antes del grid y los checks sanos no deben competir visualmente con incidencias o advertencias
+- en `/healthcheck`, la causa actual debe verse antes del grid y antes de la bitácora histórica; los checks sanos no deben competir visualmente con incidencias o advertencias
 
 ### Responsive fino
 - grids apilan paneles con dignidad

--- a/openspec/issue-104-healthcheck-review-clarity-verify-checklist.md
+++ b/openspec/issue-104-healthcheck-review-clarity-verify-checklist.md
@@ -1,0 +1,23 @@
+# Issue #104 — Verify checklist
+
+## Backend Healthcheck
+- [ ] `PYTHONPATH=. pytest apps/api/tests/test_healthcheck_dashboard_api.py -q`
+- [ ] `npm run verify:healthcheck-source-policy`
+- [ ] `npm run verify:healthcheck-review-clarity`
+
+## Frontend visible
+- [ ] `npm --prefix apps/web run typecheck`
+- [ ] `npm --prefix apps/web run build`
+- [ ] `npm run verify:visual-baseline`
+- [ ] Smoke browser `/healthcheck` con consola limpia y sin overflow evidente.
+
+## Hygiene
+- [ ] `git diff --check`
+- [ ] PR con resumen claro y reviewers Usopp + Chopper.
+- [ ] Tras merge: rebuild web, reinicio `mugiwara-control-panel-web.service`, reinicio API si backend cambió y smoke Tailscale.
+
+## Criterios específicos
+- [ ] `En revisión` muestra causa actual visible antes de módulos/bitácora.
+- [ ] `Project health` puede ser causa actual sin implicar caída de gateways.
+- [ ] La bitácora aparece como histórica y sus eventos `fail` no se muestran como incidencia activa.
+- [ ] No se exponen rutas internas, comandos, logs crudos, stdout/stderr, manifests, tokens, prompts ni secrets.

--- a/openspec/issue-104-healthcheck-review-clarity.md
+++ b/openspec/issue-104-healthcheck-review-clarity.md
@@ -1,0 +1,48 @@
+# Issue #104 — Healthcheck review clarity
+
+## Objetivo
+Aclarar por qué Healthcheck muestra `En revisión` y separar visual/semánticamente:
+1. estado actual;
+2. causa/motivos actuales;
+3. bitácora histórica.
+
+## Alcance
+- Añadir una causa actual saneada al read model (`summary_bar.current_cause`) derivada solo de registros vivos (`modules`/records), nunca de eventos históricos.
+- Marcar la bitácora como histórica (`events[].kind = historical`).
+- Ajustar `/healthcheck` para mostrar `Estado actual del Healthcheck`, `Causa actual` y `Bitácora histórica` en jerarquía separada.
+- Ajustar copy de badges históricos para evitar `Incidencia` a secas en eventos pasados.
+- Mantener Healthcheck read-only, server-only y saneado.
+
+## Fuera de alcance
+- Nuevas fuentes Healthcheck.
+- Nuevos comandos host o lectura de logs/stdout/stderr.
+- Cambios grandes de arquitectura o consola host.
+- Exponer rutas internas, units, manifests, tokens, prompts, secrets o datos runtime.
+
+## Diseño
+El backend ya calculaba `overall_status` desde los módulos vivos; la bitácora (`SAFE_EVENTS`) era solo payload visual. La microfase fija esa frontera en contrato:
+
+- `summary_bar.current_cause` se calcula desde el registro vivo con mayor prioridad por `_STATUS_ORDER` cuando `overall_status != pass`.
+- Si todos los módulos vivos están `pass`, `current_cause = null` aunque existan eventos históricos `warn/fail`.
+- `events[].kind = historical` identifica explícitamente que la bitácora no es estado activo.
+- La UI usa `current_cause` para copy tipo `En revisión por Project health` y muestra la bitácora bajo título `Bitácora histórica` con subtítulo de no-actividad.
+
+## Semántica resultante
+Antes:
+- `En revisión` era la traducción visual genérica de `warn` y la causa podía inferirse mirando tarjetas/señales.
+- Eventos históricos con `fail` podían parecer incidencias activas por aparecer como `Incidencia` en la bitácora.
+
+Después:
+- `En revisión` significa que una fuente actual requiere atención por estado operativo revisable, stale/freshness, severidad media, fuente parcial/no configurada o estado desconocido.
+- La causa actual visible viene de `summary_bar.current_cause`/`signals`, no de eventos históricos.
+- La bitácora queda explícitamente histórica y no contamina el estado actual.
+
+## Tests / guardrails
+- Tests backend para demostrar que eventos históricos `fail/warn` no elevan `overall_status`, `warnings`, `incidents` ni `current_cause`.
+- `verify:healthcheck-review-clarity` fija presencia de contrato/copy de causa actual y bitácora histórica.
+- Guardrails existentes Healthcheck siguen aplicando frontera read-only/no host console.
+
+## Review esperada
+- Usopp: UI/copy/claridad/accesibilidad visible.
+- Chopper: contrato Healthcheck, saneado, no-leakage y separación histórico/estado actual.
+- Franky: no requerido salvo que detecte riesgo operativo; no se tocan producers, timers, manifests ni runtime.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "verify:vault-server-only": "node scripts/check-vault-server-only.mjs",
     "verify:health-dashboard-server-only": "node scripts/check-health-dashboard-server-only.mjs",
     "verify:healthcheck-source-policy": "node scripts/check-healthcheck-source-policy.mjs",
+    "verify:healthcheck-review-clarity": "node scripts/check-healthcheck-review-clarity.mjs",
     "verify:vault-sync-status-producer": "node scripts/check-vault-sync-status-producer.mjs",
     "verify:vault-sync-status-runner": "node scripts/check-vault-sync-status-runner.mjs",
     "verify:project-health-runner": "node scripts/check-project-health-runner.mjs",

--- a/packages/contracts/src/read-models.ts
+++ b/packages/contracts/src/read-models.ts
@@ -13,7 +13,7 @@ export type SafeLink = {
 
 export type Severity = 'operativo' | 'revision' | 'incidencia' | 'stale' | 'sin-datos'
 export type OperationalSeverity = 'low' | 'medium' | 'high' | 'critical'
-export type HealthcheckStatus = 'pass' | 'warn' | 'fail' | 'stale'
+export type HealthcheckStatus = 'pass' | 'warn' | 'fail' | 'stale' | 'not_configured' | 'unknown'
 
 export type DashboardSection = {
   id: 'dashboard' | 'healthcheck' | 'mugiwaras' | 'memory' | 'vault' | 'skills'
@@ -24,7 +24,7 @@ export type DashboardSection = {
 export type DashboardFreshness = {
   updated_at: string | null
   label: string
-  state: 'fresh' | 'stale'
+  state: 'fresh' | 'stale' | 'unknown'
 }
 
 export type DashboardCount = {
@@ -113,7 +113,17 @@ export type VaultDocument = {
 export type HealthcheckFreshness = {
   updated_at: string | null
   label: string
-  state: 'fresh' | 'stale'
+  state: 'fresh' | 'stale' | 'unknown'
+}
+
+export type HealthcheckCurrentCause = {
+  source_id: string
+  label: string
+  status: HealthcheckStatus
+  severity: OperationalSeverity | 'unknown'
+  summary: string
+  warning_text: string | null
+  freshness_state: 'fresh' | 'stale' | 'unknown'
 }
 
 export type HealthcheckSummaryBar = {
@@ -122,6 +132,7 @@ export type HealthcheckSummaryBar = {
   warnings: number
   incidents: number
   updated_at: string | null
+  current_cause: HealthcheckCurrentCause | null
 }
 
 export type HealthcheckModuleCard = {
@@ -139,6 +150,7 @@ export type HealthcheckEvent = {
   status: HealthcheckStatus
   timestamp: string
   detail: string
+  kind: 'historical'
 }
 
 export type HealthcheckSummary = {

--- a/scripts/check-healthcheck-review-clarity.mjs
+++ b/scripts/check-healthcheck-review-clarity.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs'
+
+const checks = [
+  {
+    file: 'apps/api/src/modules/healthcheck/service.py',
+    mustInclude: [
+      'HealthcheckCurrentCause',
+      "current_cause = self._current_cause(overall_record) if overall != 'pass' else None",
+    ],
+  },
+  {
+    file: 'apps/api/src/modules/healthcheck/domain.py',
+    mustInclude: [
+      "kind: str = 'historical'",
+      'class HealthcheckCurrentCause',
+    ],
+  },
+  {
+    file: 'apps/web/src/app/healthcheck/page.tsx',
+    mustInclude: [
+      'Causa actual',
+      'Bitácora histórica',
+      'Eventos anteriores saneados. No representan necesariamente el estado activo',
+      'Incidencia histórica',
+      'No procede de la bitácora histórica',
+    ],
+    mustNotInclude: [
+      'Eventos recientes',
+    ],
+  },
+  {
+    file: 'apps/api/tests/test_healthcheck_dashboard_api.py',
+    mustInclude: [
+      'test_healthcheck_current_cause_is_derived_from_current_records_not_historical_events',
+      'test_healthcheck_pass_state_has_no_current_cause_even_with_historical_warning',
+    ],
+  },
+  {
+    file: 'docs/read-models.md',
+    mustInclude: [
+      'current_cause',
+      'eventos históricos',
+    ],
+  },
+]
+
+let failed = false
+for (const check of checks) {
+  const content = readFileSync(check.file, 'utf8')
+  for (const needle of check.mustInclude ?? []) {
+    if (!content.includes(needle)) {
+      console.error(`[healthcheck-review-clarity] ${check.file} must include: ${needle}`)
+      failed = true
+    }
+  }
+  for (const needle of check.mustNotInclude ?? []) {
+    if (content.includes(needle)) {
+      console.error(`[healthcheck-review-clarity] ${check.file} must not include stale copy: ${needle}`)
+      failed = true
+    }
+  }
+}
+
+if (failed) {
+  process.exit(1)
+}
+
+console.log('Healthcheck review clarity guardrail passed')

--- a/scripts/visual-verify-baseline.mjs
+++ b/scripts/visual-verify-baseline.mjs
@@ -88,8 +88,8 @@ const routes = [
     path: '/healthcheck',
     title: 'Salud del sistema',
     checks: [
-      'resumen agregado, módulos, eventos y señales respetan wrap y stacking',
-      'la prioridad actual aparece antes del grid cuando hay incidencia o advertencia',
+      'resumen actual, causa actual, módulos, bitácora histórica y señales respetan wrap y stacking',
+      'la causa actual aparece antes del grid y antes de la bitácora histórica cuando hay incidencia o advertencia',
       'badges de estado/severidad no duplican el mismo significado visual',
       'checks sanos mantienen menor peso visual que incidencias o advertencias',
       'si la API no está configurada, queda claro que los checks son snapshot local saneado y no tiempo real',


### PR DESCRIPTION
## Resumen

Cierra la microfase de issue #104: Healthcheck separa estado actual, causa actual y bitácora histórica.

### Qué cambia
- Añade `summary_bar.current_cause` al read model Healthcheck, derivado solo de registros vivos (`modules`/records) cuando `overall_status != pass`.
- Marca `events[].kind = historical` para que la bitácora quede semánticamente separada.
- Cambia `/healthcheck` para mostrar `Estado actual del Healthcheck`, `Causa actual` y `Bitácora histórica` en jerarquía visible.
- Cambia copy de eventos históricos: `Incidencia histórica` / `Evento histórico`, evitando `Incidencia` a secas en eventos pasados.
- Añade guardrail `npm run verify:healthcheck-review-clarity`.

### Antes
- `En revisión` era la traducción visual genérica de `warn`; la causa podía inferirse desde módulos/señales, pero no estaba fijada como causa actual visible.
- Eventos históricos `fail` de la bitácora podían parecer incidencia activa.

### Después
- `En revisión` significa: una fuente actual requiere atención por estado operativo revisable, freshness/stale, severidad media, fuente parcial/no configurada o estado desconocido.
- La causa actual se expone en `summary_bar.current_cause` y se ve como `En revisión por Project health`.
- La bitácora histórica no participa en `overall_status`, `warnings`, `incidents` ni `current_cause`.

## Seguridad / frontera
- Healthcheck sigue siendo read-only.
- No hay nuevas fuentes, comandos host, producers, timers ni lectura de logs/stdout/stderr.
- No se exponen rutas internas, manifests, nombres de units, prompts, tokens, secrets ni salidas crudas.

## Verificación de Zoro
- `PYTHONPATH=. pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` → 49 passed
- `npm run verify:healthcheck-source-policy` → passed
- `npm run verify:healthcheck-review-clarity` → passed
- `npm run verify:health-dashboard-server-only` → passed
- `npm --prefix apps/web run typecheck` → passed
- `npm --prefix apps/web run build` → passed; `/healthcheck` dinámica
- `npm run verify:visual-baseline` → passed/checklist actualizada
- `git diff --check` → passed
- Smoke HTTP local con API `127.0.0.1:8012` + web `127.0.0.1:3018`: `current_cause=Project health`, `events.kind=historical`, HTML contiene `Causa actual`/`Bitácora histórica`, no contiene `Eventos recientes`, backend URL ni env server-only.
- Browser smoke local `/healthcheck`: consola limpia; captura visual confirma causa actual antes de bitácora y sin overflow horizontal evidente.

## Review solicitado
- Usopp: claridad UI/copy, jerarquía visual, responsive/accesibilidad básica.
- Chopper: contrato Healthcheck, no-leakage, separación estado actual vs histórico.

Franky no solicitado inicialmente: no se tocan runtime, producers, timers, manifests ni semántica operativa de fuentes.
