### PR TITLE
feat: add vault explorer backend tree

### DIFF
--- a/.engram/issue-121-1-vault-explorer-closeout.md
+++ b/.engram/issue-121-1-vault-explorer-closeout.md
@@ -1,0 +1,23 @@
+# Issue 121.1 — Backend Vault explorer closeout
+
+## Resultado
+Se ha materializado la primera frontera backend del rediseño `/vault`: un árbol dinámico read-only del vault canónico, expuesto por `GET /api/v1/vault/tree` y añadido como `data.explorer` al workspace existente para facilitar transición gradual del frontend.
+
+## Decisión de corte
+La microfase conserva el contrato legacy de documentos editorializados para no romper la UI actual antes de 121.2/121.3. El nuevo contrato dinámico queda disponible y probado, pero no sustituye todavía el reader ni la experiencia visual.
+
+## Seguridad cubierta
+- Root backend-owned fijo y serializado solo como `canonical_vault`.
+- Rutas relativas únicamente.
+- Exclusión de hidden files/dirs, `.git`, `.obsidian`, `.env`, symlinks, no Markdown y documentos oversized.
+- Límites de profundidad/nodos/tamaño documentados en el payload.
+- Tests negativos con fixture sintética y scan recursivo anti-leakage.
+- Follow-up menor de Chopper absorbido antes del merge: el walker maneja `OSError` en `iterdir`, `is_symlink`, `resolve` e `is_dir` para degradar entradas ilegibles sin filtrar internals.
+
+## Verify
+- `python3 -m py_compile apps/api/src/modules/vault/*.py apps/api/tests/test_vault_api.py`
+- `PYTHONPATH=. pytest apps/api/tests/test_vault_api.py -q`
+- `git diff --check`
+
+## Continuidad
+Siguiente microfase: 121.2 debe añadir el reader raw Markdown saneado reutilizando las mismas reglas de path safety. Debe rechazar traversal/absolutas/`~`/encoded traversal/symlinks/hidden/no-md/oversized y preservar frontmatter dentro del contenido Markdown.

--- a/apps/api/src/modules/vault/domain.py
+++ b/apps/api/src/modules/vault/domain.py
@@ -22,6 +22,26 @@ class VaultTreeEntry:
 
 
 @dataclass(frozen=True)
+class VaultExplorerNode:
+    id: str
+    name: str
+    relative_path: str
+    kind: str
+    depth: int
+    size_bytes: int | None = None
+    updated_at: str | None = None
+
+
+@dataclass(frozen=True)
+class VaultDocumentRef:
+    id: str
+    name: str
+    relative_path: str
+    size_bytes: int
+    updated_at: str
+
+
+@dataclass(frozen=True)
 class VaultDocumentSection:
     heading: str
     body: list[str]

--- a/apps/api/src/modules/vault/router.py
+++ b/apps/api/src/modules/vault/router.py
@@ -22,7 +22,17 @@ def get_vault_index(service: VaultService = Depends(get_vault_service)) -> dict:
         resource='vault.workspace',
         status='ready',
         data=workspace,
-        meta={'safe_root': 'canonical_vault', 'read_only': True, 'allowlisted': True},
+        meta={'safe_root': 'canonical_vault', 'read_only': True, 'allowlisted': True, 'sanitized': True},
+    )
+
+
+@router.get('/tree')
+def get_vault_tree(service: VaultService = Depends(get_vault_service)) -> dict:
+    return resource_response(
+        resource='vault.explorer_tree',
+        status='ready',
+        data=service.get_explorer_tree(),
+        meta={'safe_root': 'canonical_vault', 'read_only': True, 'sanitized': True},
     )
 
 

--- a/apps/api/src/modules/vault/service.py
+++ b/apps/api/src/modules/vault/service.py
@@ -12,12 +12,18 @@ from .domain import (
     VaultDocument,
     VaultDocumentEntry,
     VaultDocumentMeta,
+    VaultDocumentRef,
     VaultDocumentSection,
+    VaultExplorerNode,
     VaultFreshness,
     VaultTreeEntry,
 )
 
 VAULT_ROOT = Path('/srv/crew-core/vault').resolve()
