### PR TITLE
feat: add vault raw markdown reader

### DIFF
--- a/.engram/issue-121-2-vault-document-reader-closeout.md
+++ b/.engram/issue-121-2-vault-document-reader-closeout.md
@@ -1,0 +1,23 @@
+# Issue 121.2 — Backend raw Markdown reader closeout
+
+## Resultado
+Se ha materializado el reader backend raw Markdown para `/vault`: `GET /api/v1/vault/documents/{document_path:path}` lee documentos `.md` dinámicos bajo root backend-owned fijo y devuelve contenido completo en `markdown` con metadata mínima segura.
+
+## Decisión de corte
+La microfase no toca la UI. `GET /api/v1/vault` conserva el workspace/documentos legacy para no romper la experiencia actual antes de 121.3. La nueva UI debe consumir el árbol 121.1 y este reader 121.2.
+
+## Seguridad cubierta
+- Rutas relativas `.md` únicamente.
+- Revalidación server-side completa; no se confía en rutas emitidas por el árbol.
+- Rechazo de rutas absolutas, `~`, traversal, hidden files/dirs, symlinks, no Markdown, oversized y fuera de root.
+- Errores saneados sin host paths ni trazas.
+- Tests sintéticos cubren frontmatter/tablas/código preservados y rechazos principales.
+
+## Verify
+- `python3 -m py_compile apps/api/src/modules/vault/*.py apps/api/tests/test_vault_api.py`
+- `PYTHONPATH=. pytest apps/api/tests/test_vault_api.py -q`
+- `git diff --check`
+- Smoke TestClient dirigido sobre documento raw permitido y rutas maliciosas.
+
+## Continuidad
+Siguiente microfase: 121.3 debe reemplazar la UI actual de `/vault` por dos columnas, consumiendo `GET /api/v1/vault/tree` y el reader raw Markdown. Debe retirar cards/textos editoriales actuales, panel de metadata externo y TOC lateral obligatorio, y pedir review Usopp + Chopper.

--- a/apps/api/src/modules/vault/router.py
+++ b/apps/api/src/modules/vault/router.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import asdict
-
 from fastapi import APIRouter, Depends
 
 from ...shared.contracts import resource_response
@@ -42,6 +40,6 @@ def get_vault_document(document_path: str, service: VaultService = Depends(get_v
     return resource_response(
         resource='vault.document',
         status='ready',
-        data=asdict(document),
-        meta={'path': document.meta.path, 'markdown_only': True, 'read_only': True, 'allowlisted': True},
+        data=document,
+        meta={'path': document['relative_path'], 'markdown_only': True, 'read_only': True, 'sanitized': True},
     )

--- a/apps/api/src/modules/vault/service.py
+++ b/apps/api/src/modules/vault/service.py
@@ -168,12 +168,48 @@ class VaultService:
             raise self._reject(status.HTTP_404_NOT_FOUND, 'not_found', 'Documento no disponible en la allowlist del vault.')
         return self._read_document(document)
 
-    def get_document_by_path(self, requested_path: str) -> VaultDocument:
+    def get_document_by_path(self, requested_path: str) -> dict:
+        file_path, safe_path = self._resolve_reader_path(requested_path)
+        try:
+            text = file_path.read_text(encoding='utf-8')
+            stat = file_path.stat()
+        except UnicodeDecodeError:
+            raise self._reject(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, 'unsupported_media_type', 'Documento Markdown no legible como UTF-8.')
+        except OSError:
+            raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'source_unavailable', 'Documento de vault no disponible.')
+        return {
+            'relative_path': safe_path,
+            'name': file_path.name,
+            'markdown': text,
+            'updated_at': datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+            'size_bytes': stat.st_size,
+            'read_only': True,
+        }
+
+    def _resolve_reader_path(self, requested_path: str) -> tuple[Path, str]:
         safe_path = self._normalize_requested_path(requested_path)
-        document = self._paths.get(safe_path)
-        if document is None:
-            raise self._reject(status.HTTP_404_NOT_FOUND, 'not_found', 'Documento no disponible en la allowlist del vault.')
-        return self._read_document(document)
+        raw_candidate = self._root / safe_path
+        if self._is_hidden(raw_candidate):
+            raise self._reject(status.HTTP_404_NOT_FOUND, 'not_found', 'Documento no disponible en el vault.')
+        try:
+            if raw_candidate.is_symlink() or self._has_symlink_parent(raw_candidate):
+                raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'source_unavailable', 'Documento de vault no disponible.')
+            candidate = raw_candidate.resolve()
+        except HTTPException:
+            raise
+        except OSError:
+            raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'source_unavailable', 'Documento de vault no disponible.')
+        if self._root != candidate and self._root not in candidate.parents:
+            raise self._reject(status.HTTP_400_BAD_REQUEST, 'validation_error', 'Ruta de vault no permitida.')
+        if not candidate.exists() or not candidate.is_file():
+            raise self._reject(status.HTTP_404_NOT_FOUND, 'not_found', 'Documento no disponible en el vault.')
+        try:
+            size_bytes = candidate.stat().st_size
+        except OSError:
+            raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'source_unavailable', 'Documento de vault no disponible.')
+        if size_bytes > self._max_document_bytes:
+            raise self._reject(status.HTTP_413_CONTENT_TOO_LARGE, 'payload_too_large', 'Documento de vault demasiado grande para lectura.')
+        return candidate, safe_path
 
     def _iter_safe_children(self, directory: Path) -> list[Path]:
         if directory.is_symlink() or not directory.exists() or not directory.is_dir():
