### PR TITLE
fix: close vault responsive hardening

### DIFF
--- a/.engram/issue-121-4-vault-closeout.md
+++ b/.engram/issue-121-4-vault-closeout.md
@@ -1,0 +1,23 @@
+# Engram closeout — Issue #121.4 Vault final closeout
+
+## Estado
+121.4 cierra el bloque #121 después de PR #125 con una microfase de hardening responsive, guardrail y docs/canon. No introduce endpoints, dependencias ni escritura nueva.
+
+## Decisiones técnicas
+- En tablet, `/vault` apila explorer y reader como dos paneles de ancho completo a partir de `max-width: 1100px`, evitando el layout intermedio anterior que dejaba el lector en una fila completa bajo un explorer estrecho.
+- En móvil, se prioriza la lectura: `vault-reader-panel` pasa antes que `vault-explorer-panel`; el árbol queda abajo con `max-height: 30vh` y scroll propio.
+- La indentación del árbol se capa con `clamp(8px, depth, 96px)` para evitar que carpetas profundas empujen el viewport.
+- Las tablas Markdown usan `min-width: min(520px, 100%)` y wrap interno para no forzar overflow horizontal global.
+- `verify:vault-server-only` queda como guardrail vivo del contrato 121.4, no solo de server-only/env.
+
+## Verify previsto/ejecutado
+- `npm run verify:vault-server-only`
+- `npm --prefix apps/web run typecheck`
+- `npm --prefix apps/web run build`
+- `PYTHONPATH=. pytest apps/api/tests/test_vault_api.py -q`
+- `npm run verify:visual-baseline`
+- `git diff --check`
+- Browser smoke local y Tailscale post-merge de `/vault`.
+
+## Follow-ups
+Si tras uso real el árbol del vault se vuelve demasiado denso, valorar búsqueda/filtro o recordar colapsados como issue separada. No forma parte de 121.4.

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -90,6 +90,10 @@ button {
   align-items: stretch;
 }
 
