### PR TITLE
feat: redesign git repos status cards

### DIFF
--- a/.engram/git-repos-status-cards-2026-04-30.md
+++ b/.engram/git-repos-status-cards-2026-04-30.md
@@ -1,0 +1,18 @@
+# Git repos status cards — 2026-04-30
+
+## Objetivo
+Reorientar `/git` desde una página de historial/diff poco útil para Pablo a un revisor de estado de repos Git locales.
+
+## Cambio
+- `/git` renderiza una card por repo allowlisteado.
+- Cada card muestra rama actual, ramas disponibles, conteo de cambios, conteo no trackeado y último commit con fecha/hora.
+- El último commit usa `<details>` y un cuadro `pre` para desplegar el mensaje saneado.
+- Por seguridad, el cuadro renderiza solo `commit.subject` del resumen backend; el cuerpo libre de commit sigue sin publicarse.
+- La página sigue siendo server-only y read-only: sin inputs, sin refs/rangos/revspecs, sin acciones Git, sin rutas host y sin diffs en la UI actual.
+
+## Verify esperado
+- `npm run verify:git-server-only`
+- `npm --prefix apps/web run typecheck`
+- `npm --prefix apps/web run build`
+- `git diff --check`
+- smoke visual/HTML de `/git` contra producción o servidor local antes de merge/despliegue.

--- a/apps/web/src/app/git/page.tsx
+++ b/apps/web/src/app/git/page.tsx
@@ -1,21 +1,15 @@
 import type { ReactNode } from 'react'
 
-import { redirect } from 'next/navigation'
-
-import type { GitBranchList, GitCommitDetail, GitCommitDiff, GitCommitList, GitCommitSummary, GitRepoIndex, GitRepoSummary } from '@contracts/read-models'
+import type { GitBranchList, GitCommitList, GitCommitSummary, GitRepoIndex, GitRepoSummary } from '@contracts/read-models'
 
 import {
   fetchGitBranches,
-  fetchGitCommitDetail,
-  fetchGitCommitDiff,
   fetchGitCommits,
   fetchGitRepos,
   GitApiError,
 } from '@/modules/git/api/git-http'
 import {
   gitBranchListFixture,
-  gitCommitDetailFixture,
-  gitCommitDiffFixture,
   gitCommitListFixture,
   gitRepoIndexFixture,
 } from '@/modules/git/view-models/git-surface.fixture'
@@ -36,168 +30,85 @@ type GitPageNotice = {
   detail?: string
 }
 