@@ -313,8 +349,10 @@ class VaultService:
         if requested_path.startswith('/') or requested_path.startswith('~'):
             raise self._reject(status.HTTP_400_BAD_REQUEST, 'validation_error', 'Ruta de vault no permitida.')
         path = Path(requested_path)
-        if path.suffix != '.md':
-            raise self._reject(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, 'unsupported_media_type', 'Solo se permiten documentos Markdown allowlisted.')
+        if path.is_absolute():
+            raise self._reject(status.HTTP_400_BAD_REQUEST, 'validation_error', 'Ruta de vault no permitida.')
+        if path.suffix.lower() != '.md':
+            raise self._reject(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, 'unsupported_media_type', 'Solo se permiten documentos Markdown.')
         if any(part in {'..', ''} for part in path.parts):
             raise self._reject(status.HTTP_400_BAD_REQUEST, 'validation_error', 'Ruta de vault no permitida.')
         return path.as_posix()

--- a/apps/api/tests/test_vault_api.py
+++ b/apps/api/tests/test_vault_api.py
@@ -111,28 +111,52 @@ def test_vault_explorer_tree_enforces_depth_and_node_limits(tmp_path):
     assert capped_tree['limits']['nodes_truncated'] is True
 
 
-def test_vault_document_reads_markdown_only_allowlisted_path():
-    response = client.get('/api/v1/vault/documents/03-Projects/Project Summary - Mugiwara Control Panel.md')
+def test_vault_document_reads_raw_markdown_from_safe_relative_path(tmp_path):
+    docs = tmp_path / 'docs'
+    docs.mkdir()
+    document = docs / 'note.md'
+    markdown = '---\ntitle: Note\n---\n\n# Heading\n\n| A | B |\n| - | - |\n| 1 | 2 |\n\n```text\ncode block\n```\n'
+    document.write_text(markdown, encoding='utf-8')
+    service = VaultService(root=tmp_path)
+    app.dependency_overrides[get_vault_service] = lambda: service
+    try:
+        response = client.get('/api/v1/vault/documents/docs/note.md')
+    finally:
+        app.dependency_overrides.clear()
 
     assert response.status_code == 200
     payload = response.json()
     assert payload['resource'] == 'vault.document'
-    assert payload['meta']['markdown_only'] is True
-    assert payload['meta']['allowlisted'] is True
-    assert payload['data']['id'] == 'mugiwara-control-panel-summary'
-    assert payload['data']['meta']['path'] == '03-Projects/Project Summary - Mugiwara Control Panel.md'
-    assert payload['data']['sections']
-    _assert_no_host_paths(payload)
+    assert payload['meta'] == {
+        'path': 'docs/note.md',
+        'markdown_only': True,
+        'read_only': True,
+        'sanitized': True,
+    }
+    assert payload['data']['relative_path'] == 'docs/note.md'
+    assert payload['data']['name'] == 'note.md'
+    assert payload['data']['markdown'] == markdown
+    assert payload['data']['read_only'] is True
+    assert payload['data']['size_bytes'] == len(markdown.encode('utf-8'))
+    assert payload['data']['updated_at']
+    assert 'sections' not in payload['data']
+    assert 'canon_callout' not in payload['data']
+    _assert_no_host_paths({k: v for k, v in payload.items() if k != 'data'})
 
 
 def test_vault_rejects_path_traversal_without_host_path_leak():
-    response = client.get('/api/v1/vault/documents/00-System/%2e%2e/Policy - Memory governance.md')
+    for url in (
+        '/api/v1/vault/documents/00-System/%2e%2e/Policy - Memory governance.md',
+        '/api/v1/vault/documents/00-System/%2E%2E/Policy - Memory governance.md',
+        '/api/v1/vault/documents/00-System/%252e%252e/Policy - Memory governance.md',
+    ):
+        response = client.get(url)
 