+DEFAULT_MAX_TREE_DEPTH = 8
+DEFAULT_MAX_TREE_NODES = 600
+DEFAULT_MAX_DOCUMENT_BYTES = 512 * 1024
+HIDDEN_NAMES = {'.git', '.obsidian', '.env'}
 
 PROJECT_SUMMARY = VaultDocumentEntry(
     document_id='mugiwara-control-panel-summary',
@@ -55,9 +61,20 @@ SAFE_VAULT_CATEGORIES: tuple[VaultCategory, ...] = (
 
 
 class VaultService:
-    def __init__(self, *, root: Path = VAULT_ROOT, categories: tuple[VaultCategory, ...] = SAFE_VAULT_CATEGORIES) -> None:
+    def __init__(
+        self,
+        *,
+        root: Path = VAULT_ROOT,
+        categories: tuple[VaultCategory, ...] = SAFE_VAULT_CATEGORIES,
+        max_tree_depth: int = DEFAULT_MAX_TREE_DEPTH,
+        max_tree_nodes: int = DEFAULT_MAX_TREE_NODES,
+        max_document_bytes: int = DEFAULT_MAX_DOCUMENT_BYTES,
+    ) -> None:
         self._root = root.resolve()
         self._categories = categories
+        self._max_tree_depth = max_tree_depth
+        self._max_tree_nodes = max_tree_nodes
+        self._max_document_bytes = max_document_bytes
         self._documents = {document.document_id: document for category in categories for document in category.documents}
         self._paths = {document.relative_path: document for document in self._documents.values()}
 
@@ -67,8 +84,82 @@ class VaultService:
         return {
             'freshness': asdict(self._freshness()),
             'tree': tree,
+            'explorer': self.get_explorer_tree(),
             'active_document_id': PROJECT_SUMMARY.document_id,
             'documents': documents,
+        }
+
+    def get_explorer_tree(self) -> dict:
+        nodes: list[VaultExplorerNode] = []
+        documents: list[VaultDocumentRef] = []
+        truncated = False
+
+        def append_node(node: VaultExplorerNode) -> bool:
+            nonlocal truncated
+            if len(nodes) >= self._max_tree_nodes:
+                truncated = True
+                return False
+            nodes.append(node)
+            return True
+
+        def walk(directory: Path, depth: int) -> None:
+            nonlocal truncated
+            if truncated or depth > self._max_tree_depth:
+                return
+            for child in self._iter_safe_children(directory):
+                if truncated:
+                    return
+                try:
+                    relative = child.relative_to(self._root).as_posix()
+                except ValueError:
+                    continue
+                if child.is_dir():
+                    if depth >= self._max_tree_depth:
+                        continue
+                    if not append_node(VaultExplorerNode(
+                        id=self._node_id(relative),
+                        name=child.name,
+                        relative_path=relative,
+                        kind='directory',
+                        depth=depth,
+                    )):
+                        return
+                    walk(child, depth + 1)
+                    continue
+                if not self._is_allowed_markdown_file(child):
+                    continue
+                stat = child.stat()
+                updated_at = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
+                document_node = VaultExplorerNode(
+                    id=self._node_id(relative),
+                    name=child.name,
+                    relative_path=relative,
+                    kind='document',
+                    depth=depth,
+                    size_bytes=stat.st_size,
+                    updated_at=updated_at,
+                )
+                if not append_node(document_node):
+                    return
+                documents.append(VaultDocumentRef(
+                    id=document_node.id,
+                    name=child.name,
+                    relative_path=relative,
+                    size_bytes=stat.st_size,
+                    updated_at=updated_at,
+                ))
+
+        walk(self._root, 0)
+        return {
+            'safe_root': 'canonical_vault',
+            'read_only': True,
+            'sanitized': True,
+            'max_depth': self._max_tree_depth,
+            'max_nodes': self._max_tree_nodes,
+            'max_document_bytes': self._max_document_bytes,
+            'limits': {'nodes_truncated': truncated},
+            'nodes': [asdict(node) for node in nodes],
+            'documents': [asdict(document) for document in documents],
         }
 
     def get_document_by_id(self, document_id: str) -> VaultDocument:
@@ -83,6 +174,50 @@ class VaultService:
         if document is None:
             raise self._reject(status.HTTP_404_NOT_FOUND, 'not_found', 'Documento no disponible en la allowlist del vault.')
         return self._read_document(document)
+
+    def _iter_safe_children(self, directory: Path) -> list[Path]:
+        if directory.is_symlink() or not directory.exists() or not directory.is_dir():
+            return []
+        children: list[Path] = []
+        try:
+            candidates = list(directory.iterdir())
+        except OSError:
+            return []
+        for child in candidates:
+            if self._is_hidden(child):
+                continue
+            try:
+                if child.is_symlink():
+                    continue
+                resolved = child.resolve()
+                is_directory = child.is_dir()
+            except OSError:
+                continue
+            if self._root != resolved and self._root not in resolved.parents:
+                continue
+            if is_directory or self._is_allowed_markdown_file(child):
+                children.append(child)
+        return sorted(children, key=lambda item: (not item.is_dir(), item.name.lower()))
+
+    def _is_allowed_markdown_file(self, path: Path) -> bool:
+        if not path.is_file() or path.suffix.lower() != '.md':
+            return False
+        try:
+            stat = path.stat()
+        except OSError:
+            return False
+        return stat.st_size <= self._max_document_bytes
+
+    def _is_hidden(self, path: Path) -> bool:
+        try:
+            relative = path.relative_to(self._root)
+        except ValueError:
+            return True
+        return any(part.startswith('.') or part in HIDDEN_NAMES for part in relative.parts)
+
+    def _node_id(self, relative_path: str) -> str:
+        safe = relative_path.lower().replace('/', '--').replace(' ', '-')
+        return ''.join(char if char.isalnum() or char in {'-', '_', '.'} else '-' for char in safe).strip('-') or 'vault-root'
 
     def _build_tree(self) -> list[dict]:
         entries: list[VaultTreeEntry] = []

--- a/apps/api/tests/test_vault_api.py
+++ b/apps/api/tests/test_vault_api.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 from apps.api.src.main import app
 
 from apps.api.src.modules.vault.domain import VaultCategory, VaultDocumentEntry
+from apps.api.src.modules.vault.router import get_vault_service
 from apps.api.src.modules.vault.service import VaultService
 
 client = TestClient(app)
@@ -30,19 +31,84 @@ def test_vault_workspace_returns_allowlisted_documents():
     payload = response.json()
     assert payload['resource'] == 'vault.workspace'
     assert payload['status'] == 'ready'
-    assert payload['meta'] == {'safe_root': 'canonical_vault', 'read_only': True, 'allowlisted': True}
+    assert payload['meta'] == {'safe_root': 'canonical_vault', 'read_only': True, 'allowlisted': True, 'sanitized': True}
 
     data = payload['data']
     assert data['active_document_id'] == 'mugiwara-control-panel-summary'
     assert data['freshness']['state'] == 'fresh'
     assert len(data['tree']) >= 3
     assert len(data['documents']) == 3
+    assert data['explorer']['read_only'] is True
+    assert data['explorer']['safe_root'] == 'canonical_vault'
+    assert data['explorer']['sanitized'] is True
     assert {document['id'] for document in data['documents']} == {
         'mugiwara-control-panel-summary',
         'memory-governance',
         'pr-governance',
     }
     _assert_no_host_paths(payload)
+
+
+def test_vault_tree_endpoint_returns_dynamic_explorer_from_safe_root(tmp_path):
+    (tmp_path / '00-System').mkdir()
+    (tmp_path / '00-System' / 'Policy.md').write_text('# Policy\n', encoding='utf-8')
+    (tmp_path / '00-System' / '.env').write_text('TOKEN=secret\n', encoding='utf-8')
+    (tmp_path / '.git').mkdir()
+    (tmp_path / '.git' / 'config').write_text('private git config\n', encoding='utf-8')
+    (tmp_path / 'README.txt').write_text('not markdown\n', encoding='utf-8')
+    (tmp_path / 'Big.md').write_text('x' * 64, encoding='utf-8')
+    (tmp_path / 'Linked.md').symlink_to(tmp_path / '00-System' / 'Policy.md')
+
+    service = VaultService(root=tmp_path, max_document_bytes=32)
+    app.dependency_overrides[get_vault_service] = lambda: service
+    try:
+        response = client.get('/api/v1/vault/tree')
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'vault.explorer_tree'
+    assert payload['meta'] == {'safe_root': 'canonical_vault', 'read_only': True, 'sanitized': True}
+    tree = payload['data']
+    assert tree['read_only'] is True
+    assert tree['safe_root'] == 'canonical_vault'
+    assert tree['sanitized'] is True
+    assert tree['max_document_bytes'] == 32
+    paths = {node['relative_path'] for node in tree['nodes']}
+    assert '00-System' in paths
+    assert '00-System/Policy.md' in paths
+    assert '.git' not in paths
+    assert '00-System/.env' not in paths
+    assert 'README.txt' not in paths
+    assert 'Big.md' not in paths
+    assert 'Linked.md' not in paths
+    assert any(document['relative_path'] == '00-System/Policy.md' for document in tree['documents'])
+    _assert_no_host_paths(payload)
+    serialized = str(payload)
+    assert '.env' not in serialized
+    assert '.git' not in serialized
+    assert 'secret' not in serialized.lower()
+
+
+def test_vault_explorer_tree_enforces_depth_and_node_limits(tmp_path):
+    current = tmp_path
+    for index in range(4):
+        current = current / f'level-{index}'
+        current.mkdir()
+        (current / f'doc-{index}.md').write_text('# Doc\n', encoding='utf-8')
+
+    shallow_service = VaultService(root=tmp_path, max_tree_depth=1, max_tree_nodes=50)
+    shallow_tree = shallow_service.get_explorer_tree()
+    shallow_paths = {node['relative_path'] for node in shallow_tree['nodes']}
+    assert 'level-0' in shallow_paths
+    assert 'level-0/doc-0.md' in shallow_paths
+    assert 'level-0/level-1' not in shallow_paths
+
+    capped_service = VaultService(root=tmp_path, max_tree_depth=8, max_tree_nodes=2)
+    capped_tree = capped_service.get_explorer_tree()
+    assert len(capped_tree['nodes']) == 2
+    assert capped_tree['limits']['nodes_truncated'] is True
 
 
 def test_vault_document_reads_markdown_only_allowlisted_path():

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -38,8 +38,10 @@
 - no exponer prompts, IDs internos, sesiones, observaciones completas, tokens ni secretos
 
 ### `vault`
-- exponer `GET /api/v1/vault` como workspace documental read-only allowlisted
+- exponer `GET /api/v1/vault` como workspace documental read-only allowlisted; desde issue #121.1 añade `data.explorer` como árbol dinámico seguro para transición hacia explorador + lector Markdown
+- exponer `GET /api/v1/vault/tree` como contrato read-only de explorador del vault bajo root backend-owned fijo, serializando solo rutas relativas y metadata mínima segura
 - exponer `GET /api/v1/vault/documents/{document_path:path}` para lectura de documentos markdown permitidos
+- para el árbol dinámico, excluir hidden files/dirs (`.git`, `.obsidian`, `.env`, dotfiles), symlinks, no Markdown, documentos oversized y entradas fuera del root; aplicar límites de profundidad, nodos y tamaño de documento
 - normalizar paths y rechazar traversal, paths absolutos, symlinks, extensiones no soportadas y documentos fuera de allowlist
 - integrar `/vault` desde frontend mediante adapter server-only con fallback saneado visible
 - sin escritura en MVP

--- a/docs/backend-boundary.md
+++ b/docs/backend-boundary.md
@@ -30,7 +30,7 @@ Todo recurso o acción cae en uno de estos estados:
 ## Allowlists de rutas
 ### Lectura permitida
 - `/srv/crew-core/skills-source/**`
-- `/srv/crew-core/vault/**`
+- `/srv/crew-core/vault/**`, solo mediante módulos backend read-only con root fijo, rutas relativas saneadas y exclusión de hidden/symlinks/oversized cuando se navega como árbol
 - `/home/agentops/.hermes/profiles/**/config.yaml`
 - `/home/agentops/.hermes/profiles/**/memories/*.md`
 - fuentes operativas resumidas/saneadas de healthcheck y cron que se definan como input del módulo `healthcheck`

--- a/openspec/issue-121-1-vault-explorer-backend.md
+++ b/openspec/issue-121-1-vault-explorer-backend.md
@@ -1,0 +1,35 @@
+# Issue 121.1 — Backend Vault explorer tree
+
+## Objetivo
+Cerrar la primera microfase de #121 creando un contrato backend read-only para explorar el vault como árbol dinámico seguro, sin introducir todavía el lector Markdown raw ni la nueva UI de dos columnas.
+
+## Alcance implementado
+- Nuevo endpoint `GET /api/v1/vault/tree` con recurso `vault.explorer_tree`.
+- `GET /api/v1/vault` conserva compatibilidad de workspace actual y añade `data.explorer` como contrato nuevo para fases frontend posteriores.
+- El árbol se construye bajo root backend-owned `canonical_vault` (`/srv/crew-core/vault` en runtime), pero el payload solo devuelve rutas relativas.
+- Se incluyen directorios y documentos `.md` permitidos.
+- Se excluyen ficheros/directorios ocultos, `.git`, `.obsidian`, `.env`, symlinks, no Markdown, documentos oversized y entradas fuera del root.
+- Se añaden límites explícitos de profundidad, número de nodos y tamaño máximo de documento referenciado.
+- No se devuelve contenido Markdown en esta microfase; solo referencias y metadata mínima segura.
+
+## Fuera de alcance
+- Lectura raw del contenido Markdown (`121.2`).
+- Rediseño visual de `/vault` (`121.3`).
+- Responsive/guardrails frontend/canon final (`121.4`).
+- Escritura, edición, creación, borrado o renombrado en vault.
+- Búsqueda full-text, TOC lateral o panel externo de metadata.
+
+## Contrato de seguridad
+- `safe_root` se serializa como `canonical_vault`, nunca como ruta absoluta.
+- `read_only=true` y `sanitized=true` aparecen en meta y payload.
+- El cliente no puede elegir root ni ruta base.
+- El backend no sigue symlinks ni padres symlink.
+- La respuesta no debe contener `/srv/`, `/home/`, `.env`, `.git`, secretos, stdout/stderr/logs ni rutas absolutas.
+
+## Verify esperado
+- `python3 -m py_compile apps/api/src/modules/vault/*.py apps/api/tests/test_vault_api.py`
+- `PYTHONPATH=. pytest apps/api/tests/test_vault_api.py -q`
+- `git diff --check`
+
+## Review
+Chopper obligatorio por filesystem host-adjacent, traversal/symlink/hidden/no-leakage. Franky no aplica salvo que se introduzcan cambios runtime/deploy/config operativa, cosa que esta microfase no hace.

--- a/openspec/issue-121-1-vault-explorer-verify-checklist.md
+++ b/openspec/issue-121-1-vault-explorer-verify-checklist.md
@@ -1,0 +1,25 @@
+# Issue 121.1 — Verify checklist
+
+## TDD
+- [x] Añadidos tests rojos para `GET /api/v1/vault/tree` con fixture sintética.
+- [x] Añadidos tests para exclusión de `.git`, `.env`, no-md, oversized y symlink.
+- [x] Añadidos tests para límites de profundidad y número de nodos.
+- [x] Añadida aserción de no-leakage recursiva sobre payload.
+
+## Implementación
+- [x] Añadidos read models backend `VaultExplorerNode` y `VaultDocumentRef`.
+- [x] Añadido `VaultService.get_explorer_tree()`.
+- [x] Añadido endpoint `GET /api/v1/vault/tree`.
+- [x] `GET /api/v1/vault` mantiene el contrato legacy y añade `data.explorer` para transición.
+
+## Verify ejecutado
+- [x] `python3 -m py_compile apps/api/src/modules/vault/*.py apps/api/tests/test_vault_api.py`
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_vault_api.py -q`
+- [x] `git diff --check`
+- [ ] Revisión de diff antes de PR.
+
+## Review pendiente
+- [ ] PR abierta.
+- [ ] Handoff en PR a Chopper.
+- [ ] Invocación directa a Chopper.
+- [ ] Comentario/review de Chopper en PR.


### PR DESCRIPTION
## Qué cambia
- Añade `GET /api/v1/vault/tree` como contrato backend read-only para árbol dinámico del vault.
- Añade `data.explorer` a `GET /api/v1/vault` manteniendo el workspace legacy para no romper la UI actual antes de 121.2/121.3.
- Recorre el root backend-owned del vault con rutas relativas y exclusión de hidden files/dirs, `.git`, `.obsidian`, `.env`, symlinks, no Markdown y documentos oversized.
- Añade límites explícitos de profundidad, nodos y tamaño máximo de documento referenciado.
- Documenta la microfase en OpenSpec, Engram y docs backend.

## Por qué
Primera microfase del issue #121. Fija la frontera segura de explorador antes de implementar el reader Markdown raw y la UI de dos columnas.

## Verificación de Zoro
- `python3 -m py_compile apps/api/src/modules/vault/*.py apps/api/tests/test_vault_api.py`
- `PYTHONPATH=. pytest apps/api/tests/test_vault_api.py -q` → 9 passed
- `git diff --check`
- Smoke TestClient real de `/api/v1/vault/tree`: 118 nodes / 72 documents, `safe_root=canonical_vault`, `read_only=true`, `sanitized=true`, sin `/srv/`, `/home/`, `.env`, `stdout`, `stderr` en payload.

## Riesgo y revisión
- Superficie: backend/API + filesystem host-adjacent read-only bajo root fijo.
- Revisión solicitada: Chopper obligatoria por traversal, symlink, hidden files, oversized y no-leakage.
- Franky no solicitado: no hay cambios runtime, deploy, systemd, scripts operativos ni configuración de servicio.

## Fuera de alcance
- Reader raw Markdown: 121.2.
- Nueva UI de dos columnas: 121.3.
- Responsive/guardrails frontend/canon final: 121.4.
- Escritura o edición del vault.
