### PR TITLE
feat: usar laya-mugiwara como marca principal

### DIFF
--- a/.engram/issue-117-laya-mugiwara-brand-closeout.md
+++ b/.engram/issue-117-laya-mugiwara-brand-closeout.md
@@ -1,0 +1,21 @@
+# Issue 117 — Laya Mugiwara brand closeout
+
+## Decisión
+`laya-mugiwara` pasa a ser la marca visual general del panel privado: SVG para favicon/app icon y JPG para `PageHeader`.
+
+## Frontera preservada
+Los assets quedan como dependencia local privada bajo `apps/web/public/assets/brand/`, carpeta ignorada por `.gitignore`. No se fuerza su versionado en el repo público.
+
+## Implementación
+- `PageHeader` renderiza `LayaMugiwaraMark` y ya no acepta `mugiwaraSlug` para cabeceras generales.
+- Las crests de Mugiwara se conservan en `/mugiwaras` y selectores/contextos de agente.
+- Guardrail `verify:laya-mugiwara-brand` fija metadata, PageHeader, ausencia de `mugiwaraSlug` en headers generales y no tracking de assets privados.
+
+## Verify
+Completado en la rama `zoro/issue-117-laya-mugiwara-brand` antes de PR:
+- `npm run verify:laya-mugiwara-brand`
+- `npm --prefix apps/web run typecheck`
+- `npm --prefix apps/web run build`
+- `npm run verify:visual-baseline`
+- `git diff --check`
+- smoke browser production local en `/dashboard`, `/healthcheck`, `/skills`, `/usage`, `/mugiwaras` con consola limpia, sin overflow horizontal y header usando `/assets/brand/laya-mugiwara.jpg`.

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -107,7 +107,6 @@ export default async function DashboardPage() {
         eyebrow="Dashboard"
         title="Estado del barco"
         subtitle="Resumen de observabilidad de solo lectura con contadores, severidad visible y accesos a módulos propietarios."
-        mugiwaraSlug="luffy"
         detailPills={['Puente de mando', 'Lectura saneada', 'Módulos propietarios']}
       />
 

--- a/apps/web/src/app/git/page.tsx
+++ b/apps/web/src/app/git/page.tsx
@@ -338,7 +338,6 @@ export default async function GitPage({ searchParams }: GitPageProps) {
         eyebrow="Repos Git"
         title="Repos Git"
         subtitle="Lectura server-only de repositorios allowlisteados con selección controlada por enlaces: historial, ramas locales, detalle de commit y diff histórico saneado. Sin operaciones mutables ni rutas cliente."
-        mugiwaraSlug="zoro"
         detailPills={['Solo lectura', 'repo_id/SHA backend-owned', 'Selección controlada', 'Diff redactado/truncado/omitido']}
       />
 

--- a/apps/web/src/app/healthcheck/page.tsx
+++ b/apps/web/src/app/healthcheck/page.tsx
@@ -256,7 +256,6 @@ export default async function HealthcheckPage() {
         eyebrow="Healthcheck"
         title="Salud del sistema"
         subtitle="Resumen operativo del perímetro: estado actual, causa visible y bitácora histórica separada sin exponer metadata sensible del host."
-        mugiwaraSlug="chopper"
         detailPills={['Perímetro', 'Señales saneadas', 'Respuesta priorizada']}
       />
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 
 import { fetchSystemMetrics, SystemMetricsApiError } from '@/modules/system/api/system-metrics-http'
 import { createHeaderSystemMetricsSnapshot, createUnavailableHeaderSystemMetrics } from '@/modules/system/view-models/system-metrics-summary'
+import { LAYA_MUGIWARA_FAVICON_SRC } from '@/shared/brand/laya-mugiwara-brand'
 import { AppShell } from '@/shared/ui/app-shell/AppShell'
 
 import './globals.css'
@@ -11,6 +12,13 @@ export const dynamic = 'force-dynamic'
 export const metadata: Metadata = {
   title: 'Mugiwara Control Panel',
   description: 'Private Mugiwara/Hermes control plane',
+  icons: {
+    icon: [
+      { url: LAYA_MUGIWARA_FAVICON_SRC, type: 'image/svg+xml' },
+    ],
+    shortcut: [LAYA_MUGIWARA_FAVICON_SRC],
+    apple: [LAYA_MUGIWARA_FAVICON_SRC],
+  },
 }
 
 async function loadHeaderSystemMetrics() {

--- a/apps/web/src/app/memory/MemoryClient.tsx
+++ b/apps/web/src/app/memory/MemoryClient.tsx
@@ -146,7 +146,6 @@ export function MemoryClient({ apiSummaries, apiDetails, apiState, apiNotice }: 
         eyebrow="Memory"
         title="Memoria operativa"
         subtitle="Selector por Mugiwara, tabs Built-in/Honcho y lectura resumida de fuente, manteniendo separación explícita respecto a Vault."
-        mugiwaraSlug="robin"
         detailPills={['Continuidad viva', 'Fuentes separadas', apiState === 'ready' ? 'API solo lectura' : 'Fallback saneado']}
       />
 

--- a/apps/web/src/app/mugiwaras/page.tsx
+++ b/apps/web/src/app/mugiwaras/page.tsx
@@ -348,7 +348,6 @@ export default async function MugiwarasPage() {
         eyebrow="Mugiwaras"
         title="Tripulación"
         subtitle="Vista de solo lectura de la tripulación, con descripción humana por agente y canon operativo AGENTS.md renderizado como Markdown seguro."
-        mugiwaraSlug="luffy"
         detailPills={['Índice de tripulación', 'Descripción humana', 'AGENTS.md read-only']}
       />
 

--- a/apps/web/src/app/skills/page.tsx
+++ b/apps/web/src/app/skills/page.tsx
@@ -652,7 +652,6 @@ export default function SkillsPage() {
         eyebrow="Skills"
         title="Skills"
         subtitle="Selecciona una fuente, elige una skill y alterna entre lectura Markdown y edición controlada."
-        mugiwaraSlug="zoro"
         detailPills={["Globales o Mugiwara", "Lector Markdown", "Editor auditado"]}
       />
 

--- a/apps/web/src/app/usage/page.tsx
+++ b/apps/web/src/app/usage/page.tsx
@@ -611,7 +611,6 @@ export default async function UsagePage() {
         eyebrow="Uso"
         title="Uso Codex/Hermes"
         subtitle="Cuota Codex, ciclos de reset, ventanas 5h y actividad local agregada saneada."
-        mugiwaraSlug="franky"
         detailPills={[
           `Plan: ${usage.plan.type}`,
           `${isSnapshotMode ? 'Corte del snapshot' : 'Última actualización'}: ${formatTimestamp(usage.current_snapshot.captured_at)}`,

--- a/apps/web/src/app/vault/VaultClient.tsx
+++ b/apps/web/src/app/vault/VaultClient.tsx
@@ -77,7 +77,6 @@ export function VaultClient({ initialWorkspace, apiState, apiErrorCode }: VaultC
         eyebrow="Vault"
         title="Vault"
         subtitle="Lectura documental y editorial del canon curado, con árbol allowlisted, documento legible y metadatos visibles."
-        mugiwaraSlug="robin"
         detailPills={['Canon curado', 'Lectura editorial', 'Sin memoria viva']}
       />
 

--- a/apps/web/src/shared/brand/LayaMugiwaraMark.tsx
+++ b/apps/web/src/shared/brand/LayaMugiwaraMark.tsx
@@ -1,0 +1,35 @@
+import { LAYA_MUGIWARA_MARK_ALT, LAYA_MUGIWARA_MARK_SRC } from './laya-mugiwara-brand'
+
+type LayaMugiwaraMarkSize = 'sm' | 'md'
+
+const sizeMap: Record<LayaMugiwaraMarkSize, number> = {
+  sm: 28,
+  md: 40,
+}
+
+type LayaMugiwaraMarkProps = {
+  size?: LayaMugiwaraMarkSize
+  decorative?: boolean
+}
+
+export function LayaMugiwaraMark({ size = 'sm', decorative = false }: LayaMugiwaraMarkProps) {
+  const dimension = sizeMap[size]
+
+  return (
+    <img
+      src={LAYA_MUGIWARA_MARK_SRC}
+      alt={decorative ? '' : LAYA_MUGIWARA_MARK_ALT}
+      aria-hidden={decorative}
+      width={dimension}
+      height={dimension}
+      style={{
+        display: 'block',
+        width: `${dimension}px`,
+        height: `${dimension}px`,
+        objectFit: 'cover',
+        borderRadius: '999px',
+        boxShadow: '0 0 0 1px rgba(255, 255, 255, 0.14), 0 0 14px rgba(90, 157, 219, 0.24)',
+      }}
+    />
+  )
+}

--- a/apps/web/src/shared/brand/laya-mugiwara-brand.ts
+++ b/apps/web/src/shared/brand/laya-mugiwara-brand.ts
@@ -1,0 +1,3 @@
+export const LAYA_MUGIWARA_FAVICON_SRC = '/assets/brand/laya-mugiwara.svg'
+export const LAYA_MUGIWARA_MARK_SRC = '/assets/brand/laya-mugiwara.jpg'
+export const LAYA_MUGIWARA_MARK_ALT = 'Emblema Laya Mugiwara'

--- a/apps/web/src/shared/ui/app-shell/PageHeader.tsx
+++ b/apps/web/src/shared/ui/app-shell/PageHeader.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react'
 
-import type { MugiwaraSlug } from '@/shared/mugiwara/crest-map'
-import { MugiwaraCrest } from '@/shared/mugiwara/MugiwaraCrest'
+import { LayaMugiwaraMark } from '@/shared/brand/LayaMugiwaraMark'
 import { appTheme } from '@/shared/theme/tokens'
 
 type PageHeaderProps = {
@@ -9,32 +8,29 @@ type PageHeaderProps = {
   subtitle?: string
   eyebrow?: string
   actions?: ReactNode
-  mugiwaraSlug?: MugiwaraSlug
   detailPills?: string[]
 }
 
-export function PageHeader({ title, subtitle, eyebrow, actions, mugiwaraSlug, detailPills = [] }: PageHeaderProps) {
+export function PageHeader({ title, subtitle, eyebrow, actions, detailPills = [] }: PageHeaderProps) {
   return (
     <section className="page-header">
       <div className="page-header__body">
         <div>
-          {eyebrow || mugiwaraSlug ? (
+          {eyebrow ? (
             <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap', marginBottom: '8px' }}>
-              {mugiwaraSlug ? <MugiwaraCrest slug={mugiwaraSlug} size="sm" accent /> : null}
-              {eyebrow ? (
-                <p
-                  style={{
-                    margin: 0,
-                    color: appTheme.colors.brandSky500,
-                    fontWeight: 700,
-                    fontSize: '12px',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.08em',
-                  }}
-                >
-                  {eyebrow}
-                </p>
-              ) : null}
+              <LayaMugiwaraMark size="sm" />
+              <p
+                style={{
+                  margin: 0,
+                  color: appTheme.colors.brandSky500,
+                  fontWeight: 700,
+                  fontSize: '12px',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.08em',
+                }}
+              >
+                {eyebrow}
+              </p>
             </div>
           ) : null}
 

--- a/docs/frontend-implementation-handoff.md
+++ b/docs/frontend-implementation-handoff.md
@@ -254,6 +254,7 @@ Responsabilidades:
 ### `PageHeader`
 - `title`
 - `subtitle`
+- emblema visual general con `laya-mugiwara.jpg` mediante componente compartido de marca; no usar `MugiwaraCrest` ni `mugiwaraSlug` en cabeceras generales
 - `actions`
 - `breadcrumbs?`
 - puede usar un heading editorial visible distinto del nombre canónico de ruta si la spec lo permite (ej. `Dashboard` -> `Estado del barco`)
@@ -418,27 +419,29 @@ Pero la recomendación sigue siendo migrar luego a SVG.
 
 Con eso ya se puede construir una interfaz muy buena.
 
-## 7.2 Convenientes pero no imprescindibles
-### A. Logo o wordmark del producto
-Ruta sugerida:
+## 7.2 Assets de marca privados/locales
+### A. Emblema y favicon `laya-mugiwara`
+Rutas privadas/locales esperadas:
 ```text
 apps/web/public/assets/brand/
-  mugiwara-control-panel-logo.svg
-  mugiwara-control-panel-mark.svg
+  laya-mugiwara.svg
+  laya-mugiwara.jpg
 ```
 
 Sirve para:
-- topbar
-- sidebar
-- favicon futura
+- favicon/app icon: `laya-mugiwara.svg`
+- emblema de `PageHeader` y títulos generales: `laya-mugiwara.jpg`
+
+Política de empaquetado:
+- `apps/web/public/assets/brand/` permanece ignorado en `.gitignore`.
+- No versionar ni forzar `git add -f` de estos assets en el repo público salvo orden explícita de Pablo.
+- El despliegue privado debe mantener esos dos ficheros presentes localmente.
+- Las crests de Mugiwara siguen en `assets/mugiwaras/crests*` para cards/selectores/contextos de agente.
 
 ### B. Favicon / app icon
-Ruta sugerida:
+Si en el futuro se decide publicar un fallback público, debe ser una decisión explícita. La implementación actual usa metadata de Next apuntando al SVG privado/local:
 ```text
-apps/web/public/
-  favicon.ico
-  icon.png
-  apple-touch-icon.png
+apps/web/public/assets/brand/laya-mugiwara.svg
 ```
 
 ### C. Textura o fondo muy sutil opcional

--- a/docs/frontend-ui-spec.md
+++ b/docs/frontend-ui-spec.md
@@ -253,9 +253,11 @@ Contiene layout principal.
 ### `PageHeader`
 - título
 - subtítulo
+- emblema visual general del panel con `apps/web/public/assets/brand/laya-mugiwara.jpg`
 - acciones contextuales si aplican
 - opcional: breadcrumbs
 - en tablet/mobile debe apilar cuerpo y acciones sin provocar overflow; pills y badges deben poder envolver
+- las calaveras de cada Mugiwara quedan reservadas para `/mugiwaras` y contextos donde el agente concreto sea el contenido, no para cabeceras generales
 
 ## 4.2 Foundation components
 ### `SurfaceCard`

--- a/openspec/issue-117-laya-mugiwara-brand.md
+++ b/openspec/issue-117-laya-mugiwara-brand.md
@@ -1,0 +1,28 @@
+# Issue 117 — Laya Mugiwara brand
+
+## Objetivo
+Usar `laya-mugiwara` como marca visual principal del panel privado sin convertir los assets personales en parte del repo público.
+
+## Alcance
+- `apps/web/src/app/layout.tsx` declara el favicon/app icon mediante `apps/web/public/assets/brand/laya-mugiwara.svg`.
+- `PageHeader` usa el emblema general `apps/web/public/assets/brand/laya-mugiwara.jpg` mediante un componente compartido de marca.
+- Los `PageHeader` de rutas generales dejan de recibir `mugiwaraSlug`; las crests por Mugiwara quedan para `/mugiwaras` y contextos de agente como selectores/cards.
+- `.gitignore` mantiene `apps/web/public/assets/brand/` ignorado.
+- Se añade guardrail `npm run verify:laya-mugiwara-brand` para fijar la política de marca/assets privados.
+
+## Fuera de alcance
+- Rediseño global del shell.
+- Cambios backend/runtime/deploy.
+- Versionar assets privados o forzar `git add -f`.
+- Reemplazar crests en cards/selectores de Mugiwara.
+
+## Política de assets
+Los assets `laya-mugiwara.svg` y `laya-mugiwara.jpg` son dependencia local/privada del runtime. El repo público documenta las rutas, pero no debe trackear esos binarios salvo orden explícita de Pablo.
+
+## Verify esperado
+- `npm run verify:laya-mugiwara-brand`
+- `npm --prefix apps/web run typecheck`
+- `npm --prefix apps/web run build`
+- `npm run verify:visual-baseline`
+- `git diff --check`
+- smoke browser `/dashboard`, `/healthcheck`, `/skills`, `/usage`, `/mugiwaras`

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "verify:system-metrics-backend-policy": "node scripts/check-system-metrics-backend-policy.mjs",
     "verify:system-metrics-server-only": "node scripts/check-system-metrics-server-only.mjs",
     "verify:git-server-only": "node scripts/check-git-server-only.mjs",
-    "verify:control-panel-service-runner": "node scripts/check-control-panel-service-runner.mjs"
+    "verify:control-panel-service-runner": "node scripts/check-control-panel-service-runner.mjs",
+    "verify:laya-mugiwara-brand": "node scripts/check-laya-mugiwara-brand.mjs"
   },
   "overrides": {
     "postcss": "8.5.10"

--- a/scripts/check-laya-mugiwara-brand.mjs
+++ b/scripts/check-laya-mugiwara-brand.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = process.cwd()
+const read = (path) => readFileSync(join(repoRoot, path), 'utf8')
+const failures = []
+const expectIncludes = (path, needle, message) => {
+  if (!read(path).includes(needle)) failures.push(`${path}: ${message}`)
+}
+const expectNotIncludes = (path, needle, message) => {
+  if (read(path).includes(needle)) failures.push(`${path}: ${message}`)
+}
+
+expectIncludes('.gitignore', 'apps/web/public/assets/brand/', 'private brand assets directory must stay ignored')
+expectIncludes('apps/web/src/shared/brand/laya-mugiwara-brand.ts', "'/assets/brand/laya-mugiwara.svg'", 'favicon/app icon must point to local laya-mugiwara.svg')
+expectIncludes('apps/web/src/shared/brand/laya-mugiwara-brand.ts', "'/assets/brand/laya-mugiwara.jpg'", 'PageHeader mark must point to local laya-mugiwara.jpg')
+expectIncludes('apps/web/src/app/layout.tsx', 'LAYA_MUGIWARA_FAVICON_SRC', 'Next metadata icons must use laya-mugiwara favicon constant')
+expectIncludes('apps/web/src/shared/ui/app-shell/PageHeader.tsx', 'LayaMugiwaraMark', 'PageHeader must render the Laya Mugiwara brand mark')
+expectNotIncludes('apps/web/src/shared/ui/app-shell/PageHeader.tsx', 'MugiwaraCrest', 'PageHeader must not render per-agent Mugiwara crests')
+expectNotIncludes('apps/web/src/shared/ui/app-shell/PageHeader.tsx', 'mugiwaraSlug', 'PageHeader must not expose per-agent crest prop for general page titles')
+
+for (const route of [
+  'apps/web/src/app/dashboard/page.tsx',
+  'apps/web/src/app/healthcheck/page.tsx',
+  'apps/web/src/app/mugiwaras/page.tsx',
+  'apps/web/src/app/skills/page.tsx',
+  'apps/web/src/app/usage/page.tsx',
+  'apps/web/src/app/memory/MemoryClient.tsx',
+  'apps/web/src/app/vault/VaultClient.tsx',
+  'apps/web/src/app/git/page.tsx',
+]) {
+  expectNotIncludes(route, 'mugiwaraSlug=', 'general PageHeader calls must use the panel brand mark, not a per-agent crest')
+}
+
+expectIncludes('apps/web/src/app/mugiwaras/page.tsx', 'MugiwaraCrest', '/mugiwaras must keep per-agent crests in cards/contextual agent UI')
+expectIncludes('docs/frontend-ui-spec.md', 'laya-mugiwara.jpg', 'frontend spec must document the PageHeader brand mark')
+expectIncludes('docs/frontend-implementation-handoff.md', 'laya-mugiwara.svg', 'implementation handoff must document the private favicon dependency')
+
+const trackedBrandAssets = execFileSync('git', ['ls-files', 'apps/web/public/assets/brand'], { cwd: repoRoot, encoding: 'utf8' }).trim()
+if (trackedBrandAssets) {
+  failures.push(`private brand assets must not be tracked by Git: ${trackedBrandAssets}`)
+}
+
+for (const localAsset of ['apps/web/public/assets/brand/laya-mugiwara.svg', 'apps/web/public/assets/brand/laya-mugiwara.jpg']) {
+  if (!existsSync(join(repoRoot, localAsset))) {
+    console.warn(`[laya-mugiwara-brand] aviso: falta asset privado local ${localAsset}; el repo público documenta esta dependencia pero no la versiona.`)
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Laya Mugiwara brand guardrail failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log('Laya Mugiwara brand guardrail passed')


### PR DESCRIPTION
## Qué cambia
- Usa `laya-mugiwara.svg` como favicon/app icon desde metadata de Next.
- Usa `laya-mugiwara.jpg` como emblema general de `PageHeader` mediante componente `LayaMugiwaraMark`.
- Retira `mugiwaraSlug` de los `PageHeader` generales para no atribuir visualmente rutas del panel a un Mugiwara concreto.
- Conserva `MugiwaraCrest` en `/mugiwaras` y contextos de agente/selectores.
- Mantiene `apps/web/public/assets/brand/` ignorado y documenta la dependencia local privada.
- Añade guardrail `npm run verify:laya-mugiwara-brand`.

## Política de assets
No se versionan los assets privados `laya-mugiwara.svg` ni `laya-mugiwara.jpg`. El repo público solo referencia/documenta sus rutas locales y el guardrail verifica que no estén trackeados.

## Verify de Zoro
- `npm run verify:laya-mugiwara-brand`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build`
- `npm run verify:visual-baseline`
- `git diff --check`
- Smoke browser production local en `http://127.0.0.1:3127`: `/dashboard`, `/healthcheck`, `/skills`, `/usage`, `/mugiwaras`.
  - Consola limpia.
  - Sin overflow horizontal.
  - Header con `/assets/brand/laya-mugiwara.jpg`.
  - Favicon links apuntando a `/assets/brand/laya-mugiwara.svg`.
  - `/mugiwaras` conserva crests por agente.

## Review solicitada
- Usopp: marca, coherencia visual, PageHeader y responsive básico.
- Chopper: política de assets privados/locales, repo público y no exposición/versionado accidental.

Closes #117