+.vault-browser-shell > * {
+  min-width: 0;
+}
+
 .vault-explorer-panel,
 .vault-reader-panel {
   min-width: 0;
@@ -104,6 +108,11 @@ button {
   grid-template-rows: auto minmax(0, 1fr);
   max-height: min(74vh, 760px);
   overflow: hidden;
+}
+
+.vault-explorer-panel .status-badge {
+  flex-shrink: 0;
+  max-width: 100%;
 }
 
 .vault-reader-panel {
@@ -156,6 +165,7 @@ button {
 }
 
 .vault-reader-meta span {
+  min-width: 0;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 999px;
   background: rgba(90, 157, 219, 0.1);
@@ -163,6 +173,7 @@ button {
   font-size: 12px;
   font-weight: 800;
   padding: 6px 9px;
+  overflow-wrap: anywhere;
 }
 
 .vault-explorer-tree {
@@ -304,7 +315,13 @@ button {
 .vault-markdown-table-wrap table {
   width: 100%;
   border-collapse: collapse;
-  min-width: 520px;
+  min-width: min(520px, 100%);
+}
+
+.vault-markdown-table-wrap th,
+.vault-markdown-table-wrap td {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .vault-markdown-table-wrap th,
@@ -712,7 +729,7 @@ button {
   }
 }
 
-@media (max-width: 959px) {
+@media (max-width: 1100px) {
   .app-shell {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -725,7 +742,11 @@ button {
   }
 
   .vault-explorer-panel {
-    max-height: 42vh;
+    max-height: 34vh;
+  }
+
+  .vault-panel-header {
+    align-items: center;
   }
 
   .vault-reader-header {
@@ -859,6 +880,61 @@ button {
     padding: 16px !important;
   }
 
+  .vault-browser-shell {
+    gap: 12px;
+  }
+
+  .vault-reader-panel {
+    order: 1;
+    padding: 14px;
+  }
+
+  .vault-explorer-panel {
+    order: 2;
+    max-height: 30vh;
+  }
+
+  .vault-panel-header {
+    padding: 14px 14px 10px;
+  }
+
+  .vault-panel-header,
+  .vault-reader-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .vault-explorer-tree {
+    padding: 8px;
+  }
+
+  .vault-tree-row {
+    grid-template-columns: 14px 18px minmax(0, 1fr);
+    gap: 5px;
+    font-size: 12px;
+    padding-bottom: 7px;
+    padding-right: 6px;
+    padding-top: 7px;
+  }
+
+  .vault-markdown-reader {
+    font-size: 14px;
+    line-height: 1.65;
+  }
+
+  .vault-markdown-reader h1 {
+    font-size: 24px;
+  }
+
+  .vault-markdown-reader h2 {
+    font-size: 21px;
+  }
+
+  .vault-markdown-code,
+  .vault-markdown-frontmatter {
+    padding: 12px;
+  }
+
   .usage-calendar-day__metrics,
   .usage-window-row__metrics,
   .usage-hermes-activity-summary,
@@ -869,16 +945,6 @@ button {
   .usage-window-row__main,
   .usage-hermes-activity-row__main {
     flex-direction: column;
-  }
-}
-
-@media (min-width: 960px) and (max-width: 1180px) {
-  .layout-grid--vault {
-    grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
-  }
-
-  .layout-grid--vault > :last-child {
-    grid-column: 1 / -1;
   }
 }
 

--- a/apps/web/src/app/vault/VaultClient.tsx
+++ b/apps/web/src/app/vault/VaultClient.tsx
@@ -298,7 +298,7 @@ function VaultExplorer({ nodes, selectedPath }: { nodes: VaultExplorerNode[]; se
         const isDirectory = node.kind === 'directory'
         const isCollapsed = collapsedDirectories.has(node.relative_path)
         const isActive = node.relative_path === selectedPath
-        const indent = `${8 + node.depth * 18}px`
+        const indent = `clamp(8px, ${8 + node.depth * 18}px, 96px)`
 
         if (isDirectory) {
           return (

--- a/docs/frontend-implementation-handoff.md
+++ b/docs/frontend-implementation-handoff.md
@@ -592,7 +592,8 @@ Los roles exactos pueden ajustarse al canon del proyecto, pero el slug + crest p
 ## 9.6 Vault
 ### Entregar
 - layout de dos paneles: explorador de archivos + lector Markdown
-- explorador estilo VS Code/Obsidian con carpetas colapsables, indentación, activo resaltado y scroll independiente
+- responsive 121.4: tablet apila explorador y lector a una columna completa; móvil prioriza el lector antes que el explorador y mantiene el árbol con altura acotada/scroll propio
+- explorador estilo VS Code/Obsidian con carpetas colapsables, indentación capada, activo resaltado y scroll independiente
 - lector Markdown legible con frontmatter, headings, listas, tablas, enlaces, blockquotes y código
 - adapter server-only sobre `GET /api/v1/vault/tree` y `GET /api/v1/vault/documents/{document_path:path}`
 - sin ficha externa de metadatos, sin TOC lateral obligatorio y sin callout editorial legacy

--- a/docs/frontend-ui-spec.md
+++ b/docs/frontend-ui-spec.md
@@ -730,7 +730,10 @@ Subtítulo: Explorador de archivos del vault canónico y lector Markdown renderi
 ### Estilo
 - explorador izquierdo cercano a VS Code/Obsidian: indentación, carpetas colapsables, activo claro y scroll independiente
 - lector derecho con ancho cómodo, buena legibilidad y soporte para tablas/código sin overflow horizontal
-- en tablet/mobile los paneles apilan; se prioriza lectura y se limita la altura del explorador
+- en tablet/mobile los paneles apilan; tablet baja explorador y lector a una columna completa sin huecos intermedios
+- en móvil se prioriza lectura: el lector queda antes que el explorador, y el explorador mantiene altura acotada con scroll propio
+- tablas/código/frontmatter deben mantener overflow interno o wrap seguro sin forzar ancho horizontal de página
+- la indentación del árbol debe estar capada para que carpetas profundas no empujen el viewport
 
 ### Patrón recomendado
 - header mínimo con `Vault · Solo lectura`

--- a/docs/observability-surface.md
+++ b/docs/observability-surface.md
@@ -72,6 +72,7 @@ Debe mostrar:
 - estructura navegable allowlisted
 - metadata de índice
 - documento markdown ya autorizado
+- UI explorador + lector Markdown responsive, con móvil priorizando lectura y sin overflow horizontal de tablas/código/frontmatter
 
 No debe mostrar:
 - ficheros ocultos
@@ -132,7 +133,9 @@ Formas documentadas de esta fase:
 - `memory.agent_summary`
 - `memory.agent_detail`
 - `vault.index`
-- `vault.document`
+- `vault.explorer_tree`
+- `vault.markdown_document`
+- `vault.document` legacy/transición
 - `mugiwara.card`
 - `mugiwara.profile`
 

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -175,6 +175,9 @@ npm run verify:skills-server-only
 3. `/vault` declara `export const dynamic = 'force-dynamic'`.
 4. Si la API falta, falla o devuelve un payload inválido, la página mantiene fixture documental saneado y muestra aviso explícito de estado degradado.
 5. El aviso no expone URL backend, rutas host, stack traces ni cuerpo de respuesta.
+6. Desde 121.3/121.4, `/vault` ya no consume el workspace legacy `GET /api/v1/vault` para la UI principal: usa `GET /api/v1/vault/tree` y `GET /api/v1/vault/documents/{document_path:path}`.
+7. La selección del documento se valida contra `tree.documents` backend-owned y el documento devuelto debe coincidir con `selectedPath` antes de renderizar.
+8. `VaultClient` no lee env ni backend URL, no usa `dangerouslySetInnerHTML`, sanea enlaces Markdown y mantiene overflow interno para tablas/código/frontmatter en móvil.
 
 Antes de cerrar cambios que toquen Vault config o fallback, ejecutar:
 

--- a/openspec/issue-121-4-vault-closeout-verify-checklist.md
+++ b/openspec/issue-121-4-vault-closeout-verify-checklist.md
@@ -1,0 +1,40 @@
+# Verify checklist — Issue #121.4 Vault closeout
+
+## Static / guardrails
+- [x] `npm run verify:vault-server-only` → passed.
+- [x] `npm run verify:visual-baseline` → checklist emitted.
+- [x] `git diff --check` → passed.
+
+## Web build
+- [x] `npm --prefix apps/web run typecheck` → passed.
+- [x] `npm --prefix apps/web run build` → passed; `/vault` dinámica (`ƒ /vault`).
+
+## Backend regression
+- [x] `PYTHONPATH=. pytest apps/api/tests/test_vault_api.py -q` → 10 passed.
+
+## Browser / HTML smoke local
+- [x] `/vault` responde 200 con API real de rama (`http://127.0.0.1:3022/vault` + API `127.0.0.1:8121`).
+- [x] Sin fallback visible cuando API real está activa.
+- [x] Sin textos legacy: `Canon curado`, `Índice allowlisted`, `Lectura editorial`, `Pieza canónica`, `TOC sin entradas`.
+- [x] Sin backend URL, `MUGIWARA_CONTROL_PANEL_API_URL`, `NEXT_PUBLIC`, rutas host ni `Traceback` en HTML/DOM visible.
+- [x] Sin overflow horizontal global en viewport disponible 1280×720 (`scrollWidth === clientWidth`).
+- [x] Explorer mantiene scroll interno acotado en árbol real.
+- [x] Guardrail CSS fija tablet/mobile: stack desde 1100px, lector antes que explorer en móvil y explorer `max-height: 30vh`.
+- [x] Tablas/código/frontmatter no fuerzan ancho horizontal global por contrato CSS (`min-width: min(520px, 100%)`, wrap interno).
+
+## Limitación del smoke responsive
+- El navegador Hermes disponible no permitió redimensionar viewport real desde la sesión browser. La evidencia responsive queda cubierta por CSS guardrail, build/typecheck y browser smoke real en 1280×720; Usopp debe revisar criterio visual de tablet/mobile en PR.
+
+## Review
+- [ ] PR comentada con handoff de Zoro.
+- [ ] Usopp invocado y comentario/review recibido.
+- [ ] Chopper invocado y comentario/review recibido.
+
+## Post-merge / producción privada
+- [ ] `main` actualizado tras merge.
+- [ ] `npm --prefix apps/web run build` desde `main`.
+- [ ] Reinicio `mugiwara-control-panel-web.service`.
+- [ ] Reinicio `mugiwara-control-panel-api.service` si el smoke requiere endpoint nuevo/reciente o API persistente pudiera estar stale.
+- [ ] Smoke Tailscale `http://<tailscale-ip>:3017/vault` con API real, sin fallback, sin fuga y sin overflow horizontal obvio.
+- [ ] Project Summary del vault actualizado y sincronizado.
+- [ ] #121 comentada/cerrada si todo queda cerrado.

--- a/openspec/issue-121-4-vault-closeout.md
+++ b/openspec/issue-121-4-vault-closeout.md
@@ -1,0 +1,60 @@
+# Issue #121.4 — Vault responsive, guardrails, docs y closeout
+
+## Objetivo
+Cerrar el bloque #121 después de PR #125 dejando `/vault` estable como explorador de archivos + lector Markdown, con responsive móvil/tablet endurecido, guardrail `verify:vault-server-only` alineado al contrato nuevo, documentación viva y canon actualizados.
+
+## Contexto
+- #121.1 cerró el contrato backend de árbol seguro.
+- #121.2 cerró el reader raw Markdown backend.
+- #121.3 / PR #125 sustituyó la UI legacy por explorer + reader y fue aprobada por Usopp + Chopper.
+- 121.4 no abre capacidades nuevas: no escritura, no búsqueda full-text, no editor, no endpoints nuevos.
+
+## Alcance
+- Endurecer layout responsive de `/vault`:
+  - tablet: una columna completa para explorer + reader, sin huecos intermedios.
+  - móvil: priorizar lectura colocando el lector antes que el explorador.
+  - explorador con altura acotada y scroll propio.
+  - indentación capada para árboles profundos.
+  - tablas/código/frontmatter sin overflow horizontal de página.
+- Actualizar `verify:vault-server-only` para fijar el contrato 121.4.
+- Actualizar docs vivas relevantes.
+- Actualizar Project Summary/canon del vault si el cierre cambia el estado canónico.
+- Ejecutar verify real y smoke Tailscale post-merge.
+- Comentar y cerrar #121 si todo queda cerrado.
+
+## Fuera de alcance
+- Escritura/edición del vault.
+- Crear/borrar/renombrar documentos.
+- Búsqueda full-text.
+- Nuevo backend, auth, runtime config o dependencias Markdown.
+- Tercer panel, TOC lateral obligatorio o ficha externa de metadata.
+
+## Cambios aplicados
+- `VaultClient` limita la indentación visual del árbol con `clamp(...)`.
+- CSS de `/vault` apila antes en tablet (`max-width: 1100px`) y elimina el layout intermedio que dejaba el lector en fila completa con hueco lateral.
+- En móvil (`max-width: 640px`) el lector tiene `order: 1` y el explorador `order: 2`, con explorer a `max-height: 30vh`.
+- Markdown tables pasan a `min-width: min(520px, 100%)` y celdas con `overflow-wrap:anywhere`.
+- Metadata, code/frontmatter y tree rows quedan con min-width/wrap/padding más seguros.
+- `scripts/check-vault-server-only.mjs` ahora comprueba path assertion, responsive 121.4 e invariantes de overflow.
+- Docs vivas actualizadas: `frontend-ui-spec`, `frontend-implementation-handoff`, `observability-surface`, `runtime-config`.
+
+## Definition of done
+- [x] Responsive móvil/tablet endurecido sin ampliar producto.
+- [x] Guardrail `verify:vault-server-only` actualizado.
+- [x] Docs vivas actualizadas.
+- [x] Verify local real ejecutado.
+- [x] PR con Usopp + Chopper si el diff UI/seguridad lo requiere.
+- [ ] PR mergeada a `main`.
+- [ ] Servicios persistentes reiniciados si hay cambio visible.
+- [ ] Smoke Tailscale de `/vault` post-merge.
+- [ ] Project Summary del vault actualizado/pusheado.
+- [ ] #121 comentada y cerrada.
+
+## Review routing
+- Usopp: obligatorio por responsive móvil/tablet visible.
+- Chopper: obligatorio porque se endurece `verify:vault-server-only`, no-leakage y reader Markdown.
+- Franky: no requerido salvo que aparezcan cambios de runtime/deploy/config operativa; esta microfase no los toca.
+
+## Riesgos
+- Browser smoke local puede no redimensionar todos los viewports; se compensa con checks DOM de overflow y CSS guardrail, pero se debe documentar cualquier límite.
+- Smoke Tailscale debe hacerse después de merge + build + restart de web/API si procede, para no validar un build viejo.

--- a/scripts/check-vault-server-only.mjs
+++ b/scripts/check-vault-server-only.mjs
@@ -13,6 +13,7 @@ const vaultHttp = readFileSync(vaultHttpPath, 'utf8')
 const vaultPage = readFileSync(vaultPagePath, 'utf8')
 const vaultClient = readFileSync(vaultClientPath, 'utf8')
 const vaultFixture = readFileSync(vaultFixturePath, 'utf8')
+const globalCss = readFileSync(join(repoRoot, 'apps/web/src/app/globals.css'), 'utf8')
 const failures = []
 
 if (!vaultHttp.includes("import 'server-only'")) {
@@ -67,6 +68,18 @@ for (const retiredText of ['Canon curado', 'Índice allowlisted', 'Lectura edito
 }
 if (!vaultClient.includes('Vault · Solo lectura') || !vaultClient.includes('Explorador') || !vaultClient.includes('Documento seleccionado')) {
   failures.push('VaultClient must expose the new explorer + reader UI contract')
+}
+if (!vaultPage.includes('document.relative_path !== selectedPath')) {
+  failures.push('vault/page.tsx must assert returned document path matches selectedPath')
+}
+if (!vaultClient.includes('clamp(8px') || !globalCss.includes('@media (max-width: 1100px)')) {
+  failures.push('Vault responsive contract must cap deep indentation and stack earlier for tablet')
+}
+if (!globalCss.includes('.vault-reader-panel') || !globalCss.includes('order: 1') || !globalCss.includes('.vault-explorer-panel') || !globalCss.includes('order: 2') || !globalCss.includes('max-height: 30vh')) {
+  failures.push('Vault mobile contract must prioritize the reader and keep explorer height bounded')
+}
+if (!globalCss.includes('min-width: min(520px, 100%)') || !globalCss.includes('.vault-markdown-table-wrap td')) {
+  failures.push('Vault Markdown tables must keep overflow internal and avoid forcing mobile page width')
 }
 if (!vaultFixture.includes('---') || !vaultFixture.includes('| Superficie | Estado |') || !vaultFixture.includes('\\`\\`\\`text')) {
   failures.push('Vault fixture must exercise frontmatter, tables and fenced code')


### PR DESCRIPTION
## Resumen
Cierra la microfase **121.4** del rediseño de `/vault` tras PR #125:

- endurece responsive tablet/mobile de `/vault` sin abrir features nuevas;
- apila explorer + reader desde tablet y prioriza el lector en móvil;
- acota altura/scroll del explorer e indentación de árbol profundo;
- evita que tablas/código/frontmatter fuercen overflow horizontal;
- actualiza `verify:vault-server-only` para fijar contrato 121.4;
- actualiza docs vivas y deja OpenSpec/Engram de closeout.

## Alcance
- UI/CSS responsive de `/vault`.
- Guardrail estático `scripts/check-vault-server-only.mjs`.
- Docs: `frontend-ui-spec`, `frontend-implementation-handoff`, `observability-surface`, `runtime-config`.
- OpenSpec/Engram de cierre.

## Fuera de alcance
- Escritura/edición del vault.
- Endpoints nuevos.
- Dependencias Markdown nuevas.
- Cambios de runtime/deploy/config operativa.

## Verify de Zoro
- `npm run verify:vault-server-only` ✅
- `npm --prefix apps/web run typecheck` ✅
- `npm --prefix apps/web run build` ✅ (`ƒ /vault` dinámica)
- `PYTHONPATH=. pytest apps/api/tests/test_vault_api.py -q` ✅ (10 passed)
- `npm run verify:visual-baseline` ✅
- `git diff --check` ✅
- Browser smoke local `/vault` con API real: 200, sin fallback visible, sin textos legacy, sin backend URL/env/rutas host/tracebacks en DOM visible, sin overflow horizontal global en viewport disponible 1280×720.

## Limitación conocida
El navegador Hermes disponible no permitió redimensionado real a 1024×768/390×844; por eso el responsive queda fijado por CSS + guardrail y pido revisión Usopp específica en tablet/mobile.

## Review requerida
- Usopp: UI/UX responsive y jerarquía lector/explorer.
- Chopper: no-leakage, server-only guardrail y superficie Markdown/read-only.

Closes #121 tras merge + smoke Tailscale + cierre de issue.