-    assert response.status_code == 400
-    detail = response.json()['detail']
-    assert detail['code'] == 'validation_error'
-    assert '/srv/' not in detail['message']
-    assert '/home/' not in detail['message']
+        assert response.status_code != 200
+        detail = response.json()['detail']
+        assert detail['code'] in {'validation_error', 'not_found'}
+        assert '/srv/' not in detail['message']
+        assert '/home/' not in detail['message']
 
 
 def test_vault_rejects_unknown_markdown_document():
@@ -142,6 +166,43 @@ def test_vault_rejects_unknown_markdown_document():
     detail = response.json()['detail']
     assert detail['code'] == 'not_found'
     assert '/srv/' not in detail['message']
+
+
+def test_vault_document_reader_rejects_hidden_symlink_oversized_and_absolute_paths(tmp_path):
+    docs = tmp_path / 'docs'
+    docs.mkdir()
+    (docs / 'allowed.md').write_text('# Allowed\n', encoding='utf-8')
+    (docs / '.hidden.md').write_text('# Hidden\n', encoding='utf-8')
+    (tmp_path / '.obsidian').mkdir()
+    (tmp_path / '.obsidian' / 'private.md').write_text('# Private\n', encoding='utf-8')
+    (docs / 'big.md').write_text('x' * 64, encoding='utf-8')
+    (docs / 'note.txt').write_text('text\n', encoding='utf-8')
+    outside = tmp_path / 'outside'
+    outside.mkdir()
+    (outside / 'outside.md').write_text('# Outside\n', encoding='utf-8')
+    (docs / 'link-parent').symlink_to(outside)
+    service = VaultService(root=tmp_path, max_document_bytes=32)
+    app.dependency_overrides[get_vault_service] = lambda: service
+    try:
+        cases = {
+            '/api/v1/vault/documents/docs/.hidden.md': (404, 'not_found'),
+            '/api/v1/vault/documents/.obsidian/private.md': (404, 'not_found'),
+            '/api/v1/vault/documents/docs/link-parent/outside.md': (503, 'source_unavailable'),
+            '/api/v1/vault/documents/docs/big.md': (413, 'payload_too_large'),
+            '/api/v1/vault/documents/docs/note.txt': (415, 'unsupported_media_type'),
+            '/api/v1/vault/documents/~/.ssh/config.md': (400, 'validation_error'),
+            '/api/v1/vault/documents//tmp/secret.md': (400, 'validation_error'),
+        }
+        for url, (expected_status, expected_code) in cases.items():
+            response = client.get(url)
+            assert response.status_code == expected_status, url
+            detail = response.json()['detail']
+            assert detail['code'] == expected_code
+            assert '/srv/' not in detail['message']
+            assert '/home/' not in detail['message']
+            assert str(tmp_path) not in detail['message']
+    finally:
+        app.dependency_overrides.clear()
 
 
 def test_vault_rejects_unsupported_extension():

--- a/docs/api-modules.md
+++ b/docs/api-modules.md
@@ -40,9 +40,9 @@
 ### `vault`
 - exponer `GET /api/v1/vault` como workspace documental read-only allowlisted; desde issue #121.1 añade `data.explorer` como árbol dinámico seguro para transición hacia explorador + lector Markdown
 - exponer `GET /api/v1/vault/tree` como contrato read-only de explorador del vault bajo root backend-owned fijo, serializando solo rutas relativas y metadata mínima segura
-- exponer `GET /api/v1/vault/documents/{document_path:path}` para lectura de documentos markdown permitidos
-- para el árbol dinámico, excluir hidden files/dirs (`.git`, `.obsidian`, `.env`, dotfiles), symlinks, no Markdown, documentos oversized y entradas fuera del root; aplicar límites de profundidad, nodos y tamaño de documento
-- normalizar paths y rechazar traversal, paths absolutos, symlinks, extensiones no soportadas y documentos fuera de allowlist
+- exponer `GET /api/v1/vault/documents/{document_path:path}` como reader raw Markdown dinámico bajo root backend-owned fijo; devuelve `relative_path`, `name`, `markdown`, `updated_at`, `size_bytes` y `read_only`, preservando frontmatter/tablas/código dentro del contenido
+- para el árbol y el reader dinámico, excluir hidden files/dirs (`.git`, `.obsidian`, `.env`, dotfiles), symlinks, no Markdown, documentos oversized y entradas fuera del root; aplicar límites de profundidad/nodos/tamaño cuando corresponda
+- normalizar paths y rechazar traversal, paths absolutos, `~`, symlinks, extensiones no soportadas y documentos fuera del root permitido
 - integrar `/vault` desde frontend mediante adapter server-only con fallback saneado visible
 - sin escritura en MVP
 