-type GitPageData = {
-  repoIndex: GitRepoIndex
-  commits: GitCommitList
+type GitRepoCardSnapshot = {
+  repo: GitRepoSummary
   branches: GitBranchList
-  commitDetail: GitCommitDetail
-  commitDiff: GitCommitDiff
-  notice: GitPageNotice | null
-  selection: {
-    repoId: string | null
-    sha: string | null
-    requestedRepoAccepted: boolean
-    requestedShaAccepted: boolean
-  }
+  commits: GitCommitList
+  latestCommit: GitCommitSummary | null
+  sourceState: 'ready' | 'unknown'
 }
 
-type GitPageSearchParams = Promise<Record<string, string | string[] | undefined>>
+type GitPageData = {
+  repoIndex: GitRepoIndex
+  cards: GitRepoCardSnapshot[]
+  notice: GitPageNotice | null
+}
 
-type GitPageProps = {
-  searchParams?: GitPageSearchParams
+function makeFallbackCard(repo: GitRepoSummary): GitRepoCardSnapshot {
+  return {
+    repo,
+    branches: repo.repo_id === gitBranchListFixture.repo_id ? gitBranchListFixture : { ...gitBranchListFixture, repo_id: repo.repo_id },
+    commits: repo.repo_id === gitCommitListFixture.repo_id ? gitCommitListFixture : { ...gitCommitListFixture, repo_id: repo.repo_id, commits: [] },
+    latestCommit: repo.repo_id === gitCommitListFixture.repo_id ? (gitCommitListFixture.commits[0] ?? null) : null,
+    sourceState: 'unknown',
+  }
 }
 
 function getFallbackData(notice: GitPageNotice): GitPageData {
-  const fallbackRepo = gitRepoIndexFixture.repos[0] ?? null
-  const fallbackCommit = gitCommitListFixture.commits[0] ?? null
-
   return {
     repoIndex: gitRepoIndexFixture,
-    commits: gitCommitListFixture,
-    branches: gitBranchListFixture,
-    commitDetail: gitCommitDetailFixture,
-    commitDiff: gitCommitDiffFixture,
+    cards: gitRepoIndexFixture.repos.map(makeFallbackCard),
     notice,
-    selection: {
-      repoId: fallbackRepo?.repo_id ?? null,
-      sha: fallbackCommit?.sha ?? null,
-      requestedRepoAccepted: false,
-      requestedShaAccepted: false,
-    },
   }
 }
 
-function getSingleSearchParam(searchParams: Record<string, string | string[] | undefined>, key: 'repo_id' | 'sha') {
-  const value = searchParams[key]
-  if (typeof value === 'string') return value
-  if (Array.isArray(value)) return value[0]
-  return undefined
-}
+async function getRepoCardSnapshot(repo: GitRepoSummary): Promise<GitRepoCardSnapshot> {
+  try {
+    const [commitsResponse, branchesResponse] = await Promise.all([
+      fetchGitCommits(repo.repo_id),
+      fetchGitBranches(repo.repo_id),
+    ])
 
-function hasUnsupportedGitSearchParams(searchParams: Record<string, string | string[] | undefined>) {
-  return Object.keys(searchParams).some((key) => key !== 'repo_id' && key !== 'sha')
-}
-
-function isNextRedirectError(error: unknown) {
-  return Boolean(
-    error &&
-    typeof error === 'object' &&
-    'digest' in error &&
-    String((error as { digest?: unknown }).digest).startsWith('NEXT_REDIRECT'),
-  )
-}
-
-async function getGitPageData(searchParams: Record<string, string | string[] | undefined>): Promise<GitPageData> {
-  const requestedRepoId = getSingleSearchParam(searchParams, 'repo_id')
-  const requestedSha = getSingleSearchParam(searchParams, 'sha')
-  const unsupportedSearchParams = hasUnsupportedGitSearchParams(searchParams)
-
-  if (unsupportedSearchParams) {
-    redirect('/git')
+    return {
+      repo,
+      branches: branchesResponse.data,
+      commits: commitsResponse.data,
+      latestCommit: commitsResponse.data.commits[0] ?? null,
+      sourceState: commitsResponse.status === 'ready' && branchesResponse.status === 'ready' ? 'ready' : 'unknown',
+    }
+  } catch {
+    return makeFallbackCard(repo)
   }
+}
 
+async function getGitPageData(): Promise<GitPageData> {
   try {
     const reposResponse = await fetchGitRepos()
     const repoIndex = reposResponse.data
-    const selectedRepo = repoIndex.repos.find((repo) => repo.repo_id === requestedRepoId) ?? repoIndex.repos[0]
-    const requestedRepoAccepted = Boolean(requestedRepoId && selectedRepo?.repo_id === requestedRepoId)
 
-    if (reposResponse.status !== 'ready' || !selectedRepo) {
-      if (requestedRepoId || requestedSha) {
-        redirect('/git')
-      }
-
+    if (reposResponse.status !== 'ready' || repoIndex.repos.length === 0) {
       return getFallbackData({
         status: 'revision',
-        title: 'Repos Git en modo fallback local',
-        description: 'La API respondió sin repositorio Git listo. Se muestra un snapshot local saneado para conservar la navegación, sin lectura real ni tiempo real.',
+        title: 'Revisor de repos Git en modo fallback local',
+        description: 'La API respondió sin repositorio Git listo. Se muestra un snapshot local saneado, sin lectura real ni tiempo real.',
         detail: `Estado técnico: ${reposResponse.status}`,
       })
     }
 
-    if (requestedRepoId && !requestedRepoAccepted) {
-      redirect(gitRepoHref(selectedRepo.repo_id))
-    }
-
-    const commitsResponse = await fetchGitCommits(selectedRepo.repo_id)
-    const branchesResponse = await fetchGitBranches(selectedRepo.repo_id)
-    const selectedCommit = commitsResponse.data.commits.find((commit) => commit.sha === requestedSha) ?? commitsResponse.data.commits[0]
-    const requestedShaAccepted = Boolean(requestedSha && selectedCommit?.sha === requestedSha)
-
-    if (!selectedCommit || commitsResponse.status !== 'ready') {
-      if (requestedSha) {
-        redirect(gitRepoHref(selectedRepo.repo_id))
-      }
-
-      return {
-        repoIndex,
-        commits: commitsResponse.data,
-        branches: branchesResponse.data,
-        commitDetail: { ...gitCommitDetailFixture, repo_id: selectedRepo.repo_id, commit: null, files: [], source_state: 'unknown' },
-        commitDiff: { ...gitCommitDiffFixture, repo_id: selectedRepo.repo_id, sha: '', files: [], omitted_files_count: 0, source_state: 'unknown' },
-        notice: {
-          status: 'revision',
-          title: 'Historial Git no disponible para el repo seleccionado',
-          description: 'La página mantiene índice y ramas saneadas, pero no muestra detalle ni diff porque el backend no devolvió commits listos.',
-          detail: `Estado técnico: ${commitsResponse.status}`,
-        },
-        selection: {
-          repoId: selectedRepo.repo_id,
-          sha: null,
-          requestedRepoAccepted,
-          requestedShaAccepted: false,
-        },
-      }
-    }
-
-    if (unsupportedSearchParams) {
-      redirect(gitCommitHref(selectedRepo.repo_id, selectedCommit.sha))
-    }
-
-    if (requestedSha && !requestedShaAccepted) {
-      redirect(gitRepoHref(selectedRepo.repo_id))
-    }
-
-    const detailResponse = await fetchGitCommitDetail(selectedRepo.repo_id, selectedCommit.sha)
-    const diffResponse = await fetchGitCommitDiff(selectedRepo.repo_id, selectedCommit.sha)
+    const cards = await Promise.all(repoIndex.repos.map(async (repo) => getRepoCardSnapshot(repo)))
 
     return {
       repoIndex,
-      commits: commitsResponse.data,
-      branches: branchesResponse.data,
-      commitDetail: detailResponse.data,
-      commitDiff: diffResponse.data,
+      cards,
       notice: null,
-      selection: {
-        repoId: selectedRepo.repo_id,
-        sha: selectedCommit.sha,
-        requestedRepoAccepted,
-        requestedShaAccepted,
-      },
     }
   } catch (error) {
-    if (isNextRedirectError(error)) throw error
-
-    if (requestedRepoId || requestedSha) {
-      redirect('/git')
-    }
-
     const apiError = error instanceof GitApiError ? error : null
     return getFallbackData({
       status: apiError?.code === 'not_configured' ? 'revision' : 'incidencia',
       title:
         apiError?.code === 'not_configured'
-          ? 'Repos Git en modo fallback local'
+          ? 'Revisor de repos Git en modo fallback local'
           : apiError?.code === 'invalid_config'
             ? 'Configuración server-only de Repos Git inválida'
             : 'API Git no disponible',
@@ -210,16 +121,6 @@ async function getGitPageData(searchParams: Record<string, string | string[] | u
   }
 }
 
-function gitRepoHref(repoId: string) {
-  const params = new URLSearchParams({ repo_id: repoId })
-  return `/git?${params.toString()}`
-}
-
-function gitCommitHref(repoId: string, sha: string) {
-  const params = new URLSearchParams({ repo_id: repoId, sha })
-  return `/git?${params.toString()}`
-}
-
 function formatTimestamp(value: string | null | undefined) {
   if (!value) return 'Sin fecha'
   const date = new Date(value)
@@ -227,8 +128,9 @@ function formatTimestamp(value: string | null | undefined) {
   return new Intl.DateTimeFormat('es-ES', { dateStyle: 'short', timeStyle: 'short' }).format(date)
 }
 
-function statusForRepo(repo: GitRepoSummary): AppStatus {
-  if (repo.status.source_state !== 'ready' || repo.status.working_tree === 'unknown') return 'sin-datos'
+function statusForRepo(snapshot: GitRepoCardSnapshot): AppStatus {
+  const repo = snapshot.repo
+  if (snapshot.sourceState !== 'ready' || repo.status.source_state !== 'ready' || repo.status.working_tree === 'unknown') return 'sin-datos'
   if (repo.status.working_tree === 'dirty') return 'revision'
   return 'operativo'
 }
@@ -239,14 +141,9 @@ function workingTreeCopy(repo: GitRepoSummary) {
   return 'Estado no disponible'
 }
 
-function renderShaGroups(sha: string) {
-  const groups = sha.match(/.{1,8}/g) ?? [sha]
-
-  return groups.map((group, index) => (
-    <span key={`${group}-${index}`} className="git-sha-group">
-      {group}
-    </span>
-  ))
+function valueOrDash(value: number | string | null | undefined) {
+  if (value === null || value === undefined || value === '') return '—'
+  return value
 }
 
 function Pill({ children }: { children: ReactNode }) {
@@ -269,76 +166,110 @@ function Pill({ children }: { children: ReactNode }) {
   )
 }
 
-function RepoCard({ repo, selected }: { repo: GitRepoSummary; selected: boolean }) {
+function BranchList({ branches }: { branches: GitBranchList }) {
+  const visibleBranches = branches.branches.slice(0, 8)
+  const hiddenCount = Math.max(branches.branches.length - visibleBranches.length, 0)
+
+  if (branches.branches.length === 0) {
+    return <p style={{ margin: 0, color: appTheme.colors.textMuted }}>Sin ramas disponibles en esta lectura.</p>
+  }
+
   return (
-    <a className="git-selector-link" href={gitRepoHref(repo.repo_id)} aria-current={selected ? 'true' : undefined}>
-      <SurfaceCard title={repo.label} eyebrow={selected ? 'Repo seleccionado' : 'Repo allowlisteado'} accent={selected ? 'sky' : undefined}>
-        <div style={{ display: 'grid', gap: '12px', minWidth: 0 }}>
-          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-            {selected ? <StatusBadge status="operativo" label="Seleccionado" /> : null}
-            <StatusBadge status={statusForRepo(repo)} label={workingTreeCopy(repo)} />
-            <Pill>{repo.scope}</Pill>
-            <Pill>repo_id: {repo.repo_id}</Pill>
-          </div>
-          <p className="text-break" style={{ margin: 0, color: appTheme.colors.textSecondary, lineHeight: 1.6 }}>
-            Solo lectura. La UI no conoce rutas del host ni remotes; usa únicamente el identificador lógico devuelto por backend.
-          </p>
-          <dl className="git-metric-list">
-            <div>
-              <dt>Rama actual</dt>
-              <dd>{repo.status.current_branch ?? 'No disponible'}</dd>
-            </div>
-            <div>
-              <dt>Cambios</dt>
-              <dd>{repo.status.changed_files_count ?? '—'}</dd>
-            </div>
-            <div>
-              <dt>No trackeados</dt>
-              <dd>{repo.status.untracked_files_count ?? '—'}</dd>
-            </div>
-          </dl>
-        </div>
-      </SurfaceCard>
-    </a>
+    <div className="git-branch-chip-list" aria-label="Ramas disponibles">
+      {visibleBranches.map((branch) => (
+        <span key={branch.sha + branch.name} className={`git-branch-chip${branch.current ? ' git-branch-chip--current' : ''}`}>
+          <span className="text-break">{branch.name}</span>
+          {branch.current ? <strong>actual</strong> : null}
+        </span>
+      ))}
+      {hiddenCount > 0 ? <Pill>+{hiddenCount} más</Pill> : null}
+    </div>
   )
 }
 
-function CommitItem({ commit, selected, repoId }: { commit: GitCommitSummary; selected: boolean; repoId: string }) {
+function LatestCommit({ commit }: { commit: GitCommitSummary | null }) {
+  if (!commit) {
+    return <p style={{ margin: 0, color: appTheme.colors.textMuted }}>Sin último commit disponible en esta lectura.</p>
+  }
+
   return (
-    <li className={`git-commit-row${selected ? ' git-commit-row--selected' : ''}`}>
-      <a className="git-selector-link git-commit-link" href={gitCommitHref(repoId, commit.sha)} aria-current={selected ? 'true' : undefined}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap', minWidth: 0 }}>
-          <strong className="text-break" style={{ color: appTheme.colors.textPrimary }}>{commit.subject}</strong>
-          <code className="git-inline-code">{commit.short_sha}</code>
-        </div>
-        <p className="text-break" style={{ margin: '8px 0 0', color: appTheme.colors.textSecondary }}>
-          {commit.author_name} · {formatTimestamp(commit.committed_at)}
+    <details className="git-commit-message">
+      <summary>
+        <span>Último commit</span>
+        <strong>{formatTimestamp(commit.committed_at)}</strong>
+        <code className="git-inline-code">{commit.short_sha}</code>
+      </summary>
+      <div className="git-commit-message__body">
+        <p style={{ margin: 0, color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 800, letterSpacing: '0.08em', textTransform: 'uppercase' }}>
+          Mensaje del commit
         </p>
-        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginTop: '10px' }}>
-          {selected ? <StatusBadge status="operativo" label="Commit seleccionado" /> : null}
+        <pre className="git-commit-message__text">{commit.subject}</pre>
+        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+          <Pill>Autor: {commit.author_name}</Pill>
           <Pill>Mugiwara-Agent: {commit.trailers.mugiwara_agent ?? 'sin trailer'}</Pill>
           <Pill>Signed-off-by: {commit.trailers.signed_off_by ? 'presente' : 'sin trailer'}</Pill>
         </div>
-      </a>
-    </li>
+      </div>
+    </details>
   )
 }
 
-export default async function GitPage({ searchParams }: GitPageProps) {
-  const resolvedSearchParams = searchParams ? await searchParams : {}
-  const { repoIndex, commits, branches, commitDetail, commitDiff, notice, selection } = await getGitPageData(resolvedSearchParams)
-  const selectedRepo = repoIndex.repos.find((repo) => repo.repo_id === selection.repoId) ?? repoIndex.repos[0]
-  const selectedCommit = commitDetail.commit ?? commits.commits.find((commit) => commit.sha === selection.sha) ?? commits.commits[0] ?? null
+function RepoStatusCard({ snapshot }: { snapshot: GitRepoCardSnapshot }) {
+  const { repo, branches, latestCommit } = snapshot
+
+  return (
+    <SurfaceCard title={repo.label} eyebrow="Estado local por repo" accent={statusForRepo(snapshot) === 'revision' ? 'warning' : 'sky'}>
+      <article className="git-repo-status-card">
+        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+          <StatusBadge status={statusForRepo(snapshot)} label={workingTreeCopy(repo)} />
+          <Pill>{repo.scope}</Pill>
+          <Pill>repo_id: {repo.repo_id}</Pill>
+        </div>
+
+        <dl className="git-metric-list git-metric-list--repo-card">
+          <div>
+            <dt>Rama actual</dt>
+            <dd>{valueOrDash(repo.status.current_branch)}</dd>
+          </div>
+          <div>
+            <dt>Ramas disponibles</dt>
+            <dd>{branches.branches.length}</dd>
+          </div>
+          <div>
+            <dt>Cambios</dt>
+            <dd>{valueOrDash(repo.status.changed_files_count)}</dd>
+          </div>
+          <div>
+            <dt>No trackeado</dt>
+            <dd>{valueOrDash(repo.status.untracked_files_count)}</dd>
+          </div>
+        </dl>
+
+        <div className="git-repo-status-card__section">
+          <h2>Ramas disponibles</h2>
+          <BranchList branches={branches} />
+        </div>
+
+        <div className="git-repo-status-card__section">
+          <h2>Último commit desplegable</h2>
+          <LatestCommit commit={latestCommit} />
+        </div>
+      </article>
+    </SurfaceCard>
+  )
+}
+
+export default async function GitPage() {
+  const { repoIndex, cards, notice } = await getGitPageData()
   const isSnapshotMode = Boolean(notice)
-  const hasDenseBranches = branches.branches.length > 8
 
   return (
     <>
       <PageHeader
         eyebrow="Repos Git"
-        title="Repos Git"
-        subtitle="Lectura server-only de repositorios allowlisteados con selección controlada por enlaces: historial, ramas locales, detalle de commit y diff histórico saneado. Sin operaciones mutables ni rutas cliente."
-        detailPills={['Solo lectura', 'repo_id/SHA backend-owned', 'Selección controlada', 'Diff redactado/truncado/omitido']}
+        title="Revisor de repos Git locales"
+        subtitle="Una card por repo allowlisteado con rama actual, ramas disponibles, cambios, no trackeado y último commit desplegable. Lectura server-only, sin acciones Git y sin rutas del host."
+        detailPills={['Solo lectura', 'Estado local por repo', 'Último commit desplegable', 'Sin operaciones mutables']}
       />
 
       {notice ? (
@@ -356,7 +287,7 @@ export default async function GitPage({ searchParams }: GitPageProps) {
       <StatePanel
         status="revision"
         title="Frontera Git bloqueada en modo read-only"
-        description="Esta pantalla no expone operaciones mutables, selectores arbitrarios ni diffs de cambios no confirmados. El diff visible procede solo de commits ya seleccionados por SHA backend-owned y puede estar redactado, truncado u omitido."
+        description="La pantalla revisa estado local de repos allowlisteados sin operaciones mutables, sin selectores arbitrarios y sin publicar rutas del host. El mensaje desplegable usa solo el asunto saneado del último commit expuesto por backend."
         eyebrow="Guardrail UI"
       >
         <SourceStatePills
@@ -365,116 +296,19 @@ export default async function GitPage({ searchParams }: GitPageProps) {
             { label: 'Sin rutas host', tone: 'connected' },
             { label: 'Sin texto libre de commits', tone: 'connected' },
             { label: 'Solo repos allowlisteados', tone: 'connected' },
-            { label: 'Solo SHAs listados por backend', tone: 'connected' },
-            { label: 'Diff histórico saneado', tone: 'fallback' },
           ]}
         />
       </StatePanel>
 
-      <StatePanel
-        status="operativo"
-        title="Selección controlada"
-        description="Repo y commit se eligen con enlaces server-side. La página solo acepta repo_id existentes en el índice backend-owned y SHA presentes en el historial cargado del repo seleccionado; cualquier parámetro inválido se ignora sin eco en la UI."
-        detail={`Repo seleccionado: ${selectedRepo?.label ?? 'sin repo'} · Commit seleccionado: ${selectedCommit?.short_sha ?? 'sin commit'}`}
-        eyebrow="Selector server-only"
-      >
-        <SourceStatePills
-          items={[
-            { label: selection.requestedRepoAccepted ? 'repo_id aceptado' : 'repo_id por defecto saneado', tone: 'connected' },
-            { label: selection.requestedShaAccepted ? 'SHA aceptado' : 'SHA por defecto saneado', tone: 'connected' },
-          ]}
-        />
-      </StatePanel>
-
-      <section className="section-block layout-grid layout-grid--cards-280" aria-label="Repositorios Git allowlisteados">
-        {repoIndex.repos.map((repo) => (
-          <RepoCard key={repo.repo_id} repo={repo} selected={repo.repo_id === selectedRepo?.repo_id} />
+      <section className="section-block layout-grid layout-grid--cards-280" aria-label="Cards de estado de repos Git locales">
+        {cards.map((snapshot) => (
+          <RepoStatusCard key={snapshot.repo.repo_id} snapshot={snapshot} />
         ))}
       </section>
 
-      <section className="section-block layout-grid layout-grid--content-aside" aria-label="Historial y ramas Git">
-        <SurfaceCard title="Historial reciente" eyebrow={isSnapshotMode ? 'Commits del snapshot' : 'Commits backend-owned'} accent="gold">
-          <ol className="git-commit-list">
-            {commits.commits.map((commit) => (
-              <CommitItem key={commit.sha} commit={commit} repoId={selectedRepo?.repo_id ?? commits.repo_id} selected={commit.sha === selectedCommit?.sha} />
-            ))}
-          </ol>
-          <p style={{ margin: '14px 0 0', color: appTheme.colors.textMuted, fontSize: '13px', lineHeight: 1.6 }}>
-            El cuerpo libre del commit no se renderiza. Los trailers se muestran como campos allowlisteados.
-          </p>
-        </SurfaceCard>
-
-        <SurfaceCard title="Ramas locales" eyebrow="Sin refs arbitrarias" accent="sky">
-          <div style={{ display: 'grid', gap: '10px', minWidth: 0 }}>
-            <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
-              Rama actual: <strong>{branches.current_branch ?? 'No disponible'}</strong>
-            </p>
-            <p style={{ margin: 0, color: appTheme.colors.textMuted, fontSize: '13px', lineHeight: 1.5 }}>
-              {branches.branches.length} rama(s) locales. {hasDenseBranches ? 'Vista compacta con scroll interno para mantener la página escaneable.' : 'Lista completa en lectura compacta.'}
-            </p>
-            <ul className={`git-branch-list${hasDenseBranches ? ' git-branch-list--dense' : ''}`}>
-              {branches.branches.length > 0 ? branches.branches.map((branch) => (
-                <li key={branch.sha + branch.name} className="git-branch-row">
-                  <span className="text-break">{branch.name}</span>
-                  <code className="git-inline-code">{branch.short_sha}</code>
-                  {branch.current ? <StatusBadge status="operativo" label="actual" /> : null}
-                </li>
-              )) : <li style={{ color: appTheme.colors.textMuted }}>Sin ramas disponibles en esta lectura.</li>}
-            </ul>
-          </div>
-        </SurfaceCard>
-      </section>
-
-      <section className="section-block layout-grid layout-grid--content-aside" aria-label="Detalle de commit y diff seguro">
-        <SurfaceCard title="Detalle de commit" eyebrow="SHA backend-owned" accent="success">
-          {selectedCommit ? (
-            <div style={{ display: 'grid', gap: '12px', minWidth: 0 }}>
-              <code className="git-block-code git-sha-code" aria-label={`SHA completo ${selectedCommit.sha}`}>{renderShaGroups(selectedCommit.sha)}</code>
-              <p className="text-break" style={{ margin: 0, color: appTheme.colors.textPrimary, fontWeight: 800 }}>{selectedCommit.subject}</p>
-              <dl className="git-metric-list">
-                <div><dt>Autor</dt><dd>{selectedCommit.author_name}</dd></div>
-                <div><dt>Fecha</dt><dd>{formatTimestamp(selectedCommit.committed_at)}</dd></div>
-                <div><dt>Archivos</dt><dd>{commitDetail.files.length}</dd></div>
-              </dl>
-              <ul className="git-file-list">
-                {commitDetail.files.map((file, index) => (
-                  <li key={`${file.path ?? 'omitted'}-${index}`} className="git-file-row">
-                    <span className="text-break">{file.omitted ? 'Archivo omitido por seguridad' : file.path ?? 'Path no publicado'}</span>
-                    <span>{file.change_type}</span>
-                    <span>{file.binary ? 'binario' : `${file.additions ?? '—'}+ / ${file.deletions ?? '—'}-`}</span>
-                    {file.omitted ? <StatusBadge status="revision" label={file.omitted_reason ?? 'omitido'} /> : null}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ) : (
-            <p style={{ margin: 0, color: appTheme.colors.textMuted }}>Sin commit seleccionado por backend.</p>
-          )}
-        </SurfaceCard>
-
-        <SurfaceCard title="Diff seguro" eyebrow="Redactado / truncado / omitido" accent={commitDiff.redacted || commitDiff.truncated || commitDiff.omitted_files_count > 0 ? 'warning' : 'sky'}>
-          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginBottom: '12px' }}>
-            <StatusBadge status={commitDiff.redacted ? 'revision' : 'operativo'} label={commitDiff.redacted ? 'Redactado' : 'Sin redacciones'} />
-            <StatusBadge status={commitDiff.truncated ? 'stale' : 'operativo'} label={commitDiff.truncated ? 'Truncado' : 'Dentro de límites'} />
-            <Pill>Omitidos: {commitDiff.omitted_files_count}</Pill>
-          </div>
-          <div className="git-diff-panel">
-            {commitDiff.files.length > 0 ? commitDiff.files.map((file, index) => (
-              <div key={`${file.path ?? 'omitted'}-${index}`} className="git-diff-file">
-                <div className="git-diff-file__header">
-                  <strong className="text-break">{file.omitted ? 'Archivo omitido por seguridad' : file.path ?? 'Path no publicado'}</strong>
-                  <span>{file.truncated ? 'truncado' : 'límite OK'} · {file.redacted ? 'redactado' : 'sin redacción'}</span>
-                </div>
-                <p style={{ margin: 0, color: appTheme.colors.textMuted, lineHeight: 1.6 }}>
-                  {file.omitted
-                    ? `Contenido omitido: ${file.omitted_reason ?? 'política de seguridad'}`
-                    : `Contenido del diff omitido en frontend; ${file.lines.length} línea(s) recibida(s) del backend saneado.`}
-                </p>
-              </div>
-            )) : <p style={{ margin: 0, color: appTheme.colors.textMuted }}>Sin diff disponible en esta lectura.</p>}
-          </div>
-        </SurfaceCard>
-      </section>
+      <p style={{ margin: '4px 0 0', color: appTheme.colors.textMuted, fontSize: '13px', lineHeight: 1.6 }}>
+        {repoIndex.repos.length} repo(s) Git en lectura {isSnapshotMode ? 'snapshot saneada' : 'server-only'}.
+      </p>
     </>
   )
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1034,6 +1034,102 @@ button {
   padding: 12px;
 }
 
+.git-repo-status-card {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+}
+
+.git-metric-list--repo-card {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.git-repo-status-card__section {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.git-repo-status-card__section h2 {
+  margin: 0;
+  color: #9aa7bd;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.git-branch-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+}
+
+.git-branch-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  padding: 6px 10px;
+  color: #d9e4f2;
+  background: rgba(255, 255, 255, 0.04);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.git-branch-chip--current {
+  border-color: rgba(129, 199, 132, 0.55);
+  background: rgba(129, 199, 132, 0.12);
+}
+
+.git-branch-chip strong {
+  color: #81c784;
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.git-commit-message {
+  min-width: 0;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.16);
+  padding: 12px;
+}
+
+.git-commit-message summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  cursor: pointer;
+  color: #d9e4f2;
+  font-weight: 900;
+}
+
+.git-commit-message__body {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+  min-width: 0;
+}
+
+.git-commit-message__text {
+  margin: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(0, 0, 0, 0.28);
+  color: #f8fafc;
+  padding: 12px;
+  font: inherit;
+  line-height: 1.55;
+}
+
 .git-commit-row--selected {
   border-color: rgba(232, 181, 106, 0.55);
   background: rgba(232, 181, 106, 0.08);

--- a/apps/web/src/modules/AGENTS.md
+++ b/apps/web/src/modules/AGENTS.md
@@ -9,5 +9,5 @@ Features y módulos funcionales del frontend (dashboard, mugiwaras, skills, memo
 - **Vigilar `.gitignore`** y no subir mocks, capturas o outputs sensibles no saneados.
 - `usage`: Usage/Codex quota read-only frontend consuming server-only current snapshot, calendar, dedicated five-hour windows and aggregated Hermes activity adapters; no client-side backend URL or Hermes profiles root exposure.
 - `system`: adapter frontend server-only para `GET /api/v1/system/metrics` y view-model del header global; sin fetch de navegador, sin `NEXT_PUBLIC_*`, sin URL backend ni errores crudos en cliente.
-- `git`: página `/git` (`Repos Git`) con adapter server-only para repositorios Git backend-owned; solo lectura, solo `repo_id`/SHA de backend, sin rutas cliente, sin acciones Git, sin working-tree diff y con diff histórico redactado/truncado/omitido.
+- `git`: página `/git` (`Repos Git`) con adapter server-only para repositorios Git backend-owned; solo lectura, una card por repo con rama actual, ramas disponibles, cambios, no trackeado y último commit desplegable; sin rutas cliente, sin acciones Git ni diffs en la UI actual.
 - Si nace un módulo nuevo, documentarlo aquí y en docs.

--- a/apps/web/src/modules/git/AGENTS.md
+++ b/apps/web/src/modules/git/AGENTS.md
@@ -1,14 +1,14 @@
 # AGENTS.md — apps/web/src/modules/git
 
 ## Rol
-Módulo frontend read-only para la página `/git` (`Repos Git`).
+Módulo frontend read-only para la página `/git` (`Repos Git`), actualmente orientada a revisar estado local de repositorios Git allowlisteados mediante una card por repo.
 
 ## Reglas
 - El adapter HTTP debe ser `server-only` y usar únicamente `MUGIWARA_CONTROL_PANEL_API_URL` en servidor.
-- El cliente/UI solo puede operar con `repo_id` y SHA completo devueltos por backend; no paths, refs, rangos, revspecs ni discovery arbitrario. En 40.5, la `Selección controlada` acepta `searchParams.repo_id` solo si existe en `repoIndex.repos` y `searchParams.sha` solo si existe en `commits.commits` del repo seleccionado.
+- El cliente/UI solo puede operar con `repo_id` y datos devueltos por backend; no paths, refs, rangos, revspecs ni discovery arbitrario.
 - No introducir acciones Git: checkout/reset/commit/push/pull/fetch/stash/merge/rebase.
-- 40.4 no muestra working-tree diff; solo índice, commits, ramas, detalle y diff histórico ya saneado por backend.
+- La UI actual no muestra working-tree diff ni diff histórico; muestra rama actual, ramas disponibles, conteos de cambios/no trackeado y último commit desplegable.
 - No renderizar backend URL, rutas host, stdout/stderr, stack traces, errores crudos, cuerpo libre de commits ni paths omitidos por seguridad.
-- La UI debe mostrar claramente modo solo lectura, redacción, truncado y omisión de diff.
+- La UI debe mostrar claramente modo solo lectura y que el mensaje desplegado del último commit está limitado al asunto saneado del resumen backend.
 
 Nota guardrail: sin paths cliente ni paths host renderizados.

--- a/docs/frontend-implementation-handoff.md
+++ b/docs/frontend-implementation-handoff.md
@@ -700,13 +700,13 @@ Regla del bloque:
 - no abrir nuevas superficies de escritura
 - si identidad y claridad compiten, gana claridad
 
-## Módulo frontend `git` — Issue #40.4 (`Repos Git`)
+## Módulo frontend `git` — `Repos Git`
 - Ruta: `apps/web/src/app/git/page.tsx`.
 - Adapter: `apps/web/src/modules/git/api/git-http.ts`, siempre `server-only`, con `MUGIWARA_CONTROL_PANEL_API_URL`, `cache: 'no-store'`, validación `http(s)` y errores codificados/saneados.
 - Fixture/fallback: `apps/web/src/modules/git/view-models/git-surface.fixture.ts`, sin rutas host, secretos, detalles internos de ejecución ni errores crudos.
-- CSS/responsive: clases `git-*` en `globals.css` para listas/cards/diff con `min-width: 0`, wrap y scroll interno del diff.
-- Seguridad de presentación: la página no lee `process.env`, no hace fetch browser, no conoce backend URL, no acepta input de paths/refs/revspecs y solo encadena `repo_id`/SHA que vienen de respuestas backend.
-- Selector 40.5: `Selección controlada` repo/commit mediante enlaces server-side; `searchParams.repo_id` se acepta solo si existe en `repoIndex.repos` y `searchParams.sha` solo si existe en `commits.commits` del repo seleccionado. No hay inputs, forms, búsqueda libre ni selector de refs/rangos.
+- CSS/responsive: clases `git-*` en `globals.css` para cards de estado, métricas, chips de ramas y cuadro desplegable del último commit con `min-width: 0`, wrap y scroll interno controlado.
+- Seguridad de presentación: la página no lee `process.env`, no hace fetch browser, no conoce backend URL, no acepta input de paths/refs/revspecs y solo consume `repo_id`, ramas y commits que vienen de respuestas backend.
+- Modelo UI actual: una card por repo con `Estado local por repo`, rama actual, ramas disponibles, cambios, no trackeado y `Último commit` desplegable. No hay inputs, forms, búsqueda libre ni selector de refs/rangos.
 - Verificación obligatoria: `npm run verify:git-server-only`, typecheck, build, `npm run verify:visual-baseline`, `git diff --check` y smoke HTML/DOM anti-leakage.
 
-Nota 40.4: el contenido de líneas del diff se omite en frontend; la UI muestra metadata, contadores y estados de redacción/truncado/omisión para evitar reintroducir canarios o secretos históricos en HTML/DOM. Guardrail: `npm run verify:git-server-only`.
+Nota actual: el cuadro desplegable del último commit renderiza solo el asunto saneado del resumen de commits; el cuerpo libre del commit sigue fuera del contrato público para evitar reintroducir canarios o secretos históricos en HTML/DOM. Guardrail: `npm run verify:git-server-only`.

--- a/docs/frontend-ui-spec.md
+++ b/docs/frontend-ui-spec.md
@@ -939,13 +939,11 @@ Ese equilibrio debe mantenerse en todas las decisiones de frontend del MVP.
 
 
 ## Ruta `/git` — Repos Git
-- Navegación principal: añadir `Repos Git` como superficie read-only de Zoro.
-- Propósito: consultar repositorios Git allowlisteados desde backend, historial reciente, ramas locales, detalle de commit y diff histórico ya saneado.
-- Copy obligatorio: dejar visible `Solo lectura`, `repo_id/SHA backend-owned`, `Selección controlada`, `Solo repos allowlisteados`, `Solo SHAs listados por backend` y `Diff redactado/truncado/omitido`.
-- Restricciones UI: sin paths cliente, sin discovery arbitrario, sin refs/rangos/revspecs, sin acciones Git y sin working-tree diff en Issue #40.4/40.5.
-- Selector 40.5: repo cards y commits son enlaces server-side; `repo_id` solo se acepta si existe en `repoIndex.repos` y `sha` solo si existe en `commits.commits` del repo seleccionado. Parámetros inválidos se ignoran sin eco ni error crudo.
-- Layout: cards/listas responsive, no tablas anchas; el panel de diff usa scroll interno/controlado y `pre` con wrap para evitar overflow horizontal.
-- Estados: API real, fallback local saneado, fuente no configurada/degradada; nunca mostrar backend URL, rutas host, detalles internos de ejecución y errores crudos ni errores crudos.
+- Navegación principal: `Repos Git` funciona como revisor de estado de repositorios Git locales allowlisteados.
+- Propósito actual: una card por repo con información operativa concreta: rama actual, ramas disponibles, conteo de cambios, conteo no trackeado y último commit con fecha/hora.
+- El último commit se muestra como bloque desplegable (`details`) y el cuadro de texto renderiza solo el asunto saneado expuesto por backend; no se publica cuerpo libre de commit.
+- Copy obligatorio: dejar visible `Solo lectura`, `Estado local por repo`, `Último commit desplegable`, `Sin operaciones mutables`, `Sin rutas host`, `Sin texto libre de commits` y `Solo repos allowlisteados`.
+- Restricciones UI: sin paths cliente, sin discovery arbitrario, sin refs/rangos/revspecs, sin acciones Git y sin working-tree diff.
+- Layout: cards responsive, métricas escaneables, ramas como chips con wrap y cuadro de mensaje con scroll interno/controlado para evitar overflow horizontal.
+- Estados: API real, fallback local saneado, fuente no configurada/degradada; nunca mostrar backend URL, rutas host, detalles internos de ejecución ni errores crudos.
 - Guardrail: `npm run verify:git-server-only`.
-
-Nota 40.4: el contenido de líneas del diff se omite en frontend; la UI muestra metadata, contadores y estados de redacción/truncado/omisión para evitar reintroducir canarios o secretos históricos en HTML/DOM. Guardrail: `npm run verify:git-server-only`.

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -257,13 +257,13 @@ Resumen de la decisión:
 - El cuerpo libre de commit no forma parte del contrato público; solo se lee internamente para trailers allowlisteados.
 
 ## Git control frontend / Repos Git
-Issue #40.4 añade la ruta frontend `/git` con etiqueta visible `Repos Git`. La página es una Server Component dinámica y consume el backend solo desde `apps/web/src/modules/git/api/git-http.ts` con `import 'server-only'` y `MUGIWARA_CONTROL_PANEL_API_URL`. Issue #40.5 añade `Selección controlada` repo/commit mediante enlaces server-side y validación estricta de `searchParams`.
+La ruta frontend `/git` con etiqueta visible `Repos Git` es una Server Component dinámica y consume el backend solo desde `apps/web/src/modules/git/api/git-http.ts` con `import 'server-only'` y `MUGIWARA_CONTROL_PANEL_API_URL`. La página se presenta como revisor de estado local: una card por repo allowlisteado con `Estado local por repo`, rama actual, ramas disponibles, cambios, no trackeado y `Último commit` desplegable.
 
 Reglas de runtime:
 1. El navegador no recibe ni usa `MUGIWARA_CONTROL_PANEL_API_URL`, `NEXT_PUBLIC_*` ni backend URL absoluta.
-2. La UI no acepta paths, URLs, remotes, refs, rangos, revspecs ni comandos Git desde cliente; usa solo `repo_id` y SHA completo devueltos por backend.
-3. `repo_id` solo se acepta si existe en `repoIndex.repos`, y `sha` solo si existe en `commits.commits` del repo seleccionado; query params inválidos se ignoran sin eco ni error crudo.
-4. La página muestra índice de repos, commits, ramas locales, detalle de commit y diff histórico saneado. No muestra working-tree diff en 40.4/40.5.
+2. La UI no acepta paths, URLs, remotes, refs, rangos, revspecs ni comandos Git desde cliente; solo consume repos, ramas y commits devueltos por backend allowlisteado.
+3. La página no usa inputs ni selectores arbitrarios: renderiza directamente el índice de repos y consulta ramas/último commit por cada `repo_id` backend-owned.
+4. La página muestra estado por repo, ramas locales y último commit. No muestra working-tree diff ni diff histórico en la UI actual.
 5. El fallback local está saneado y no renderiza rutas host, detalles internos de ejecución y errores crudos, errores crudos, tokens ni secretos.
 6. Antes de cerrar cambios sobre esta frontera ejecutar:
 
@@ -271,4 +271,4 @@ Reglas de runtime:
 npm run verify:git-server-only
 ```
 
-Nota 40.4: el contenido de líneas del diff se omite en frontend; la UI muestra metadata, contadores y estados de redacción/truncado/omisión para evitar reintroducir canarios o secretos históricos en HTML/DOM. Guardrail: `npm run verify:git-server-only`.
+Nota actual: el cuadro desplegable del último commit renderiza solo el asunto saneado incluido en el resumen de commits; el cuerpo libre del commit sigue fuera del contrato público para evitar reintroducir canarios o secretos históricos en HTML/DOM. Guardrail: `npm run verify:git-server-only`.

--- a/scripts/check-git-server-only.mjs
+++ b/scripts/check-git-server-only.mjs
@@ -88,32 +88,23 @@ for (const forbidden of [
 
 for (const snippet of [
   "export const dynamic = 'force-dynamic'",
-  "type GitPageSearchParams = Promise<Record<string, string | string[] | undefined>>",
-  "getSingleSearchParam(searchParams, 'repo_id')",
-  "getSingleSearchParam(searchParams, 'sha')",
-  'repoIndex.repos.find((repo) => repo.repo_id === requestedRepoId)',
-  'commitsResponse.data.commits.find((commit) => commit.sha === requestedSha)',
-  'hasUnsupportedGitSearchParams(searchParams)',
-  'redirect(gitRepoHref(selectedRepo.repo_id))',
-  'redirect(gitCommitHref(selectedRepo.repo_id, selectedCommit.sha))',
   'fetchGitRepos()',
-  'fetchGitCommits(selectedRepo.repo_id)',
-  'fetchGitBranches(selectedRepo.repo_id)',
-  'fetchGitCommitDetail(selectedRepo.repo_id, selectedCommit.sha)',
-  'fetchGitCommitDiff(selectedRepo.repo_id, selectedCommit.sha)',
-  'href={gitRepoHref(repo.repo_id)}',
-  'href={gitCommitHref(repoId, commit.sha)}',
-  'Selección controlada',
-  'Solo repos allowlisteados',
-  'Solo SHAs listados por backend',
-  'Repos Git',
-  'Solo lectura',
-  'repo_id/SHA backend-owned',
-  'Diff redactado/truncado/omitido',
+  'Promise.all(repoIndex.repos.map(async (repo) =>',
+  'fetchGitCommits(repo.repo_id)',
+  'fetchGitBranches(repo.repo_id)',
+  'type GitRepoCardSnapshot',
+  'RepoStatusCard',
+  'Ramas disponibles',
+  'Último commit',
+  'Mensaje del commit',
+  '<details className="git-commit-message"',
   'Sin operaciones mutables',
   'Sin rutas host',
   'Sin texto libre de commits',
-  'Archivo omitido por seguridad',
+  'Repos Git',
+  'Solo lectura',
+  'Estado local por repo',
+  'Último commit desplegable',
 ]) mustInclude(page, snippet, 'git page')
 
 for (const forbidden of [
@@ -185,10 +176,16 @@ for (const doc of [runtimeConfig, frontendSpec, handoff, openspec, openspecSelec
   mustInclude(doc, 'server-only', 'Git docs/OpenSpec/Engram')
 }
 
-for (const doc of [runtimeConfig, frontendSpec, handoff, openspecSelector, engramSelector]) {
-  mustInclude(doc, 'Selección controlada', 'Git selector docs/OpenSpec/Engram')
-  mustInclude(doc, 'repo_id', 'Git selector docs/OpenSpec/Engram')
-  mustInclude(doc, 'SHA', 'Git selector docs/OpenSpec/Engram')
+for (const doc of [runtimeConfig, frontendSpec, handoff]) {
+  mustInclude(doc, 'Estado local por repo', 'Git status cards docs')
+  mustInclude(doc, 'Último commit', 'Git status cards docs')
+  mustInclude(doc, 'repo', 'Git status cards docs')
+}
+
+for (const doc of [openspecSelector, engramSelector]) {
+  mustInclude(doc, 'Selección controlada', 'Git historical selector docs/OpenSpec/Engram')
+  mustInclude(doc, 'repo_id', 'Git historical selector docs/OpenSpec/Engram')
+  mustInclude(doc, 'SHA', 'Git historical selector docs/OpenSpec/Engram')
 }
 
 if (failures.length > 0) {


### PR DESCRIPTION
## Resumen
- Rediseña `/git` como revisor de estado de repos Git locales con una card por repo allowlisteado.
- Cada card muestra rama actual, ramas disponibles, cambios, no trackeado y último commit con fecha/hora.
- El último commit se despliega con `<details>` y cuadro de texto `pre` mostrando solo el asunto saneado del resumen backend.
- Mantiene frontera server-only/read-only: sin inputs, sin acciones Git, sin rutas host, sin working-tree diff ni diff histórico en la UI actual.

## Verificación
- `npm run verify:git-server-only`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build`
- `npm run verify:visual-baseline`
- `git diff --check`
- Smoke HTTP local production `http://127.0.0.1:3018/git`: 200, presencia de título/cards/ramas/último commit/mensaje y ausencia de `MUGIWARA_CONTROL_PANEL_API_URL`, `NEXT_PUBLIC`, `/srv/`, `/home/`, `.env`, `Traceback`, `stdout`, `stderr`.

## Riesgos
- El cuerpo completo del commit no se muestra: por política de seguridad se renderiza solo `commit.subject`; si Pablo quiere cuerpo completo, hace falta microfase backend/API con revisión Chopper.
- Cambio visible de UI: requiere review de Usopp.
- Superficie Git server-only/read-only sigue siendo host-adjacent: requiere review de Chopper.
