### PR TITLE
fix: remove git guardrail notice card

### DIFF
--- a/apps/web/src/app/git/page.tsx
+++ b/apps/web/src/app/git/page.tsx
@@ -284,21 +284,6 @@ export default async function GitPage() {
         </StatePanel>
       ) : null}
 
-      <StatePanel
-        status="revision"
-        title="Frontera Git bloqueada en modo read-only"
-        description="La pantalla revisa estado local de repos allowlisteados sin operaciones mutables, sin selectores arbitrarios y sin publicar rutas del host. El mensaje desplegable usa solo el asunto saneado del último commit expuesto por backend."
-        eyebrow="Guardrail UI"
-      >
-        <SourceStatePills
-          items={[
-            { label: 'Sin operaciones mutables', tone: 'connected' },
-            { label: 'Sin rutas host', tone: 'connected' },
-            { label: 'Sin texto libre de commits', tone: 'connected' },
-            { label: 'Solo repos allowlisteados', tone: 'connected' },
-          ]}
-        />
-      </StatePanel>
 
       <section className="section-block layout-grid layout-grid--cards-280" aria-label="Cards de estado de repos Git locales">
         {cards.map((snapshot) => (

--- a/scripts/check-git-server-only.mjs
+++ b/scripts/check-git-server-only.mjs
@@ -99,8 +99,6 @@ for (const snippet of [
   'Mensaje del commit',
   '<details className="git-commit-message"',
   'Sin operaciones mutables',
-  'Sin rutas host',
-  'Sin texto libre de commits',
   'Repos Git',
   'Solo lectura',
   'Estado local por repo',


### PR DESCRIPTION
## Summary
- Removes the visible `Guardrail UI` notice container from `/git`.
- Keeps the Git route server-only/read-only architecture unchanged.
- Updates the static frontend guardrail so it no longer requires the removed guardrail-card-only copy.

## Author
- Mugiwara-Agent: zoro
- Signed-off-by: zoro <asistentes.mugiwara@gmail.com>

## Verification
- `npm run verify:git-server-only`
- `npm --prefix apps/web run typecheck`
- `git diff --check`
- `npm --prefix apps/web run build`

## Risk
Low. UI-only removal requested by Pablo; no backend/API/runtime/dependency changes and no new Git inputs or selectors.