--- a/docs/backend-boundary.md
+++ b/docs/backend-boundary.md
@@ -30,7 +30,7 @@ Todo recurso o acción cae en uno de estos estados:
 ## Allowlists de rutas
 ### Lectura permitida
 - `/srv/crew-core/skills-source/**`
-- `/srv/crew-core/vault/**`, solo mediante módulos backend read-only con root fijo, rutas relativas saneadas y exclusión de hidden/symlinks/oversized cuando se navega como árbol
+- `/srv/crew-core/vault/**`, solo mediante módulos backend read-only con root fijo, rutas relativas saneadas y exclusión de hidden/symlinks/oversized tanto al navegar como al leer Markdown raw
 - `/home/agentops/.hermes/profiles/**/config.yaml`
 - `/home/agentops/.hermes/profiles/**/memories/*.md`
 - fuentes operativas resumidas/saneadas de healthcheck y cron que se definan como input del módulo `healthcheck`

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -110,6 +110,21 @@ Phase 18.0 reconciles those explicit follow-ups into a dedicated Healthcheck pro
 
 Phase 18.3 adds `scripts/write-backup-health-status.py` and `npm run write:backup-health-status` as the producer for `/srv/crew-core/runtime/healthcheck/backup-health-status.json`; there is no unit/timer in Phase 18.3. The producer does not run backups, observes only the fixed local backup artifact directory, validates the latest checksum with `sha256sum -c`, and serializes only `status`, `result`, `updated_at`, optional `last_success_at`, `checksum_present` and `retention_count`. It never serializes archive names, paths, sizes, hashes, Drive targets, stdout/stderr, logs or raw output.
 
+### `vault.document`
+Campos esperados:
+- `relative_path`
+- `name`
+- `markdown`
+- `updated_at`
+- `size_bytes`
+- `read_only`
+
+Uso:
+- leer documentos Markdown del vault canónico desde backend, nunca desde navegador/filesystem directo
+- preservar frontmatter, headings, tablas, listas y bloques de código dentro de `markdown` para que la UI 121.3 los renderice sin panel externo de metadata
+- aceptar solo rutas relativas `.md` bajo root backend-owned; rechazar absolutas, `~`, traversal, hidden files/dirs, symlinks, no-md, oversized y fuera de root
+- devolver errores saneados sin paths host, tracebacks ni excepción cruda
+
 ### `usage.current`
 Campos esperados:
 - `current_snapshot` con `captured_at`, `source_label` y `freshness`

