### PR TITLE
fix: polish git reviewer microcopy

### DIFF
--- a/apps/web/src/app/git/page.tsx
+++ b/apps/web/src/app/git/page.tsx
@@ -240,7 +240,7 @@ function RepoStatusCard({ snapshot }: { snapshot: GitRepoCardSnapshot }) {
             <dd>{valueOrDash(repo.status.changed_files_count)}</dd>
           </div>
           <div>
-            <dt>No trackeado</dt>
+            <dt>Sin trackear</dt>
             <dd>{valueOrDash(repo.status.untracked_files_count)}</dd>
           </div>
         </dl>
@@ -251,7 +251,7 @@ function RepoStatusCard({ snapshot }: { snapshot: GitRepoCardSnapshot }) {
         </div>
 
         <div className="git-repo-status-card__section">
-          <h2>Último commit desplegable</h2>
+          <h2>Último commit</h2>
           <LatestCommit commit={latestCommit} />
         </div>
       </article>
@@ -268,8 +268,8 @@ export default async function GitPage() {
       <PageHeader
         eyebrow="Repos Git"
         title="Revisor de repos Git locales"
-        subtitle="Una card por repo allowlisteado con rama actual, ramas disponibles, cambios, no trackeado y último commit desplegable. Lectura server-only, sin acciones Git y sin rutas del host."
-        detailPills={['Solo lectura', 'Estado local por repo', 'Último commit desplegable', 'Sin operaciones mutables']}
+        subtitle="Una card por repo allowlisteado con rama actual, ramas disponibles, cambios, sin trackear y último commit. Lectura server-only, sin acciones Git y sin rutas del host."
+        detailPills={['Solo lectura', 'Estado local por repo', 'Último commit', 'Sin operaciones mutables']}
       />
 
       {notice ? (

--- a/apps/web/src/modules/AGENTS.md
+++ b/apps/web/src/modules/AGENTS.md
@@ -9,5 +9,5 @@ Features y módulos funcionales del frontend (dashboard, mugiwaras, skills, memo
 - **Vigilar `.gitignore`** y no subir mocks, capturas o outputs sensibles no saneados.
 - `usage`: Usage/Codex quota read-only frontend consuming server-only current snapshot, calendar, dedicated five-hour windows and aggregated Hermes activity adapters; no client-side backend URL or Hermes profiles root exposure.
 - `system`: adapter frontend server-only para `GET /api/v1/system/metrics` y view-model del header global; sin fetch de navegador, sin `NEXT_PUBLIC_*`, sin URL backend ni errores crudos en cliente.
-- `git`: página `/git` (`Repos Git`) con adapter server-only para repositorios Git backend-owned; solo lectura, una card por repo con rama actual, ramas disponibles, cambios, no trackeado y último commit desplegable; sin rutas cliente, sin acciones Git ni diffs en la UI actual.
+- `git`: página `/git` (`Repos Git`) con adapter server-only para repositorios Git backend-owned; solo lectura, una card por repo con rama actual, ramas disponibles, cambios, sin trackear y último commit; sin rutas cliente, sin acciones Git ni diffs en la UI actual.
 - Si nace un módulo nuevo, documentarlo aquí y en docs.

--- a/apps/web/src/modules/git/AGENTS.md
+++ b/apps/web/src/modules/git/AGENTS.md
@@ -7,7 +7,7 @@ Módulo frontend read-only para la página `/git` (`Repos Git`), actualmente ori
 - El adapter HTTP debe ser `server-only` y usar únicamente `MUGIWARA_CONTROL_PANEL_API_URL` en servidor.
 - El cliente/UI solo puede operar con `repo_id` y datos devueltos por backend; no paths, refs, rangos, revspecs ni discovery arbitrario.
 - No introducir acciones Git: checkout/reset/commit/push/pull/fetch/stash/merge/rebase.
-- La UI actual no muestra working-tree diff ni diff histórico; muestra rama actual, ramas disponibles, conteos de cambios/no trackeado y último commit desplegable.
+- La UI actual no muestra working-tree diff ni diff histórico; muestra rama actual, ramas disponibles, conteos de cambios/sin trackear y último commit.
 - No renderizar backend URL, rutas host, stdout/stderr, stack traces, errores crudos, cuerpo libre de commits ni paths omitidos por seguridad.
 - La UI debe mostrar claramente modo solo lectura y que el mensaje desplegado del último commit está limitado al asunto saneado del resumen backend.
 

--- a/docs/frontend-implementation-handoff.md
+++ b/docs/frontend-implementation-handoff.md
@@ -706,7 +706,7 @@ Regla del bloque:
 - Fixture/fallback: `apps/web/src/modules/git/view-models/git-surface.fixture.ts`, sin rutas host, secretos, detalles internos de ejecución ni errores crudos.
 - CSS/responsive: clases `git-*` en `globals.css` para cards de estado, métricas, chips de ramas y cuadro desplegable del último commit con `min-width: 0`, wrap y scroll interno controlado.
 - Seguridad de presentación: la página no lee `process.env`, no hace fetch browser, no conoce backend URL, no acepta input de paths/refs/revspecs y solo consume `repo_id`, ramas y commits que vienen de respuestas backend.
-- Modelo UI actual: una card por repo con `Estado local por repo`, rama actual, ramas disponibles, cambios, no trackeado y `Último commit` desplegable. No hay inputs, forms, búsqueda libre ni selector de refs/rangos.
+- Modelo UI actual: una card por repo con `Estado local por repo`, rama actual, ramas disponibles, cambios, sin trackear y `Último commit`. No hay inputs, forms, búsqueda libre ni selector de refs/rangos.
 - Verificación obligatoria: `npm run verify:git-server-only`, typecheck, build, `npm run verify:visual-baseline`, `git diff --check` y smoke HTML/DOM anti-leakage.
 
 Nota actual: el cuadro desplegable del último commit renderiza solo el asunto saneado del resumen de commits; el cuerpo libre del commit sigue fuera del contrato público para evitar reintroducir canarios o secretos históricos en HTML/DOM. Guardrail: `npm run verify:git-server-only`.

--- a/docs/frontend-ui-spec.md
+++ b/docs/frontend-ui-spec.md
@@ -940,9 +940,9 @@ Ese equilibrio debe mantenerse en todas las decisiones de frontend del MVP.
 
 ## Ruta `/git` — Repos Git
 - Navegación principal: `Repos Git` funciona como revisor de estado de repositorios Git locales allowlisteados.
-- Propósito actual: una card por repo con información operativa concreta: rama actual, ramas disponibles, conteo de cambios, conteo no trackeado y último commit con fecha/hora.
+- Propósito actual: una card por repo con información operativa concreta: rama actual, ramas disponibles, conteo de cambios, conteo sin trackear y último commit con fecha/hora.
 - El último commit se muestra como bloque desplegable (`details`) y el cuadro de texto renderiza solo el asunto saneado expuesto por backend; no se publica cuerpo libre de commit.
-- Copy obligatorio: dejar visible `Solo lectura`, `Estado local por repo`, `Último commit desplegable`, `Sin operaciones mutables`, `Sin rutas host`, `Sin texto libre de commits` y `Solo repos allowlisteados`.
+- Copy obligatorio: dejar visible `Solo lectura`, `Estado local por repo`, `Último commit`, `Sin operaciones mutables` y la métrica `Sin trackear`.
 - Restricciones UI: sin paths cliente, sin discovery arbitrario, sin refs/rangos/revspecs, sin acciones Git y sin working-tree diff.
 - Layout: cards responsive, métricas escaneables, ramas como chips con wrap y cuadro de mensaje con scroll interno/controlado para evitar overflow horizontal.
 - Estados: API real, fallback local saneado, fuente no configurada/degradada; nunca mostrar backend URL, rutas host, detalles internos de ejecución ni errores crudos.

--- a/docs/runtime-config.md
+++ b/docs/runtime-config.md
@@ -257,7 +257,7 @@ Resumen de la decisión:
 - El cuerpo libre de commit no forma parte del contrato público; solo se lee internamente para trailers allowlisteados.
 
 ## Git control frontend / Repos Git
-La ruta frontend `/git` con etiqueta visible `Repos Git` es una Server Component dinámica y consume el backend solo desde `apps/web/src/modules/git/api/git-http.ts` con `import 'server-only'` y `MUGIWARA_CONTROL_PANEL_API_URL`. La página se presenta como revisor de estado local: una card por repo allowlisteado con `Estado local por repo`, rama actual, ramas disponibles, cambios, no trackeado y `Último commit` desplegable.
+La ruta frontend `/git` con etiqueta visible `Repos Git` es una Server Component dinámica y consume el backend solo desde `apps/web/src/modules/git/api/git-http.ts` con `import 'server-only'` y `MUGIWARA_CONTROL_PANEL_API_URL`. La página se presenta como revisor de estado local: una card por repo allowlisteado con `Estado local por repo`, rama actual, ramas disponibles, cambios, sin trackear y `Último commit`.
 
 Reglas de runtime:
 1. El navegador no recibe ni usa `MUGIWARA_CONTROL_PANEL_API_URL`, `NEXT_PUBLIC_*` ni backend URL absoluta.

--- a/scripts/check-git-server-only.mjs
+++ b/scripts/check-git-server-only.mjs
@@ -102,7 +102,7 @@ for (const snippet of [
   'Repos Git',
   'Solo lectura',
   'Estado local por repo',
-  'Último commit desplegable',
+  'Sin trackear',
 ]) mustInclude(page, snippet, 'git page')
 
 for (const forbidden of [


### PR DESCRIPTION
## Summary
- Closes the remaining copy/UI follow-ups from #133 after PR #134 removed the heavy `Guardrail UI` container.
- Renames `Último commit desplegable` to `Último commit` while keeping the `<details>` affordance.
- Changes `No trackeado` to `Sin trackear` across the `/git` UI and living docs.
- Keeps the Git route server-only/read-only with no new inputs, selectors, refs, diffs, backend/API/runtime/dependency changes.

Closes #133

## Author
- Mugiwara-Agent: zoro
- Signed-off-by: zoro <asistentes.mugiwara@gmail.com>

## Verification
- `npm run verify:git-server-only`
- `npm --prefix apps/web run typecheck`
- `git diff --check`
- `npm --prefix apps/web run build`

## Risk
Low. UI/copy-only polish on `/git`; no data-path, security, runtime or dependency changes.
