### PR TITLE
feat: add vault explorer markdown frontend

### DIFF
--- a/.engram/issue-121-3-vault-frontend-explorer-closeout.md
+++ b/.engram/issue-121-3-vault-frontend-explorer-closeout.md
@@ -1,0 +1,23 @@
+# Issue 121.3 closeout — Vault frontend explorer + Markdown reader
+
+## Resultado
+
+121.3 sustituye `/vault` por una superficie de dos paneles: explorador de archivos y lector Markdown. La UI legacy basada en cards/editorialización queda retirada.
+
+## Decisiones técnicas
+
+- La página sigue siendo `force-dynamic` y server-side para cargar datos del backend con `MUGIWARA_CONTROL_PANEL_API_URL` privada.
+- La selección de documento via query `path` solo se acepta si el path existe en `tree.documents`; si no, se canonicaliza al primer documento seguro.
+- El cliente no conoce backend URL ni env; solo recibe árbol/documento ya saneados.
+- Markdown se renderiza con parser conservador propio y React nodes, no HTML raw.
+- Frontmatter se conserva visible como bloque de código dentro del documento, no como ficha externa.
+
+## Continuidad
+
+121.4 debe cerrar responsive/hardening/canon final:
+
+- afinar mobile/tablet si Usopp detecta problemas;
+- ampliar docs vivas de frontend/backend boundary si procede;
+- actualizar Project Summary del vault;
+- ejecutar smoke Tailscale/post-merge visible;
+- cerrar #121 solo tras 121.4.

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -83,7 +83,241 @@ button {
 }
 
 .layout-grid--vault {
-  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr) minmax(260px, 320px);
+  grid-template-columns: minmax(260px, 340px) minmax(0, 1fr);
+}
+
+.vault-browser-shell {
+  align-items: stretch;
+}
+
+.vault-explorer-panel,
+.vault-reader-panel {
+  min-width: 0;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.045);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.16);
+}
+
+.vault-explorer-panel {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  max-height: min(74vh, 760px);
+  overflow: hidden;
+}
+
+.vault-reader-panel {
+  display: grid;
+  gap: 16px;
+  align-content: start;
+  padding: 18px;
+}
+
+.vault-panel-header,
+.vault-reader-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
+.vault-panel-header {
+  padding: 16px 16px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.vault-panel-header h2,
+.vault-reader-header h2 {
+  margin: 3px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.vault-reader-header p {
+  margin: 7px 0 0;
+  color: #9aa7bd;
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.vault-panel-eyebrow {
+  color: #e8b56a;
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.vault-reader-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.vault-reader-meta span {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  background: rgba(90, 157, 219, 0.1);
+  color: #dce6f6;
+  font-size: 12px;
+  font-weight: 800;
+  padding: 6px 9px;
+}
+
+.vault-explorer-tree {
+  display: grid;
+  align-content: start;
+  gap: 2px;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 10px;
+  scrollbar-width: thin;
+}
+
+.vault-tree-row {
+  display: grid;
+  grid-template-columns: 16px 20px minmax(0, 1fr);
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-width: 0;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: #dce6f6;
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1.35;
+  padding-bottom: 8px;
+  padding-right: 8px;
+  padding-top: 8px;
+  text-align: left;
+}
+
+.vault-tree-row:hover,
+.vault-tree-row:focus-visible {
+  border-color: rgba(90, 157, 219, 0.45);
+  background: rgba(90, 157, 219, 0.12);
+  outline: none;
+}
+
+.vault-tree-row--directory {
+  color: #e8b56a;
+  font-weight: 850;
+}
+
+.vault-tree-row--document[data-active='true'] {
+  border-color: rgba(90, 157, 219, 0.85);
+  background: rgba(90, 157, 219, 0.22);
+  color: #ffffff;
+  font-weight: 850;
+}
+
+.vault-tree-row__name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vault-markdown-reader {
+  max-width: 92ch;
+  width: 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: #dce6f6;
+  line-height: 1.75;
+}
+
+.vault-markdown-reader h1,
+.vault-markdown-reader h2,
+.vault-markdown-reader h3,
+.vault-markdown-reader h4 {
+  color: #ffffff;
+  line-height: 1.25;
+  margin: 24px 0 10px;
+  overflow-wrap: anywhere;
+}
+
+.vault-markdown-reader h1:first-child,
+.vault-markdown-reader h2:first-child,
+.vault-markdown-reader h3:first-child,
+.vault-markdown-reader h4:first-child {
+  margin-top: 0;
+}
+
+.vault-markdown-reader p,
+.vault-markdown-reader ul,
+.vault-markdown-reader ol,
+.vault-markdown-reader blockquote {
+  margin: 0 0 14px;
+}
+
+.vault-markdown-reader li {
+  margin: 4px 0;
+}
+
+.vault-markdown-reader blockquote {
+  border-left: 3px solid #e8b56a;
+  border-radius: 12px;
+  background: rgba(232, 181, 106, 0.08);
+  color: #f3d19d;
+  padding: 12px 14px;
+}
+
+.vault-markdown-reader hr {
+  border: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  margin: 20px 0;
+}
+
+.vault-markdown-code,
+.vault-markdown-frontmatter {
+  max-width: 100%;
+  overflow-x: auto;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 14px;
+  background: rgba(11, 18, 32, 0.74);
+  color: #dce6f6;
+  padding: 14px;
+  white-space: pre-wrap;
+}
+
+.vault-markdown-frontmatter {
+  color: #e8b56a;
+}
+
+.vault-markdown-inline-code {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.07);
+  padding: 1px 5px;
+}
+
+.vault-markdown-table-wrap {
+  max-width: 100%;
+  overflow-x: auto;
+  margin: 0 0 16px;
+}
+
+.vault-markdown-table-wrap table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 520px;
+}
+
+.vault-markdown-table-wrap th,
+.vault-markdown-table-wrap td {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 9px 10px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.vault-markdown-table-wrap th {
+  background: rgba(90, 157, 219, 0.14);
+  color: #ffffff;
 }
 
 .page-header {
@@ -488,6 +722,19 @@ button {
   .layout-grid--content-aside,
   .layout-grid--vault {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .vault-explorer-panel {
+    max-height: 42vh;
+  }
+
+  .vault-reader-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .vault-reader-meta {
+    justify-content: flex-start;
   }
 
   .page-header {

--- a/apps/web/src/app/vault/VaultClient.tsx
+++ b/apps/web/src/app/vault/VaultClient.tsx
@@ -48,15 +48,6 @@ function formatBytes(value?: number | null) {
   return `${(value / (1024 * 1024)).toFixed(1)} MB`
 }
 
-function isUnsafeText(value: string) {
-  const lower = value.toLowerCase()
-  return lower.includes('/srv/') || lower.includes('/home/') || lower.includes('mugiwara_control_panel_api_url') || lower.includes('next_public')
-}
-
-function safeText(value: string) {
-  return isUnsafeText(value) ? 'Contenido saneado' : value
-}
-
 function getSafeHref(href: string): string | null {
   const trimmed = href.trim()
   if (!trimmed || /[\u0000-\u001f]/.test(trimmed)) return null
@@ -80,13 +71,13 @@ function renderInlineMarkdown(text: string): ReactNode[] {
   let match: RegExpExecArray | null
 
   while ((match = inlinePattern.exec(text)) !== null) {
-    if (match.index > cursor) nodes.push(safeText(text.slice(cursor, match.index)))
+    if (match.index > cursor) nodes.push(text.slice(cursor, match.index))
 
     const token = match[0]
     const linkMatch = /^\[([^\]]+)\]\(([^\s)]+)\)$/.exec(token)
     if (linkMatch) {
       const safeHref = getSafeHref(linkMatch[2])
-      const label = safeText(linkMatch[1])
+      const label = linkMatch[1]
       nodes.push(
         safeHref ? (
           <a key={`${match.index}-link`} href={safeHref} rel="noreferrer noopener" style={{ color: appTheme.colors.brandSky500, fontWeight: 800 }} target={safeHref.startsWith('http') ? '_blank' : undefined}>
@@ -97,15 +88,15 @@ function renderInlineMarkdown(text: string): ReactNode[] {
         ),
       )
     } else if (token.startsWith('**')) {
-      nodes.push(<strong key={`${match.index}-strong`}>{safeText(token.slice(2, -2))}</strong>)
+      nodes.push(<strong key={`${match.index}-strong`}>{token.slice(2, -2)}</strong>)
     } else if (token.startsWith('`')) {
-      nodes.push(<code key={`${match.index}-code`} className="vault-markdown-inline-code">{safeText(token.slice(1, -1))}</code>)
+      nodes.push(<code key={`${match.index}-code`} className="vault-markdown-inline-code">{token.slice(1, -1)}</code>)
     }
 
     cursor = match.index + token.length
   }
 
-  if (cursor < text.length) nodes.push(safeText(text.slice(cursor)))
+  if (cursor < text.length) nodes.push(text.slice(cursor))
   return nodes
 }
 
@@ -248,7 +239,7 @@ function MarkdownReader({ markdown }: { markdown: string }) {
     <article className="vault-markdown-reader" aria-label="Documento Markdown renderizado de forma saneada">
       {blocks.map((block, index) => {
         if (block.type === 'frontmatter') {
-          return <pre key={index} className="vault-markdown-code vault-markdown-frontmatter"><code>{safeText(block.text)}</code></pre>
+          return <pre key={index} className="vault-markdown-code vault-markdown-frontmatter"><code>{block.text}</code></pre>
         }
         if (block.type === 'heading') {
           const Heading = (`h${block.level}` as 'h1' | 'h2' | 'h3' | 'h4')
@@ -265,7 +256,7 @@ function MarkdownReader({ markdown }: { markdown: string }) {
           return <List key={index}>{block.items.map((item, itemIndex) => <li key={`${index}-${itemIndex}`}>{renderInlineMarkdown(item)}</li>)}</List>
         }
         if (block.type === 'code') {
-          return <pre key={index} className="vault-markdown-code"><code>{safeText(block.text)}</code></pre>
+          return <pre key={index} className="vault-markdown-code"><code>{block.text}</code></pre>
         }
         if (block.type === 'rule') {
           return <hr key={index} />

--- a/apps/web/src/app/vault/VaultClient.tsx
+++ b/apps/web/src/app/vault/VaultClient.tsx
@@ -1,336 +1,416 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useMemo, useState, type ReactNode } from 'react'
 
-import type { VaultWorkspace } from '@/modules/vault/view-models/vault-workspace.fixture'
+import type { VaultExplorerNode, VaultExplorerTree, VaultMarkdownDocument } from '@/modules/vault/view-models/vault-explorer.fixture'
+import { appTheme } from '@/shared/theme/tokens'
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
-import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
 import { StatePanel } from '@/shared/ui/state/StatePanel'
 import { SourceStatePills } from '@/shared/ui/status/SourceStatePills'
 import { StatusBadge } from '@/shared/ui/status/StatusBadge'
-import { appTheme } from '@/shared/theme/tokens'
 
-function getVaultFreshnessStatus(state: 'fresh' | 'stale') {
-  return state === 'stale' ? 'stale' : 'operativo'
-}
-
-function formatTimestamp(value: string) {
-  const date = new Date(value)
-
-  if (Number.isNaN(date.getTime())) {
-    return value
-  }
-
-  return new Intl.DateTimeFormat('es-ES', {
-    dateStyle: 'short',
-    timeStyle: 'short',
-  }).format(date)
-}
+type MarkdownBlock =
+  | { type: 'frontmatter'; text: string }
+  | { type: 'heading'; level: 1 | 2 | 3 | 4; text: string }
+  | { type: 'paragraph'; text: string }
+  | { type: 'blockquote'; text: string }
+  | { type: 'list'; ordered: boolean; items: string[] }
+  | { type: 'code'; text: string }
+  | { type: 'rule' }
+  | { type: 'table'; headers: string[]; rows: string[][] }
 
 type VaultClientProps = {
-  initialWorkspace: VaultWorkspace
-  apiState: 'ready' | 'fallback'
-  apiErrorCode?: string
+  tree: VaultExplorerTree
+  document: VaultMarkdownDocument | null
+  selectedPath: string | null
+  notice: {
+    status: 'ready' | 'fallback'
+    code?: string
+  }
 }
 
-function getVaultApiNotice(apiState: VaultClientProps['apiState'], apiErrorCode?: string) {
-  if (apiState === 'ready') {
+function vaultDocumentHref(relativePath: string) {
+  return `/vault?path=${encodeURIComponent(relativePath)}`
+}
+
+function formatTimestamp(value?: string | null) {
+  if (!value) return 'Fecha no disponible'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return 'Fecha no disponible'
+  return new Intl.DateTimeFormat('es-ES', { dateStyle: 'medium', timeStyle: 'short' }).format(date)
+}
+
+function formatBytes(value?: number | null) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 'Tamaño no disponible'
+  if (value < 1024) return `${value} B`
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function isUnsafeText(value: string) {
+  const lower = value.toLowerCase()
+  return lower.includes('/srv/') || lower.includes('/home/') || lower.includes('mugiwara_control_panel_api_url') || lower.includes('next_public')
+}
+
+function safeText(value: string) {
+  return isUnsafeText(value) ? 'Contenido saneado' : value
+}
+
+function getSafeHref(href: string): string | null {
+  const trimmed = href.trim()
+  if (!trimmed || /[\u0000-\u001f]/.test(trimmed)) return null
+  if (trimmed.startsWith('/') && !trimmed.startsWith('//')) return trimmed
+  if (trimmed.startsWith('#')) return trimmed
+
+  try {
+    const parsed = new URL(trimmed)
+    if (parsed.protocol === 'https:' || parsed.protocol === 'http:') return trimmed
+  } catch {
     return null
   }
 
-  const isNotConfigured = apiErrorCode === 'not_configured'
+  return null
+}
 
+function renderInlineMarkdown(text: string): ReactNode[] {
+  const nodes: ReactNode[] = []
+  const inlinePattern = /(\[[^\]]+\]\([^\s)]+\)|\*\*[^*]+\*\*|`[^`]+`)/g
+  let cursor = 0
+  let match: RegExpExecArray | null
+
+  while ((match = inlinePattern.exec(text)) !== null) {
+    if (match.index > cursor) nodes.push(safeText(text.slice(cursor, match.index)))
+
+    const token = match[0]
+    const linkMatch = /^\[([^\]]+)\]\(([^\s)]+)\)$/.exec(token)
+    if (linkMatch) {
+      const safeHref = getSafeHref(linkMatch[2])
+      const label = safeText(linkMatch[1])
+      nodes.push(
+        safeHref ? (
+          <a key={`${match.index}-link`} href={safeHref} rel="noreferrer noopener" style={{ color: appTheme.colors.brandSky500, fontWeight: 800 }} target={safeHref.startsWith('http') ? '_blank' : undefined}>
+            {label}
+          </a>
+        ) : (
+          label
+        ),
+      )
+    } else if (token.startsWith('**')) {
+      nodes.push(<strong key={`${match.index}-strong`}>{safeText(token.slice(2, -2))}</strong>)
+    } else if (token.startsWith('`')) {
+      nodes.push(<code key={`${match.index}-code`} className="vault-markdown-inline-code">{safeText(token.slice(1, -1))}</code>)
+    }
+
+    cursor = match.index + token.length
+  }
+
+  if (cursor < text.length) nodes.push(safeText(text.slice(cursor)))
+  return nodes
+}
+
+function parseTable(lines: string[], start: number) {
+  if (start + 1 >= lines.length) return null
+  const headerLine = lines[start].trim()
+  const separatorLine = lines[start + 1].trim()
+  if (!headerLine.includes('|') || !/^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?$/.test(separatorLine)) return null
+
+  const splitRow = (line: string) => line.replace(/^\|/, '').replace(/\|$/, '').split('|').map((cell) => cell.trim())
+  const headers = splitRow(headerLine)
+  const rows: string[][] = []
+  let index = start + 2
+  while (index < lines.length && lines[index].includes('|') && lines[index].trim() !== '') {
+    rows.push(splitRow(lines[index]))
+    index += 1
+  }
+  return { block: { type: 'table' as const, headers, rows }, nextIndex: index }
+}
+
+function parseConservativeMarkdown(markdown: string): MarkdownBlock[] {
+  const blocks: MarkdownBlock[] = []
+  const lines = markdown.replace(/\r\n/g, '\n').split('\n')
+  let paragraph: string[] = []
+  let listItems: string[] = []
+  let listOrdered = false
+  let codeFence: string[] | null = null
+  let index = 0
+
+  const flushParagraph = () => {
+    if (paragraph.length > 0) {
+      blocks.push({ type: 'paragraph', text: paragraph.join(' ') })
+      paragraph = []
+    }
+  }
+  const flushList = () => {
+    if (listItems.length > 0) {
+      blocks.push({ type: 'list', ordered: listOrdered, items: listItems })
+      listItems = []
+      listOrdered = false
+    }
+  }
+
+  if (lines[0]?.trim() === '---') {
+    const closing = lines.slice(1).findIndex((line) => line.trim() === '---')
+    if (closing >= 0) {
+      blocks.push({ type: 'frontmatter', text: lines.slice(0, closing + 2).join('\n') })
+      index = closing + 2
+    }
+  }
+
+  for (; index < lines.length; index += 1) {
+    const rawLine = lines[index]
+    const line = rawLine.trimEnd()
+
+    if (line.trim().startsWith('```')) {
+      flushParagraph()
+      flushList()
+      if (codeFence) {
+        blocks.push({ type: 'code', text: codeFence.join('\n') })
+        codeFence = null
+      } else {
+        codeFence = []
+      }
+      continue
+    }
+
+    if (codeFence) {
+      codeFence.push(rawLine)
+      continue
+    }
+
+    if (line.trim() === '') {
+      flushParagraph()
+      flushList()
+      continue
+    }
+
+    const table = parseTable(lines, index)
+    if (table) {
+      flushParagraph()
+      flushList()
+      blocks.push(table.block)
+      index = table.nextIndex - 1
+      continue
+    }
+
+    const headingMatch = /^(#{1,4})\s+(.+)$/.exec(line)
+    if (headingMatch) {
+      flushParagraph()
+      flushList()
+      blocks.push({ type: 'heading', level: headingMatch[1].length as 1 | 2 | 3 | 4, text: headingMatch[2] })
+      continue
+    }
+
+    if (/^[-*_]{3,}$/.test(line.trim())) {
+      flushParagraph()
+      flushList()
+      blocks.push({ type: 'rule' })
+      continue
+    }
+
+    const quoteMatch = /^>\s?(.+)$/.exec(line)
+    if (quoteMatch) {
+      flushParagraph()
+      flushList()
+      blocks.push({ type: 'blockquote', text: quoteMatch[1] })
+      continue
+    }
+
+    const unorderedMatch = /^[-*+]\s+(.+)$/.exec(line)
+    const orderedMatch = /^\d+[.)]\s+(.+)$/.exec(line)
+    if (unorderedMatch || orderedMatch) {
+      flushParagraph()
+      const ordered = Boolean(orderedMatch)
+      if (listItems.length > 0 && listOrdered !== ordered) flushList()
+      listOrdered = ordered
+      listItems.push((unorderedMatch ?? orderedMatch)?.[1] ?? '')
+      continue
+    }
+
+    flushList()
+    paragraph.push(line.trim())
+  }
+
+  if (codeFence) blocks.push({ type: 'code', text: codeFence.join('\n') })
+  flushParagraph()
+  flushList()
+  return blocks
+}
+
+function MarkdownReader({ markdown }: { markdown: string }) {
+  const blocks = useMemo(() => parseConservativeMarkdown(markdown), [markdown])
+
+  if (blocks.length === 0) {
+    return <StatePanel eyebrow="Documento vacío" status="sin-datos" title="Markdown sin contenido" description="El documento existe, pero no contiene texto renderizable." />
+  }
+
+  return (
+    <article className="vault-markdown-reader" aria-label="Documento Markdown renderizado de forma saneada">
+      {blocks.map((block, index) => {
+        if (block.type === 'frontmatter') {
+          return <pre key={index} className="vault-markdown-code vault-markdown-frontmatter"><code>{safeText(block.text)}</code></pre>
+        }
+        if (block.type === 'heading') {
+          const Heading = (`h${block.level}` as 'h1' | 'h2' | 'h3' | 'h4')
+          return <Heading key={index}>{renderInlineMarkdown(block.text)}</Heading>
+        }
+        if (block.type === 'paragraph') {
+          return <p key={index}>{renderInlineMarkdown(block.text)}</p>
+        }
+        if (block.type === 'blockquote') {
+          return <blockquote key={index}>{renderInlineMarkdown(block.text)}</blockquote>
+        }
+        if (block.type === 'list') {
+          const List = block.ordered ? 'ol' : 'ul'
+          return <List key={index}>{block.items.map((item, itemIndex) => <li key={`${index}-${itemIndex}`}>{renderInlineMarkdown(item)}</li>)}</List>
+        }
+        if (block.type === 'code') {
+          return <pre key={index} className="vault-markdown-code"><code>{safeText(block.text)}</code></pre>
+        }
+        if (block.type === 'rule') {
+          return <hr key={index} />
+        }
+        return (
+          <div key={index} className="vault-markdown-table-wrap">
+            <table>
+              <thead><tr>{block.headers.map((header, cellIndex) => <th key={cellIndex}>{renderInlineMarkdown(header)}</th>)}</tr></thead>
+              <tbody>{block.rows.map((row, rowIndex) => <tr key={rowIndex}>{row.map((cell, cellIndex) => <td key={cellIndex}>{renderInlineMarkdown(cell)}</td>)}</tr>)}</tbody>
+            </table>
+          </div>
+        )
+      })}
+    </article>
+  )
+}
+
+function isNodeHidden(node: VaultExplorerNode, collapsedDirectories: Set<string>) {
+  const parts = node.relative_path.split('/')
+  for (let index = 1; index < parts.length; index += 1) {
+    const ancestor = parts.slice(0, index).join('/')
+    if (collapsedDirectories.has(ancestor)) return true
+  }
+  return false
+}
+
+function VaultExplorer({ nodes, selectedPath }: { nodes: VaultExplorerNode[]; selectedPath: string | null }) {
+  const directoryPaths = useMemo(() => new Set(nodes.filter((node) => node.kind === 'directory').map((node) => node.relative_path)), [nodes])
+  const [collapsedDirectories, setCollapsedDirectories] = useState<Set<string>>(new Set())
+  const visibleNodes = nodes.filter((node) => !isNodeHidden(node, collapsedDirectories))
+
+  if (nodes.length === 0) {
+    return <StatePanel eyebrow="Vault vacío" status="sin-datos" title="No hay documentos visibles" description="El backend no ha devuelto nodos Markdown permitidos para este vault." />
+  }
+
+  return (
+    <nav className="vault-explorer-tree" aria-label="Explorador de archivos del Vault">
+      {visibleNodes.map((node) => {
+        const isDirectory = node.kind === 'directory'
+        const isCollapsed = collapsedDirectories.has(node.relative_path)
+        const isActive = node.relative_path === selectedPath
+        const indent = `${8 + node.depth * 18}px`
+
+        if (isDirectory) {
+          return (
+            <button
+              key={node.id}
+              type="button"
+              className="vault-tree-row vault-tree-row--directory"
+              aria-expanded={!isCollapsed}
+              onClick={() => {
+                setCollapsedDirectories((current) => {
+                  const next = new Set(current)
+                  if (next.has(node.relative_path)) next.delete(node.relative_path)
+                  else next.add(node.relative_path)
+                  return next
+                })
+              }}
+              style={{ paddingLeft: indent }}
+            >
+              <span aria-hidden="true">{isCollapsed ? '▸' : '▾'}</span>
+              <span aria-hidden="true">📁</span>
+              <span className="vault-tree-row__name">{node.name}</span>
+            </button>
+          )
+        }
+
+        return (
+          <Link
+            key={node.id}
+            className="vault-tree-row vault-tree-row--document"
+            data-active={isActive ? 'true' : 'false'}
+            href={vaultDocumentHref(node.relative_path)}
+            style={{ paddingLeft: indent }}
+          >
+            <span aria-hidden="true">{directoryPaths.has(node.relative_path) ? '▾' : ' '}</span>
+            <span aria-hidden="true">📄</span>
+            <span className="vault-tree-row__name">{node.name}</span>
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}
+
+function getFallbackNotice(code?: string) {
+  const isNotConfigured = code === 'not_configured'
   return {
     status: isNotConfigured ? ('revision' as const) : ('incidencia' as const),
     title: isNotConfigured ? 'Vault en modo fallback local' : 'Vault en fallback saneado',
     description: isNotConfigured
-      ? 'Mostrando snapshot documental local saneado. Mantiene la navegación del canon, pero no representa lectura real ni tiempo real de la API.'
-      : 'La carga real del Vault no está disponible y la página muestra un fallback documental local. Este estado degradado queda visible sin exponer rutas internas ni detalles del backend.',
-    detail: apiErrorCode ? `Estado técnico: ${apiErrorCode}` : null,
+      ? 'La API privada no está configurada para esta ejecución. Se muestra un snapshot Markdown local saneado, sin lectura real del filesystem.'
+      : 'La lectura real del Vault no está disponible. La página conserva el explorador y lector sobre un fallback local sin exponer rutas internas ni errores crudos.',
+    detail: code ? `Estado técnico: ${code}` : undefined,
   }
 }
 
-export function VaultClient({ initialWorkspace, apiState, apiErrorCode }: VaultClientProps) {
-  const workspace = initialWorkspace
-  const [selectedDocumentId, setSelectedDocumentId] = useState(workspace.active_document_id)
-  const apiNotice = getVaultApiNotice(apiState, apiErrorCode)
-  const isSnapshotMode = Boolean(apiNotice)
-
-  const activeDocument = useMemo(
-    () => workspace.documents.find((document) => document.id === selectedDocumentId) ?? workspace.documents[0],
-    [selectedDocumentId, workspace.documents],
-  )
-
-  const freshnessNotice =
-    workspace.freshness.state === 'stale'
-      ? {
-          status: 'stale' as const,
-          title: 'Índice documental desactualizado',
-          description: 'El vault sigue siendo navegable, pero la frescura del índice no es la ideal. Conviene ejecutar el refresco canónico antes de tratarlo como snapshot reciente.',
-          detail: workspace.freshness.label,
-        }
-      : null
+export function VaultClient({ tree, document, selectedPath, notice }: VaultClientProps) {
+  const apiNotice = notice.status === 'fallback' ? getFallbackNotice(notice.code) : null
 
   return (
     <>
-      <PageHeader
-        eyebrow="Vault"
-        title="Vault"
-        subtitle="Lectura documental y editorial del canon curado, con árbol allowlisted, documento legible y metadatos visibles."
-        detailPills={['Canon curado', 'Lectura editorial', 'Sin memoria viva']}
-      />
+      <PageHeader eyebrow="Vault" title="Vault · Solo lectura" subtitle="Explorador de archivos del vault canónico y lector Markdown renderizado. Sin edición, sin escritura y sin rutas absolutas del host en la UI." detailPills={['Explorador', 'Markdown saneado', 'Read-only']} />
 
-      <section className="layout-grid layout-grid--vault">
-        <div style={{ display: 'grid', gap: '14px' }}>
-          {apiNotice ? (
-            <StatePanel
-              status={apiNotice.status}
-              title={apiNotice.title}
-              description={apiNotice.description}
-              detail={apiNotice.detail}
-              eyebrow="Estado de fuente"
-            >
-              <SourceStatePills
-                items={[
-                  { label: 'Modo fallback local', tone: 'fallback' },
-                  { label: 'Snapshot saneado', tone: 'snapshot' },
-                  { label: 'No tiempo real', tone: 'not-realtime' },
-                ]}
-              />
-            </StatePanel>
-          ) : null}
+      {apiNotice ? (
+        <div className="section-block">
+          <StatePanel status={apiNotice.status} title={apiNotice.title} description={apiNotice.description} detail={apiNotice.detail} eyebrow="Estado de fuente">
+            <SourceStatePills items={[{ label: 'Modo fallback local', tone: 'fallback' }, { label: 'Snapshot saneado', tone: 'snapshot' }, { label: 'No tiempo real', tone: 'not-realtime' }]} />
+          </StatePanel>
+        </div>
+      ) : null}
 
-          <SurfaceCard title="Canon curado" elevated eyebrow="Archivo" accent="gold">
-            <div style={{ display: 'grid', gap: '10px' }}>
-              <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
-                Vault es una capa editorial y navegable. Resume decisiones duraderas y project summaries; no funciona como memoria operativa por fuente.
-              </p>
-              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                <StatusBadge
-                  status={getVaultFreshnessStatus(workspace.freshness.state)}
-                  label={
-                    isSnapshotMode && getVaultFreshnessStatus(workspace.freshness.state) === 'operativo'
-                      ? 'Operativo en último corte'
-                      : undefined
-                  }
-                />
-                <span
-                  style={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    borderRadius: '999px',
-                    padding: '4px 10px',
-                    background: appTheme.colors.bgSurface1,
-                    border: `1px solid ${appTheme.colors.borderSubtle}`,
-                    color: appTheme.colors.brandSky500,
-                    fontSize: '12px',
-                    fontWeight: 700,
-                  }}
-                >
-                  Solo lectura documental
-                </span>
-                <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{workspace.freshness.label}</span>
-              </div>
-              <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>
-                {isSnapshotMode ? 'Corte del snapshot' : 'Última actualización'}: {formatTimestamp(workspace.freshness.updated_at)}
-              </span>
-              {freshnessNotice ? (
-                <StatePanel
-                  status={freshnessNotice.status}
-                  title={freshnessNotice.title}
-                  description={freshnessNotice.description}
-                  detail={freshnessNotice.detail}
-                  eyebrow="Estado documental"
-                />
-              ) : null}
+      <section className="layout-grid layout-grid--vault vault-browser-shell" aria-label="Explorador y lector del Vault">
+        <aside className="vault-explorer-panel" aria-label="Panel de explorador">
+          <div className="vault-panel-header">
+            <div>
+              <span className="vault-panel-eyebrow">Explorador</span>
+              <h2>Archivos</h2>
             </div>
-          </SurfaceCard>
+            <StatusBadge status={tree.limits.nodes_truncated ? 'revision' : 'operativo'} label={tree.limits.nodes_truncated ? 'Truncado' : 'Read-only'} />
+          </div>
+          <VaultExplorer nodes={tree.nodes} selectedPath={selectedPath} />
+        </aside>
 
-          <SurfaceCard title="Índice allowlisted" elevated eyebrow="Mapa" accent="sky">
-            <div id="vault-tree" style={{ display: 'grid', gap: '8px' }}>
-              {workspace.tree.length > 0 ? (
-                workspace.tree.map((entry) => {
-                  const isActive = entry.id === activeDocument?.id
-                  const isSelectable = entry.kind === 'document'
-
-                  return (
-                    <button
-                      key={entry.id}
-                      type="button"
-                      onClick={() => {
-                        if (isSelectable) {
-                          setSelectedDocumentId(entry.id)
-                        }
-                      }}
-                      aria-pressed={isSelectable ? isActive : undefined}
-                      disabled={!isSelectable}
-                      style={{
-                        textAlign: 'left',
-                        borderRadius: '12px',
-                        padding: '12px',
-                        cursor: isSelectable ? 'pointer' : 'default',
-                        border: `1px solid ${isActive ? appTheme.colors.brandSky500 : appTheme.colors.borderSubtle}`,
-                        background: isActive ? appTheme.colors.bgSurface2 : appTheme.colors.bgSurface1,
-                        color: appTheme.colors.textPrimary,
-                        display: 'grid',
-                        gap: '6px',
-                        paddingLeft: `${12 + entry.depth * 18}px`,
-                        opacity: isSelectable ? 1 : 0.9,
-                      }}
-                    >
-                      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
-                        <strong>{entry.label}</strong>
-                        <StatusBadge
-                          status={entry.kind === 'directory' ? 'revision' : 'operativo'}
-                          label={isSnapshotMode && entry.kind !== 'directory' ? 'Operativo en último corte' : undefined}
-                        />
-                      </div>
-                      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>{entry.path_segment}</span>
-                      <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{entry.summary}</span>
-                    </button>
-                  )
-                })
-              ) : (
-                <StatePanel
-                  status="sin-datos"
-                  title="Índice sin entradas allowlisted"
-                  description="No hay nodos visibles en el árbol documental. La página debe seguir mostrando el shell y el contexto editorial sin romper la navegación."
-                  eyebrow="Estado vacío"
-                />
-              )}
-            </div>
-          </SurfaceCard>
-        </div>
-
-        <div style={{ display: 'grid', gap: '14px' }}>
-          <SurfaceCard title="Documento" elevated eyebrow="Pieza canónica" accent="gold">
-            {activeDocument ? (
-              <div style={{ display: 'grid', gap: '14px' }}>
-                <nav aria-label="Breadcrumbs de Vault" style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                  {activeDocument.breadcrumbs.map((breadcrumb, index) => (
-                    <span key={breadcrumb.href} style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                      <a href={breadcrumb.href} style={{ color: appTheme.colors.brandSky500, textDecoration: 'none' }}>
-                        {breadcrumb.label}
-                      </a>
-                      {index < activeDocument.breadcrumbs.length - 1 ? ' / ' : ''}
-                    </span>
-                  ))}
-                </nav>
-
-                <div style={{ display: 'grid', gap: '6px' }}>
-                  <strong style={{ fontSize: '22px' }}>{activeDocument.title}</strong>
-                  <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>{activeDocument.summary}</p>
+        <main className="vault-reader-panel" aria-label="Lector Markdown">
+          {document ? (
+            <>
+              <div className="vault-reader-header">
+                <div>
+                  <span className="vault-panel-eyebrow">Documento seleccionado</span>
+                  <h2>{document.name}</h2>
+                  <p>{document.relative_path}</p>
                 </div>
-
-                <div
-                  style={{
-                    borderRadius: '12px',
-                    border: `1px solid ${appTheme.colors.borderSubtle}`,
-                    background: appTheme.colors.bgSurface1,
-                    padding: '12px',
-                    color: appTheme.colors.textSecondary,
-                  }}
-                >
-                  {activeDocument.canon_callout}
+                <div className="vault-reader-meta" aria-label="Metadata mínima segura del documento">
+                  <span>{formatBytes(document.size_bytes)}</span>
+                  <span>{formatTimestamp(document.updated_at)}</span>
+                  <span>Solo lectura</span>
                 </div>
-
-                {activeDocument.sections.length > 0 ? (
-                  <article style={{ display: 'grid', gap: '16px' }}>
-                    {activeDocument.sections.map((section) => (
-                      <section key={section.heading}>
-                        <h3 style={{ marginTop: 0, marginBottom: '10px', fontSize: '18px' }}>{section.heading}</h3>
-                        <div style={{ display: 'grid', gap: '10px' }}>
-                          {section.body.map((paragraph) => (
-                            <p key={paragraph} style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
-                              {paragraph}
-                            </p>
-                          ))}
-                        </div>
-                      </section>
-                    ))}
-                  </article>
-                ) : (
-                  <StatePanel
-                    status="sin-datos"
-                    title="Documento sin secciones visibles"
-                    description="El documento activo no contiene bloques editoriales publicados todavía. La superficie debe seguir siendo estable aunque falte cuerpo documental."
-                    eyebrow="Estado vacío"
-                  />
-                )}
               </div>
-            ) : (
-              <StatePanel
-                status="sin-datos"
-                title="Sin documento activo"
-                description="No hay un documento allowlisted listo para renderizar. La navegación lateral puede seguir disponible mientras llega contenido canónico."
-                eyebrow="Estado vacío"
-              />
-            )}
-          </SurfaceCard>
-        </div>
-
-        <div style={{ display: 'grid', gap: '14px' }}>
-          <SurfaceCard title="Metadatos" elevated eyebrow="Ficha" accent="sky">
-            {activeDocument ? (
-              <div style={{ display: 'grid', gap: '10px' }}>
-                <div style={{ display: 'grid', gap: '6px' }}>
-                  <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Path</span>
-                  <code
-                    className="responsive-code"
-                    style={{
-                      padding: '10px',
-                      borderRadius: '12px',
-                      background: appTheme.colors.bgSurface1,
-                      color: appTheme.colors.textSecondary,
-                    }}
-                  >
-                    {activeDocument.meta.path}
-                  </code>
-                </div>
-
-                <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                  {isSnapshotMode ? 'Corte del snapshot' : 'Actualizado'}: {formatTimestamp(activeDocument.meta.updated_at)}
-                </span>
-                <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{activeDocument.meta.context}</span>
-              </div>
-            ) : (
-              <StatePanel
-                status="sin-datos"
-                title="Metadatos no disponibles"
-                description="La ficha documental aún no tiene un documento activo del que extraer path, fecha o contexto."
-                eyebrow="Estado vacío"
-              />
-            )}
-          </SurfaceCard>
-
-          <SurfaceCard title="TOC" elevated eyebrow="Índice" accent="gold">
-            {activeDocument && activeDocument.meta.toc.length > 0 ? (
-              <div style={{ display: 'grid', gap: '8px' }}>
-                {activeDocument.meta.toc.map((item) => (
-                  <div
-                    key={item}
-                    style={{
-                      borderRadius: '12px',
-                      padding: '10px 12px',
-                      border: `1px solid ${appTheme.colors.borderSubtle}`,
-                      color: appTheme.colors.textSecondary,
-                      background: appTheme.colors.bgSurface1,
-                    }}
-                  >
-                    {item}
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <StatePanel
-                status="sin-datos"
-                title="TOC sin entradas"
-                description="No hay tabla de contenidos visible para el documento activo. El panel debe expresar el vacío con claridad en lugar de quedarse en blanco."
-                eyebrow="Estado vacío"
-              />
-            )}
-          </SurfaceCard>
-        </div>
+              <MarkdownReader markdown={document.markdown} />
+            </>
+          ) : (
+            <StatePanel eyebrow="Sin selección" status="sin-datos" title="Selecciona un documento Markdown" description="El explorador no tiene todavía un documento activo. El lector permanece vacío sin intentar acceder al filesystem desde el navegador." />
+          )}
+        </main>
       </section>
     </>
   )

--- a/apps/web/src/app/vault/page.tsx
+++ b/apps/web/src/app/vault/page.tsx
@@ -76,6 +76,10 @@ async function loadVaultPage(searchParams: Record<string, string | string[] | un
 
     const document = selectedPath ? await fetchVaultDocument(selectedPath) : null
 
+    if (document && document.relative_path !== selectedPath) {
+      redirect('/vault')
+    }
+
     return {
       tree,
       document,

--- a/apps/web/src/app/vault/page.tsx
+++ b/apps/web/src/app/vault/page.tsx
@@ -1,33 +1,106 @@
-import { VaultApiError, fetchVaultWorkspace } from '@/modules/vault/api/vault-http'
-import { vaultWorkspaceFixture } from '@/modules/vault/view-models/vault-workspace.fixture'
+import { redirect } from 'next/navigation'
+
+import { VaultApiError, fetchVaultDocument, fetchVaultTree } from '@/modules/vault/api/vault-http'
+import {
+  vaultExplorerFixture,
+  vaultMarkdownFixture,
+  type VaultExplorerTree,
+  type VaultMarkdownDocument,
+} from '@/modules/vault/view-models/vault-explorer.fixture'
 
 import { VaultClient } from './VaultClient'
 
 export const dynamic = 'force-dynamic'
 
-type VaultPageState = {
-  workspace: typeof vaultWorkspaceFixture
-  apiState: 'ready' | 'fallback'
-  apiErrorCode?: string
+type VaultPageNotice = {
+  status: 'ready' | 'fallback'
+  code?: string
 }
 
-async function loadVaultWorkspace(): Promise<VaultPageState> {
+type VaultPageState = {
+  tree: VaultExplorerTree
+  document: VaultMarkdownDocument | null
+  selectedPath: string | null
+  notice: VaultPageNotice
+}
+
+type VaultPageSearchParams = Promise<Record<string, string | string[] | undefined>>
+
+type VaultPageProps = {
+  searchParams?: VaultPageSearchParams
+}
+
+function getSingleSearchParam(searchParams: Record<string, string | string[] | undefined>, key: 'path') {
+  const value = searchParams[key]
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) return value[0]
+  return undefined
+}
+
+function hasUnsupportedVaultSearchParams(searchParams: Record<string, string | string[] | undefined>) {
+  return Object.keys(searchParams).some((key) => key !== 'path')
+}
+
+function isNextRedirectError(error: unknown) {
+  return Boolean(
+    error &&
+      typeof error === 'object' &&
+      'digest' in error &&
+      String((error as { digest?: unknown }).digest).startsWith('NEXT_REDIRECT'),
+  )
+}
+
+function isSafeSelectedPath(tree: VaultExplorerTree, selectedPath: string | undefined): selectedPath is string {
+  if (!selectedPath) return false
+  return tree.documents.some((document) => document.relative_path === selectedPath)
+}
+
+function vaultDocumentHref(relativePath: string) {
+  return `/vault?path=${encodeURIComponent(relativePath)}`
+}
+
+async function loadVaultPage(searchParams: Record<string, string | string[] | undefined>): Promise<VaultPageState> {
+  if (hasUnsupportedVaultSearchParams(searchParams)) {
+    redirect('/vault')
+  }
+
+  const requestedPath = getSingleSearchParam(searchParams, 'path')
+
   try {
+    const tree = await fetchVaultTree()
+    const selectedPath = isSafeSelectedPath(tree, requestedPath) ? requestedPath : (tree.documents[0]?.relative_path ?? null)
+
+    if (requestedPath && selectedPath !== requestedPath) {
+      redirect(selectedPath ? vaultDocumentHref(selectedPath) : '/vault')
+    }
+
+    const document = selectedPath ? await fetchVaultDocument(selectedPath) : null
+
     return {
-      workspace: await fetchVaultWorkspace(),
-      apiState: 'ready',
+      tree,
+      document,
+      selectedPath,
+      notice: { status: 'ready' },
     }
   } catch (error) {
+    if (isNextRedirectError(error)) throw error
+
+    if (requestedPath) {
+      redirect('/vault')
+    }
+
     return {
-      workspace: vaultWorkspaceFixture,
-      apiState: 'fallback',
-      apiErrorCode: error instanceof VaultApiError ? error.code : 'fetch_failed',
+      tree: vaultExplorerFixture,
+      document: vaultMarkdownFixture,
+      selectedPath: vaultMarkdownFixture.relative_path,
+      notice: { status: 'fallback', code: error instanceof VaultApiError ? error.code : 'fetch_failed' },
     }
   }
 }
 
-export default async function VaultPage() {
-  const { workspace, apiState, apiErrorCode } = await loadVaultWorkspace()
+export default async function VaultPage({ searchParams }: VaultPageProps) {
+  const resolvedSearchParams = searchParams ? await searchParams : {}
+  const { tree, document, selectedPath, notice } = await loadVaultPage(resolvedSearchParams)
 
-  return <VaultClient apiErrorCode={apiErrorCode} apiState={apiState} initialWorkspace={workspace} />
+  return <VaultClient document={document} notice={notice} selectedPath={selectedPath} tree={tree} />
 }

--- a/apps/web/src/modules/vault/api/vault-http.ts
+++ b/apps/web/src/modules/vault/api/vault-http.ts
@@ -1,11 +1,15 @@
 import 'server-only'
 
-import type { VaultWorkspace } from '@/modules/vault/view-models/vault-workspace.fixture'
+import type { VaultExplorerTree, VaultMarkdownDocument } from '@/modules/vault/view-models/vault-explorer.fixture'
 
 export const VAULT_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'
 
-type VaultWorkspaceResponse = {
-  data: VaultWorkspace
+type VaultTreeResponse = {
+  data: VaultExplorerTree
+}
+
+type VaultDocumentResponse = {
+  data: VaultMarkdownDocument
 }
 
 export class VaultApiError extends Error {
@@ -41,14 +45,35 @@ export function getVaultApiBaseUrl() {
   return trimTrailingSlash(value)
 }
 
-export async function fetchVaultWorkspace(): Promise<VaultWorkspace> {
+function encodeVaultDocumentPath(relativePath: string) {
+  return relativePath
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')
+}
+
+function assertTreePayload(value: unknown): asserts value is VaultExplorerTree {
+  const data = value as Partial<VaultExplorerTree> | null
+  if (!data || !Array.isArray(data.nodes) || !Array.isArray(data.documents) || data.read_only !== true || data.sanitized !== true) {
+    throw new VaultApiError('invalid_payload')
+  }
+}
+
+function assertDocumentPayload(value: unknown): asserts value is VaultMarkdownDocument {
+  const data = value as Partial<VaultMarkdownDocument> | null
+  if (!data || typeof data.relative_path !== 'string' || typeof data.markdown !== 'string' || data.read_only !== true) {
+    throw new VaultApiError('invalid_payload')
+  }
+}
+
+async function fetchJson<T>(path: string): Promise<T> {
   const baseUrl = getVaultApiBaseUrl()
 
   if (!baseUrl) {
     throw new VaultApiError('not_configured')
   }
 
-  const response = await fetch(`${baseUrl}/api/v1/vault`, {
+  const response = await fetch(`${baseUrl}${path}`, {
     cache: 'no-store',
     headers: {
       Accept: 'application/json',
@@ -59,11 +84,17 @@ export async function fetchVaultWorkspace(): Promise<VaultWorkspace> {
     throw new VaultApiError(`http_${response.status}`)
   }
 
-  const payload = (await response.json()) as VaultWorkspaceResponse
+  return (await response.json()) as T
+}
 
-  if (!payload.data) {
-    throw new VaultApiError('invalid_payload')
-  }
+export async function fetchVaultTree(): Promise<VaultExplorerTree> {
+  const payload = await fetchJson<VaultTreeResponse>('/api/v1/vault/tree')
+  assertTreePayload(payload.data)
+  return payload.data
+}
 
+export async function fetchVaultDocument(relativePath: string): Promise<VaultMarkdownDocument> {
+  const payload = await fetchJson<VaultDocumentResponse>(`/api/v1/vault/documents/${encodeVaultDocumentPath(relativePath)}`)
+  assertDocumentPayload(payload.data)
   return payload.data
 }

--- a/apps/web/src/modules/vault/view-models/vault-explorer.fixture.ts
+++ b/apps/web/src/modules/vault/view-models/vault-explorer.fixture.ts
@@ -1,0 +1,138 @@
+export type VaultExplorerNode = {
+  id: string
+  name: string
+  relative_path: string
+  kind: 'directory' | 'document'
+  depth: number
+  size_bytes?: number | null
+  updated_at?: string | null
+}
+
+export type VaultDocumentRef = {
+  id: string
+  name: string
+  relative_path: string
+  size_bytes: number
+  updated_at: string
+}
+
+export type VaultExplorerTree = {
+  safe_root: 'canonical_vault'
+  read_only: true
+  sanitized: true
+  max_depth: number
+  max_nodes: number
+  max_document_bytes: number
+  limits: {
+    nodes_truncated: boolean
+  }
+  nodes: VaultExplorerNode[]
+  documents: VaultDocumentRef[]
+}
+
+export type VaultMarkdownDocument = {
+  relative_path: string
+  name: string
+  markdown: string
+  updated_at: string
+  size_bytes: number
+  read_only: true
+}
+
+export const vaultExplorerFixture: VaultExplorerTree = {
+  safe_root: 'canonical_vault',
+  read_only: true,
+  sanitized: true,
+  max_depth: 8,
+  max_nodes: 600,
+  max_document_bytes: 524288,
+  limits: {
+    nodes_truncated: false,
+  },
+  nodes: [
+    {
+      id: 'project-summary-mugiwara-control-panel',
+      name: 'Project Summary - Mugiwara Control Panel.md',
+      relative_path: '03-Projects/Project Summary - Mugiwara Control Panel.md',
+      kind: 'document',
+      depth: 1,
+      size_bytes: 1337,
+      updated_at: '2026-04-29T12:00:00Z',
+    },
+    {
+      id: 'policy-memory-governance',
+      name: 'Policy - Memory governance.md',
+      relative_path: '00-System/Policy - Memory governance.md',
+      kind: 'document',
+      depth: 1,
+      size_bytes: 900,
+      updated_at: '2026-04-29T12:00:00Z',
+    },
+    {
+      id: 'playbook-pr-governance',
+      name: 'Playbook - PR governance Zoro Franky Chopper Usopp.md',
+      relative_path: '06-Playbooks/Playbook - PR governance Zoro Franky Chopper Usopp.md',
+      kind: 'document',
+      depth: 1,
+      size_bytes: 1200,
+      updated_at: '2026-04-29T12:00:00Z',
+    },
+  ],
+  documents: [
+    {
+      id: 'project-summary-mugiwara-control-panel',
+      name: 'Project Summary - Mugiwara Control Panel.md',
+      relative_path: '03-Projects/Project Summary - Mugiwara Control Panel.md',
+      size_bytes: 1337,
+      updated_at: '2026-04-29T12:00:00Z',
+    },
+    {
+      id: 'policy-memory-governance',
+      name: 'Policy - Memory governance.md',
+      relative_path: '00-System/Policy - Memory governance.md',
+      size_bytes: 900,
+      updated_at: '2026-04-29T12:00:00Z',
+    },
+    {
+      id: 'playbook-pr-governance',
+      name: 'Playbook - PR governance Zoro Franky Chopper Usopp.md',
+      relative_path: '06-Playbooks/Playbook - PR governance Zoro Franky Chopper Usopp.md',
+      size_bytes: 1200,
+      updated_at: '2026-04-29T12:00:00Z',
+    },
+  ],
+}
+
+export const vaultMarkdownFixture: VaultMarkdownDocument = {
+  relative_path: '03-Projects/Project Summary - Mugiwara Control Panel.md',
+  name: 'Project Summary - Mugiwara Control Panel.md',
+  updated_at: '2026-04-29T12:00:00Z',
+  size_bytes: 1337,
+  read_only: true,
+  markdown: `---
+title: Mugiwara Control Panel
+status: fallback-saneado
+---
+
+# Mugiwara Control Panel
+
+Fallback local saneado para mantener la experiencia de lectura cuando la API privada no está disponible.
+
+## Qué muestra esta página
+
+- Explorador de documentos Markdown permitidos.
+- Lector Markdown renderizado sin HTML ejecutable.
+- Enlaces saneados y solo lectura real de extremo a extremo.
+
+| Superficie | Estado |
+| --- | --- |
+| Vault | Solo lectura |
+| Markdown | Render conservador |
+
+> Este fallback no representa lectura en vivo del vault.
+
+\`\`\`text
+sin escritura, sin rutas absolutas host, sin backend URL en cliente
+\`\`\`
+`,
+}

--- a/docs/frontend-implementation-handoff.md
+++ b/docs/frontend-implementation-handoff.md
@@ -591,11 +591,12 @@ Los roles exactos pueden ajustarse al canon del proyecto, pero el slug + crest p
 
 ## 9.6 Vault
 ### Entregar
-- layout índice / documento / metadatos
-- breadcrumbs
-- render markdown legible
-- callout o framing de `canon curado`
-- contraste visual suficiente frente a `memory`
+- layout de dos paneles: explorador de archivos + lector Markdown
+- explorador estilo VS Code/Obsidian con carpetas colapsables, indentación, activo resaltado y scroll independiente
+- lector Markdown legible con frontmatter, headings, listas, tablas, enlaces, blockquotes y código
+- adapter server-only sobre `GET /api/v1/vault/tree` y `GET /api/v1/vault/documents/{document_path:path}`
+- sin ficha externa de metadatos, sin TOC lateral obligatorio y sin callout editorial legacy
+- contraste visual suficiente frente a `memory` manteniendo read-only claro
 
 ## 9.7 Healthcheck
 ### Entregar

--- a/docs/frontend-ui-spec.md
+++ b/docs/frontend-ui-spec.md
@@ -700,43 +700,42 @@ Subtítulo: Built-in por Mugiwara y estado resumido de Honcho
 
 ## 5.6 Vault
 ### Objetivo
-Lector/navegador documental independiente.
+Explorador de archivos del vault canónico + lector Markdown independiente, simple y de solo lectura.
 
 ### Estructura
 ```text
 [PageHeader]
-Título: Vault
-Subtítulo: Navegación y lectura del canon curado
+Título: Vault · Solo lectura
+Subtítulo: Explorador de archivos del vault canónico y lector Markdown renderizado
 
-[Search + breadcrumbs]
-- búsqueda
-- ruta actual
-
-[Three-panel layout]
-┌──────────────────┬────────────────────────────────┬─────────────────────┐
-│ árbol / índice   │ documento                      │ metadatos / TOC     │
-│                  │                                │                     │
-│ secciones        │ markdown renderizado           │ path                │
-│ carpetas         │ headings                       │ updated at          │
-│ documentos       │ bloques                        │ índice interno      │
-└──────────────────┴────────────────────────────────┴─────────────────────┘
+[Two-panel layout]
+┌──────────────────┬────────────────────────────────┐
+│ Explorador       │ Lector Markdown                │
+│                  │                                │
+│ carpetas         │ frontmatter como contenido     │
+│ documentos .md   │ headings/listas/tablas/código  │
+│ activo resaltado │ enlaces saneados               │
+└──────────────────┴────────────────────────────────┘
 ```
 
 ### Reglas
-- experiencia editorial y documental
-- lectura cómoda y jerarquía clara
-- breadcrumbs obligatorios si hay navegación profunda
-- no reutilizar la misma UI que `memory`
-- rescatar de la landing la lógica de `canon curado`, pero con un framing más documental que heroico
+- no conservar la UI editorial legacy de cards, callouts, ficha externa de metadatos ni TOC lateral obligatorio
+- la UI consume solo `GET /api/v1/vault/tree` y `GET /api/v1/vault/documents/{document_path:path}` desde adapter server-only
+- el cliente no lee filesystem, backend URL ni variables de entorno
+- selección de documento solo desde `tree.documents` devuelto por backend
+- Markdown renderizado de forma conservadora, sin HTML raw ni `dangerouslySetInnerHTML`
+- enlaces Markdown saneados; HTML dentro del Markdown se trata como texto
+- frontmatter/metadatos permanecen dentro del propio contenido Markdown, no duplicados en panel externo
 
 ### Estilo
-- más calmado, más editorial
-- puede introducir acentos `brand-brown-700` y `brand-navy-900`
+- explorador izquierdo cercano a VS Code/Obsidian: indentación, carpetas colapsables, activo claro y scroll independiente
+- lector derecho con ancho cómodo, buena legibilidad y soporte para tablas/código sin overflow horizontal
+- en tablet/mobile los paneles apilan; se prioriza lectura y se limita la altura del explorador
 
 ### Patrón recomendado
-- subtítulo tipo `Canon curado y navegación documental`
-- callout opcional diferenciando `vault` vs `memory`
-- TOC o meta panel visibles para reforzar lectura estructurada
+- header mínimo con `Vault · Solo lectura`
+- badges de estado discretos: `Explorador`, `Markdown saneado`, `Read-only`
+- fallback local visible solo si falla la API, marcado como snapshot saneado/no tiempo real
 
 ---
 

--- a/openspec/issue-121-3-vault-frontend-explorer-verify-checklist.md
+++ b/openspec/issue-121-3-vault-frontend-explorer-verify-checklist.md
@@ -1,0 +1,18 @@
+# Issue 121.3 verify checklist
+
+- [x] `/vault` carga `GET /api/v1/vault/tree` desde server page/adaptador server-only.
+- [x] `/vault` selecciona documentos solo desde `tree.documents` backend-owned.
+- [x] `/vault` carga `GET /api/v1/vault/documents/{document_path:path}` desde server page/adaptador server-only.
+- [x] `VaultClient` no lee `process.env`, no usa `MUGIWARA_CONTROL_PANEL_API_URL` y no hace fetch directo al backend.
+- [x] Markdown se renderiza sin `dangerouslySetInnerHTML`.
+- [x] Links Markdown se limitan a `http:`, `https:`, rutas internas o anchors.
+- [x] Frontmatter, tablas y fenced code tienen cobertura en fixture fallback y renderer.
+- [x] Retirada UI editorial legacy: sin `Canon curado`, `Índice allowlisted`, `Metadatos`, `TOC` como panel lateral obligatorio.
+- [x] Guardrail `npm run verify:vault-server-only` actualizado al contrato 121.3.
+- [x] `npm run verify:vault-server-only` pasa.
+- [x] `npm --prefix apps/web run typecheck` pasa.
+- [x] `npm --prefix apps/web run build` pasa y `/vault` queda dinámica.
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_vault_api.py -q` pasa.
+- [x] `npm run verify:visual-baseline` pasa.
+- [x] `git diff --check` pasa.
+- [x] Smoke HTTP/DOM/browser confirma layout explorer+reader y ausencia de textos legacy/fugas.

--- a/openspec/issue-121-3-vault-frontend-explorer.md
+++ b/openspec/issue-121-3-vault-frontend-explorer.md
@@ -1,0 +1,42 @@
+# Issue 121.3 — Vault frontend explorer + Markdown reader
+
+## Objetivo
+
+Sustituir la experiencia editorial legacy de `/vault` por un explorador de archivos + lector Markdown de solo lectura, consumiendo exclusivamente:
+
+- `GET /api/v1/vault/tree`
+- `GET /api/v1/vault/documents/{document_path:path}`
+
+## Alcance implementado
+
+- Página server-side dinámica `apps/web/src/app/vault/page.tsx`.
+- Adapter server-only `apps/web/src/modules/vault/api/vault-http.ts` con env privada `MUGIWARA_CONTROL_PANEL_API_URL`, `cache: no-store` y path encoding por segmento.
+- UI cliente sin acceso a backend URL ni env server:
+  - panel izquierdo de explorador con carpetas colapsables, indentación, activo resaltado y scroll independiente;
+  - panel derecho de lector Markdown;
+  - fallback local saneado cuando API no está configurada o falla.
+- Render Markdown conservador sin `dangerouslySetInnerHTML`:
+  - frontmatter como bloque de código visible;
+  - headings, listas, blockquotes, tablas, enlaces y fenced code;
+  - enlaces sanitizados a `http:`, `https:`, rutas internas `/...` o anchors `#...`.
+- Retirada de textos/paneles legacy: `Canon curado`, `Índice allowlisted`, ficha externa de metadatos y TOC lateral obligatorio.
+
+## Fuera de alcance
+
+- Escritura/edición/renombrado/borrado de Vault.
+- Búsqueda global.
+- Fetch client-side directo al backend.
+- Nueva dependencia Markdown externa.
+- Cierre/canon final de #121 completo, reservado para 121.4.
+
+## Riesgos y mitigaciones
+
+- **Markdown/XSS:** mitigado renderizando React nodes/texto escapado, sin HTML raw ni `dangerouslySetInnerHTML`, y links saneados.
+- **Path traversal/UI echo:** mitigado aceptando solo paths presentes en `tree.documents` backend-owned antes de pedir documento.
+- **Fugas de backend/env:** mitigado con adapter `server-only`, env privada y guardrail `verify:vault-server-only`.
+- **Responsive fino:** base apilable ya queda cubierta por CSS global; hardening completo sigue en 121.4.
+
+## Review requerida
+
+- Usopp: UI/UX, claridad del explorer, lector, responsive base y retirada del ruido editorial.
+- Chopper: server-only, read-only, no-leakage y Markdown/link sanitization.

--- a/scripts/check-vault-server-only.mjs
+++ b/scripts/check-vault-server-only.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/** Static safety check for Phase 12.4 Vault server-only integration. */
+/** Static safety check for Vault explorer + Markdown reader server-only integration. */
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
@@ -7,20 +7,28 @@ const repoRoot = process.cwd()
 const vaultHttpPath = join(repoRoot, 'apps/web/src/modules/vault/api/vault-http.ts')
 const vaultPagePath = join(repoRoot, 'apps/web/src/app/vault/page.tsx')
 const vaultClientPath = join(repoRoot, 'apps/web/src/app/vault/VaultClient.tsx')
+const vaultFixturePath = join(repoRoot, 'apps/web/src/modules/vault/view-models/vault-explorer.fixture.ts')
 
 const vaultHttp = readFileSync(vaultHttpPath, 'utf8')
 const vaultPage = readFileSync(vaultPagePath, 'utf8')
 const vaultClient = readFileSync(vaultClientPath, 'utf8')
+const vaultFixture = readFileSync(vaultFixturePath, 'utf8')
 const failures = []
 
 if (!vaultHttp.includes("import 'server-only'")) {
   failures.push('vault-http.ts must be server-only guarded')
 }
 if (!vaultHttp.includes("VAULT_API_BASE_URL_ENV = 'MUGIWARA_CONTROL_PANEL_API_URL'")) {
-  failures.push('vault-http.ts must use MUGIWARA_CONTROL_PANEL_API_URL')
+  failures.push('vault-http.ts must use private MUGIWARA_CONTROL_PANEL_API_URL')
 }
-if (vaultHttp.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL')) {
-  failures.push('vault-http.ts must not use public backend env')
+if (vaultHttp.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL') || vaultClient.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL')) {
+  failures.push('Vault frontend must not use public backend env')
+}
+if (!vaultHttp.includes("/api/v1/vault/tree") || !vaultHttp.includes("/api/v1/vault/documents/")) {
+  failures.push('vault-http.ts must consume tree and document reader endpoints')
+}
+if (!vaultHttp.includes('encodeURIComponent') || !vaultHttp.includes(".split('/')")) {
+  failures.push('vault-http.ts must encode document path by segment')
 }
 if (!vaultHttp.includes("parsed.protocol !== 'http:'") || !vaultHttp.includes("parsed.protocol !== 'https:'")) {
   failures.push('vault-http.ts must reject non-http(s) API base URLs')
@@ -34,14 +42,34 @@ if (!vaultPage.includes("export const dynamic = 'force-dynamic'")) {
 if (vaultPage.includes("'use client'")) {
   failures.push('vault/page.tsx must remain a server page')
 }
-if (!vaultPage.includes("apiState: 'fallback'") || !vaultPage.includes('apiErrorCode')) {
-  failures.push('vault/page.tsx must make fallback state observable')
+if (!vaultPage.includes("fetchVaultTree()") || !vaultPage.includes('fetchVaultDocument(selectedPath)')) {
+  failures.push('vault/page.tsx must load tree and selected Markdown document server-side')
+}
+if (!vaultPage.includes('isSafeSelectedPath') || !vaultPage.includes('tree.documents.some')) {
+  failures.push('vault/page.tsx must select documents only from backend-owned tree documents')
 }
 if (vaultClient.includes('process.env') || vaultClient.includes('MUGIWARA_CONTROL_PANEL_API_URL')) {
-  failures.push('VaultClient must not read server env')
+  failures.push('VaultClient must not read server env or backend URL')
 }
-if (!vaultClient.includes('Estado de API') || !vaultClient.includes('Vault en fallback saneado')) {
-  failures.push('VaultClient must show an explicit degraded API notice when using fallback')
+if (vaultClient.includes('dangerouslySetInnerHTML')) {
+  failures.push('VaultClient must not render Markdown with dangerouslySetInnerHTML')
+}
+if (!vaultClient.includes('getSafeHref') || !vaultClient.includes("parsed.protocol === 'https:'") || !vaultClient.includes("parsed.protocol === 'http:'")) {
+  failures.push('VaultClient must sanitize Markdown links')
+}
+if (!vaultClient.includes('parseConservativeMarkdown') || !vaultClient.includes('vault-markdown-table-wrap') || !vaultClient.includes('vault-markdown-frontmatter')) {
+  failures.push('VaultClient must use conservative Markdown rendering for tables/frontmatter/code')
+}
+for (const retiredText of ['Canon curado', 'Índice allowlisted', 'Lectura editorial', 'Pieza canónica', 'TOC sin entradas', 'Metadatos no disponibles']) {
+  if (vaultClient.includes(retiredText)) {
+    failures.push(`VaultClient must not keep retired editorial UI text: ${retiredText}`)
+  }
+}
+if (!vaultClient.includes('Vault · Solo lectura') || !vaultClient.includes('Explorador') || !vaultClient.includes('Documento seleccionado')) {
+  failures.push('VaultClient must expose the new explorer + reader UI contract')
+}
+if (!vaultFixture.includes('---') || !vaultFixture.includes('| Superficie | Estado |') || !vaultFixture.includes('\\`\\`\\`text')) {
+  failures.push('Vault fixture must exercise frontmatter, tables and fenced code')
 }
 
 if (failures.length > 0) {

--- a/scripts/visual-verify-baseline.mjs
+++ b/scripts/visual-verify-baseline.mjs
@@ -78,10 +78,10 @@ const routes = [
     path: '/vault',
     title: 'Vault',
     checks: [
-      'árbol, documento y metadatos colapsan sin forzar tres columnas en ancho medio',
-      'breadcrumbs, path y TOC no producen overflow horizontal',
-      'la lectura documental sigue siendo dominante frente a la ficha lateral',
-      'fallback documental local queda distinguido de lectura API real',
+      'explorador izquierdo y lector Markdown derecho se mantienen como dos columnas en desktop',
+      'árbol colapsable, documento activo y paths relativos no producen overflow horizontal',
+      'frontmatter, tablas, blockquotes, enlaces y code blocks se leen con comodidad',
+      'fallback documental local queda distinguido de lectura API real sin recuperar la UI editorial legacy',
     ],
   },
   {


### PR DESCRIPTION
## Resumen

Implementa la microfase 121.3 de #121: `/vault` pasa a ser explorador de archivos + lector Markdown.

## Cambios principales

- Sustituye la UI editorial legacy de `/vault` por dos paneles: explorador izquierdo y lector Markdown derecho.
- El frontend consume server-side/read-only:
  - `GET /api/v1/vault/tree`
  - `GET /api/v1/vault/documents/{document_path:path}`
- Mantiene `page.tsx` como server page dinámica y el adapter `vault-http.ts` con `import 'server-only'` y env privada `MUGIWARA_CONTROL_PANEL_API_URL`.
- Selecciona documentos solo si el `path` está presente en `tree.documents` backend-owned; si no, canonicaliza.
- Renderiza Markdown con parser conservador propio, sin `dangerouslySetInnerHTML`, preservando frontmatter como contenido y soportando headings/listas/tablas/blockquotes/código/enlaces saneados.
- Actualiza `verify:vault-server-only`, visual baseline y docs de frontend/handoff al contrato nuevo.

## Seguridad / privacidad

- Sin escritura sobre vault.
- Sin fetch browser directo al backend.
- Sin exposición de backend URL/env en `VaultClient`.
- Sin HTML raw ni links `javascript:`/`data:`.
- Sin rutas absolutas host en smoke HTML/DOM.

## Verify ejecutado por Zoro

- `npm run verify:vault-server-only`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build` — `/vault` dinámica (`ƒ /vault`)
- `PYTHONPATH=. pytest apps/api/tests/test_vault_api.py -q`
- `npm run verify:visual-baseline`
- `git diff --check`
- Smoke production local con API de la rama (`127.0.0.1:8012`) + web (`127.0.0.1:3018`): `/vault` 200, sin fallback, sin textos legacy, sin backend URL/env, sin `/srv/`/`/home/`, sin tracebacks.
- Browser smoke: selección de `Policy - Memory governance.md`, consola limpia, sin overflow horizontal, sin textos legacy ni fugas.

## Review solicitada

- **Usopp:** UI/UX, explorer estilo VS Code/Obsidian, jerarquía del lector Markdown, responsive base y retirada de ruido editorial.
- **Chopper:** server-only/read-only, sanitización Markdown/links/HTML, no-leakage, selección por paths backend-owned.

No toca runtime/deploy/config operativa persistente; Franky no aplica salvo que detectéis riesgo operativo no previsto.