--- a/openspec/issue-121-2-vault-document-reader-verify-checklist.md
+++ b/openspec/issue-121-2-vault-document-reader-verify-checklist.md
@@ -1,0 +1,25 @@
+# Issue 121.2 — Verify checklist
+
+## TDD
+- [x] Test rojo de documento Markdown permitido con frontmatter, tabla y bloque de código preservados en `markdown`.
+- [x] Test rojo de rechazo de hidden files/dirs, `.obsidian`, symlink, oversized, no-md, `~` y rutas absolutas.
+- [x] Test existente de traversal codificado sigue pasando con error saneado.
+
+## Implementación
+- [x] `VaultService.get_document_by_path()` devuelve raw Markdown dinámico bajo root fijo.
+- [x] `VaultService._resolve_reader_path()` revalida server-side ruta, root containment, hidden, symlink, existencia, tipo y tamaño.
+- [x] `GET /api/v1/vault/documents/{document_path:path}` devuelve `data.markdown` y metadata mínima segura.
+- [x] Workspace legacy se conserva para no romper UI antes de 121.3.
+
+## Verify ejecutado
+- [x] `python3 -m py_compile apps/api/src/modules/vault/*.py apps/api/tests/test_vault_api.py`
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_vault_api.py -q`
+- [x] `git diff --check`
+- [x] Smoke TestClient dirigido.
+- [ ] Revisión de diff antes de PR.
+
+## Review pendiente
+- [ ] PR abierta.
+- [ ] Handoff en PR a Chopper.
+- [ ] Invocación directa a Chopper.
+- [ ] Comentario/review de Chopper en PR.

--- a/openspec/issue-121-2-vault-document-reader.md
+++ b/openspec/issue-121-2-vault-document-reader.md
@@ -1,0 +1,44 @@
+# Issue 121.2 — Backend raw Markdown document reader
+
+## Objetivo
+Cerrar la segunda microfase del issue #121 añadiendo un reader backend read-only que entregue el Markdown completo de documentos permitidos del vault, sin editorializarlo en secciones ni separar frontmatter en metadata externa.
+
+## Alcance implementado
+- `GET /api/v1/vault/documents/{document_path:path}` pasa de allowlist estática legacy a lectura dinámica bajo el root backend-owned del vault.
+- El endpoint acepta solo rutas relativas `.md` y devuelve:
+  - `relative_path`
+  - `name`
+  - `markdown`
+  - `updated_at`
+  - `size_bytes`
+  - `read_only`
+- El contenido se preserva completo para render futuro: frontmatter, headings, tablas, listas y bloques de código permanecen dentro de `markdown`.
+- El reader revalida la ruta en servidor y no confía en que venga del árbol 121.1.
+
+## Seguridad / frontera
+- Root fijo backend-owned; el cliente nunca puede elegir root.
+- Rechaza rutas absolutas y `~`.
+- Rechaza traversal y traversal codificado ya decodificado por la ruta HTTP.
+- Rechaza hidden files/dirs (`.git`, `.obsidian`, `.env`, dotfiles).
+- Rechaza symlinks y padres symlink.
+- Rechaza no Markdown.
+- Rechaza documentos oversized con `payload_too_large`.
+- Errores saneados sin ruta host, traceback ni excepción cruda.
+
+## Decisión de compatibilidad
+`GET /api/v1/vault` conserva por ahora el workspace legacy con documentos parseados/editorializados para no romper la UI actual antes de 121.3. La sustitución completa de experiencia visual queda para la microfase frontend.
+
+## Fuera de alcance
+- Render Markdown frontend.
+- Nuevo layout de dos columnas.
+- Guardrail web `verify:vault-server-only` final.
+- Escritura/edición/creación/borrado/renombrado en vault.
+- Búsqueda full-text, TOC lateral o panel externo de metadata.
+
+## Verify esperado
+- `python3 -m py_compile apps/api/src/modules/vault/*.py apps/api/tests/test_vault_api.py`
+- `PYTHONPATH=. pytest apps/api/tests/test_vault_api.py -q`
+- `git diff --check`
+
+## Review
+Chopper obligatorio por filesystem host-adjacent, lectura raw Markdown, traversal/symlink/hidden/oversized/no-leakage. Franky no aplica salvo cambios runtime/deploy/config, que esta microfase no introduce.


### PR DESCRIPTION
## Qué cambia
- Cambia `GET /api/v1/vault/documents/{document_path:path}` a reader raw Markdown dinámico bajo root backend-owned fijo.
- Devuelve `relative_path`, `name`, `markdown`, `updated_at`, `size_bytes` y `read_only`.
- Preserva frontmatter, headings, tablas, listas y bloques de código dentro de `markdown`.
- Revalida server-side la ruta completa: no confía en que venga del árbol 121.1.
- Rechaza rutas absolutas, `~`, traversal/encoded traversal, hidden files/dirs, symlinks, no Markdown, oversized y fuera de root.
- Mantiene `GET /api/v1/vault` legacy para no romper UI antes de 121.3.
- Actualiza OpenSpec, Engram y docs backend/read-models.

## Por qué
Segunda microfase del issue #121. Tras cerrar PR #123 / 121.1 con el árbol seguro, toca entregar el contenido Markdown completo para que 121.3 pueda construir el lector renderizado sin panel externo de metadata ni secciones editorializadas.

## Verificación de Zoro
- `python3 -m py_compile apps/api/src/modules/vault/*.py apps/api/tests/test_vault_api.py`
- `PYTHONPATH=. pytest apps/api/tests/test_vault_api.py -q` → 10 passed
- Smoke TestClient dirigido: documento raw permitido preserva frontmatter/código y rutas maliciosas (`%2e%2e`, `~`) devuelven errores saneados.
- `git diff --check`

## Riesgo y revisión
- Superficie: backend/API + filesystem host-adjacent read-only + contenido Markdown raw.
- Revisión solicitada: Chopper obligatoria por traversal, symlink, hidden files, oversized, raw Markdown y no-leakage de errores.
- Franky no solicitado: no hay cambios runtime, deploy, systemd, scripts operativos ni configuración de servicio.

## Fuera de alcance
- Nueva UI de dos columnas: 121.3.
- Responsive/guardrails frontend/canon final: 121.4.
- Escritura o edición del vault.
- Sanitizer/render Markdown frontend/XSS: 121.3 con Chopper + Usopp.
