### PR TITLE
feat: add Mugiwaras SOUL viewer

### DIFF
--- a/apps/api/src/modules/mugiwaras/domain.py
+++ b/apps/api/src/modules/mugiwaras/domain.py
@@ -47,3 +47,14 @@ class CrewRulesDocument:
     read_only: bool
     canonical: bool
     markdown: str
+
+
+@dataclass(frozen=True)
+class SoulDocument:
+    document_id: str
+    title: str
+    display_path: str
+    source_label: str
+    read_only: bool
+    canonical: bool
+    markdown: str

--- a/apps/api/src/modules/mugiwaras/router.py
+++ b/apps/api/src/modules/mugiwaras/router.py
@@ -31,6 +31,17 @@ def list_mugiwaras(service: MugiwaraService = Depends(get_mugiwaras_service)) ->
     )
 
 
+@router.get('/{slug}/soul')
+def get_mugiwara_soul_document(slug: str, service: MugiwaraService = Depends(get_mugiwaras_service)) -> dict:
+    document = service.get_soul_document(slug)
+    return resource_response(
+        resource='mugiwaras.soul_document',
+        status='ready',
+        data=asdict(document),
+        meta={'slug': slug, 'read_only': True},
+    )
+
+
 @router.get('/{slug}')
 def get_mugiwara_profile(slug: str, service: MugiwaraService = Depends(get_mugiwaras_service)) -> dict:
     profile = service.get_profile(slug)

--- a/apps/api/src/modules/mugiwaras/service.py
+++ b/apps/api/src/modules/mugiwaras/service.py
@@ -5,10 +5,12 @@ from pathlib import Path
 
 from fastapi import HTTPException, status
 
-from .domain import CrewRulesDocument, MugiwaraCard, MugiwaraIdentity, MugiwaraProfile, SafeLink
+from .domain import CrewRulesDocument, MugiwaraCard, MugiwaraIdentity, MugiwaraProfile, SafeLink, SoulDocument
 
 MAX_CREW_RULES_BYTES = 200_000
+MAX_SOUL_BYTES = 120_000
 DEFAULT_CREW_RULES_PATH = Path('/srv/crew-core/AGENTS.md')
+DEFAULT_PROFILES_ROOT = Path('/home/agentops/.hermes/profiles')
 CANONICAL_CREW_RULES_DISPLAY_PATH = '/srv/crew-core/AGENTS.md'
 
 def _crew_links(slug: str) -> list[SafeLink]:
@@ -123,14 +125,15 @@ PROFILE_META: dict[str, dict[str, str]] = {
 
 
 class MugiwaraService:
-    def __init__(self, *, crew_rules_path: Path = DEFAULT_CREW_RULES_PATH) -> None:
+    def __init__(self, *, crew_rules_path: Path = DEFAULT_CREW_RULES_PATH, profiles_root: Path = DEFAULT_PROFILES_ROOT) -> None:
         self._crew_rules_path = crew_rules_path
+        self._profiles_root = profiles_root
         self._cards = {card.slug: card for card in CREW_CARDS}
 
     def list_catalog(self) -> dict:
         document = self.get_crew_rules_document()
         return {
-            'items': [asdict(card) for card in self._cards.values()],
+            'items': [asdict(card) | {'soul_document': asdict(self.get_soul_document(card.slug))} for card in self._cards.values()],
             'crew_rules_document': asdict(document),
         }
 
@@ -170,6 +173,22 @@ class MugiwaraService:
             markdown=content,
         )
 
+    def get_soul_document(self, slug: str) -> SoulDocument:
+        card = self._cards.get(slug)
+        if card is None:
+            raise self._reject(status.HTTP_404_NOT_FOUND, 'not_found', 'Mugiwara no configurado en catálogo read-only.')
+
+        content = self._read_soul_document(slug)
+        return SoulDocument(
+            document_id=f'{slug}-soul',
+            title=f'SOUL.md — {card.name}',
+            display_path=f'{slug}/SOUL.md',
+            source_label='Hermes profile SOUL.md allowlist',
+            read_only=True,
+            canonical=False,
+            markdown=content,
+        )
+
     def _read_canonical_crew_rules(self) -> str:
         self._ensure_no_symlink_component(self._crew_rules_path)
 
@@ -180,6 +199,20 @@ class MugiwaraService:
         content = resolved.read_text(encoding='utf-8')
         if len(content.encode('utf-8')) > MAX_CREW_RULES_BYTES:
             raise self._reject(status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, 'validation_error', 'AGENTS.md supera el tamaño máximo permitido.')
+        return content
+
+    def _read_soul_document(self, slug: str) -> str:
+        soul_path = self._profiles_root / slug / 'SOUL.md'
+        self._ensure_no_symlink_component(soul_path)
+
+        resolved = soul_path.expanduser().resolve()
+        expected = (self._profiles_root / slug / 'SOUL.md').expanduser().absolute()
+        if resolved != expected or not resolved.exists() or not resolved.is_file():
+            raise self._reject(status.HTTP_503_SERVICE_UNAVAILABLE, 'source_unavailable', 'SOUL.md allowlisted no disponible.')
+
+        content = resolved.read_text(encoding='utf-8')
+        if len(content.encode('utf-8')) > MAX_SOUL_BYTES:
+            raise self._reject(status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, 'validation_error', 'SOUL.md supera el tamaño máximo permitido.')
         return content
 
     def _ensure_no_symlink_component(self, path: Path) -> None:

--- a/apps/api/tests/test_mugiwaras_api.py
+++ b/apps/api/tests/test_mugiwaras_api.py
@@ -13,7 +13,14 @@ def build_service(tmp_path: Path) -> MugiwaraService:
     crew_rules_path = tmp_path / 'crew-core' / 'AGENTS.md'
     crew_rules_path.parent.mkdir(parents=True)
     crew_rules_path.write_text('# AGENTS.md\n\nCanon Mugiwara saneado.\n', encoding='utf-8')
-    return MugiwaraService(crew_rules_path=crew_rules_path)
+
+    profiles_root = tmp_path / 'hermes-profiles'
+    for slug in {'luffy', 'zoro', 'franky', 'nami', 'robin', 'usopp', 'jinbe', 'sanji', 'chopper', 'brook'}:
+        soul_path = profiles_root / slug / 'SOUL.md'
+        soul_path.parent.mkdir(parents=True, exist_ok=True)
+        soul_path.write_text(f'# SOUL.md — {slug.title()}\n\nIdentidad operativa saneada de {slug}.\n', encoding='utf-8')
+
+    return MugiwaraService(crew_rules_path=crew_rules_path, profiles_root=profiles_root)
 
 
 def test_mugiwaras_catalog_returns_safe_cards_and_canonical_agents_document(tmp_path: Path) -> None:
@@ -36,6 +43,17 @@ def test_mugiwaras_catalog_returns_safe_cards_and_canonical_agents_document(tmp_
     assert cards_by_slug['franky']['description'] == 'Opera infraestructura, servicios, automatizaciones, backups y salud del runtime.'
     assert {'label': 'Ver Skills', 'href': '/skills?mugiwara=franky'} in cards_by_slug['franky']['links']
     assert {'label': 'Ver Skills', 'href': '/skills?mugiwara=zoro'} in cards_by_slug['zoro']['links']
+    assert cards_by_slug['zoro']['soul_document'] == {
+        'document_id': 'zoro-soul',
+        'title': 'SOUL.md — Zoro',
+        'display_path': 'zoro/SOUL.md',
+        'source_label': 'Hermes profile SOUL.md allowlist',
+        'read_only': True,
+        'canonical': False,
+        'markdown': '# SOUL.md — Zoro\n\nIdentidad operativa saneada de zoro.\n',
+    }
+    assert 'hermes-profiles' not in response.text
+    assert str(tmp_path) not in response.text
     assert payload['data']['crew_rules_document'] == {
         'document_id': 'crew-core-agents',
         'title': 'AGENTS.md — reglas operativas Mugiwara',
@@ -75,6 +93,33 @@ def test_mugiwara_detail_returns_profile_and_rejects_unknown_slug(tmp_path: Path
     assert unknown.status_code == 404
     assert unknown.json()['detail']['code'] == 'not_found'
     assert '/srv/crew-core' not in unknown.text
+
+    app.dependency_overrides.clear()
+
+
+def test_mugiwara_soul_endpoint_returns_allowlisted_document_and_rejects_path_like_slug(tmp_path: Path) -> None:
+    service = build_service(tmp_path)
+    app.dependency_overrides[get_mugiwaras_service] = lambda: service
+    client = TestClient(app)
+
+    response = client.get('/api/v1/mugiwaras/zoro/soul')
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['resource'] == 'mugiwaras.soul_document'
+    assert payload['data']['display_path'] == 'zoro/SOUL.md'
+    assert payload['data']['markdown'].startswith('# SOUL.md — Zoro')
+    assert str(tmp_path) not in response.text
+    assert 'hermes-profiles' not in response.text
+
+    unknown = client.get('/api/v1/mugiwaras/unknown/soul')
+    assert unknown.status_code == 404
+    assert unknown.json()['detail']['code'] == 'not_found'
+    assert str(tmp_path) not in unknown.text
+
+    path_like = client.get('/api/v1/mugiwaras/..%2Fzoro/soul')
+    assert path_like.status_code == 404
+    assert str(tmp_path) not in path_like.text
 
     app.dependency_overrides.clear()
 

--- a/apps/web/src/app/mugiwaras/MugiwarasClient.tsx
+++ b/apps/web/src/app/mugiwaras/MugiwarasClient.tsx
@@ -1,0 +1,344 @@
+'use client'
+
+import { useState, type ReactNode } from 'react'
+import Link from 'next/link'
+
+import type { MugiwaraCard, SafeLink } from '@contracts/read-models'
+
+import { mapMugiwaraStatusToBadgeStatus } from '@/modules/mugiwaras/view-models/mugiwara-card.mappers'
+import { getMugiwaraProfile, isMugiwaraSlug } from '@/shared/mugiwara/crest-map'
+import { MugiwaraCrest } from '@/shared/mugiwara/MugiwaraCrest'
+import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
+import { StatusBadge } from '@/shared/ui/status/StatusBadge'
+import { appTheme } from '@/shared/theme/tokens'
+
+type MugiwarasClientProps = {
+  cards: MugiwaraCard[]
+  isSnapshotMode: boolean
+}
+
+type MarkdownBlock =
+  | { type: 'heading'; level: 1 | 2 | 3; text: string }
+  | { type: 'paragraph'; text: string }
+  | { type: 'list'; ordered: boolean; items: string[] }
+  | { type: 'code'; text: string }
+  | { type: 'rule' }
+
+function getSafeProfile(card: MugiwaraCard) {
+  return isMugiwaraSlug(card.slug) ? getMugiwaraProfile(card.slug) : null
+}
+
+function getSafeHref(href: string): string | null {
+  if (href.startsWith('/') && !href.startsWith('//')) return href
+
+  try {
+    const parsed = new URL(href)
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:' ? href : null
+  } catch {
+    return null
+  }
+}
+
+function renderInlineMarkdown(text: string): ReactNode[] {
+  const nodes: ReactNode[] = []
+  const inlinePattern = /(\[[^\]]+\]\([^\s)]+\)|\*\*[^*]+\*\*|`[^`]+`)/g
+  let cursor = 0
+  let match: RegExpExecArray | null
+
+  while ((match = inlinePattern.exec(text)) !== null) {
+    if (match.index > cursor) nodes.push(text.slice(cursor, match.index))
+
+    const token = match[0]
+    const linkMatch = /^\[([^\]]+)\]\(([^\s)]+)\)$/.exec(token)
+    if (linkMatch) {
+      const safeHref = getSafeHref(linkMatch[2])
+      nodes.push(
+        safeHref ? (
+          <a key={`${match.index}-link`} href={safeHref} style={{ color: appTheme.colors.brandSky500, fontWeight: 700 }}>
+            {linkMatch[1]}
+          </a>
+        ) : (
+          linkMatch[1]
+        ),
+      )
+    } else if (token.startsWith('**')) {
+      nodes.push(<strong key={`${match.index}-strong`}>{token.slice(2, -2)}</strong>)
+    } else if (token.startsWith('`')) {
+      nodes.push(
+        <code
+          key={`${match.index}-code`}
+          style={{
+            border: `1px solid ${appTheme.colors.borderSubtle}`,
+            borderRadius: '6px',
+            background: appTheme.colors.bgSurface2,
+            padding: '1px 5px',
+            fontSize: '0.92em',
+          }}
+        >
+          {token.slice(1, -1)}
+        </code>,
+      )
+    }
+
+    cursor = match.index + token.length
+  }
+
+  if (cursor < text.length) nodes.push(text.slice(cursor))
+  return nodes
+}
+
+function parseConservativeMarkdown(markdown: string): MarkdownBlock[] {
+  const blocks: MarkdownBlock[] = []
+  const lines = markdown.replace(/\r\n/g, '\n').split('\n')
+  let paragraph: string[] = []
+  let listItems: string[] = []
+  let listOrdered = false
+  let codeFence: string[] | null = null
+
+  const flushParagraph = () => {
+    if (paragraph.length > 0) {
+      blocks.push({ type: 'paragraph', text: paragraph.join(' ') })
+      paragraph = []
+    }
+  }
+  const flushList = () => {
+    if (listItems.length > 0) {
+      blocks.push({ type: 'list', ordered: listOrdered, items: listItems })
+      listItems = []
+      listOrdered = false
+    }
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd()
+
+    if (line.trim().startsWith('```')) {
+      flushParagraph()
+      flushList()
+      if (codeFence) {
+        blocks.push({ type: 'code', text: codeFence.join('\n') })
+        codeFence = null
+      } else {
+        codeFence = []
+      }
+      continue
+    }
+
+    if (codeFence) {
+      codeFence.push(rawLine)
+      continue
+    }
+
+    if (line.trim() === '') {
+      flushParagraph()
+      flushList()
+      continue
+    }
+
+    const headingMatch = /^(#{1,3})\s+(.+)$/.exec(line)
+    if (headingMatch) {
+      flushParagraph()
+      flushList()
+      blocks.push({ type: 'heading', level: headingMatch[1].length as 1 | 2 | 3, text: headingMatch[2] })
+      continue
+    }
+
+    if (/^[-*_]{3,}$/.test(line.trim())) {
+      flushParagraph()
+      flushList()
+      blocks.push({ type: 'rule' })
+      continue
+    }
+
+    const unorderedMatch = /^[-*+]\s+(.+)$/.exec(line)
+    const orderedMatch = /^\d+[.)]\s+(.+)$/.exec(line)
+    if (unorderedMatch || orderedMatch) {
+      flushParagraph()
+      const ordered = Boolean(orderedMatch)
+      if (listItems.length > 0 && listOrdered !== ordered) flushList()
+      listOrdered = ordered
+      listItems.push((unorderedMatch ?? orderedMatch)?.[1] ?? '')
+      continue
+    }
+
+    flushList()
+    paragraph.push(line.trim())
+  }
+
+  if (codeFence) blocks.push({ type: 'code', text: codeFence.join('\n') })
+  flushParagraph()
+  flushList()
+  return blocks
+}
+
+function CompactMarkdownDocument({ markdown, labelId }: { markdown: string; labelId: string }) {
+  const blocks = parseConservativeMarkdown(markdown)
+
+  return (
+    <div
+      className="soul-document-viewer"
+      aria-labelledby={labelId}
+      tabIndex={0}
+      style={{
+        maxHeight: '340px',
+        overflow: 'auto',
+        border: `1px solid ${appTheme.colors.borderSubtle}`,
+        borderRadius: appTheme.radius.md,
+        background: appTheme.colors.bgSurface1,
+        color: appTheme.colors.textPrimary,
+        padding: '14px',
+        lineHeight: 1.65,
+        boxShadow: `inset 0 -14px 20px ${appTheme.colors.bgSurface2}`,
+      }}
+    >
+      {blocks.map((block, index) => {
+        if (block.type === 'heading') {
+          const Heading = (`h${block.level}` as 'h1' | 'h2' | 'h3')
+          return (
+            <Heading key={index} style={{ margin: index === 0 ? '0 0 8px' : '16px 0 8px', lineHeight: 1.2, fontSize: block.level === 1 ? '18px' : '16px' }}>
+              {renderInlineMarkdown(block.text)}
+            </Heading>
+          )
+        }
+        if (block.type === 'list') {
+          const List = block.ordered ? 'ol' : 'ul'
+          return (
+            <List key={index} style={{ margin: '8px 0 12px', paddingLeft: '20px' }}>
+              {block.items.map((item, itemIndex) => (
+                <li key={`${index}-${itemIndex}`} style={{ marginBottom: '5px' }}>
+                  {renderInlineMarkdown(item)}
+                </li>
+              ))}
+            </List>
+          )
+        }
+        if (block.type === 'code') {
+          return (
+            <pre
+              key={index}
+              style={{
+                overflowX: 'auto',
+                whiteSpace: 'pre-wrap',
+                border: `1px solid ${appTheme.colors.borderSubtle}`,
+                borderRadius: appTheme.radius.md,
+                background: appTheme.colors.bgSurface2,
+                padding: '10px',
+                fontSize: '12px',
+              }}
+            >
+              <code>{block.text}</code>
+            </pre>
+          )
+        }
+        if (block.type === 'rule') {
+          return <hr key={index} style={{ border: 0, borderTop: `1px solid ${appTheme.colors.borderSubtle}`, margin: '14px 0' }} />
+        }
+        return (
+          <p key={index} style={{ margin: '0 0 10px', color: appTheme.colors.textSecondary }}>
+            {renderInlineMarkdown(block.text)}
+          </p>
+        )
+      })}
+    </div>
+  )
+}
+
+function renderCrewLink(mugiwara: MugiwaraCard, link: SafeLink) {
+  return (
+    <Link
+      key={`${mugiwara.slug}-${link.href}`}
+      href={link.href}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        border: `1px solid ${appTheme.colors.borderSubtle}`,
+        borderRadius: '999px',
+        background: appTheme.colors.bgSurface1,
+        color: appTheme.colors.brandSky500,
+        padding: '8px 12px',
+        textDecoration: 'none',
+        fontSize: '13px',
+        fontWeight: 800,
+      }}
+    >
+      {link.label}
+    </Link>
+  )
+}
+
+export function MugiwarasClient({ cards, isSnapshotMode }: MugiwarasClientProps) {
+  const [openSoulSlug, setOpenSoulSlug] = useState<string | null>(null)
+
+  return (
+    <section className="section-block layout-grid layout-grid--cards-280">
+      {cards.map((mugiwara) => {
+        const profile = getSafeProfile(mugiwara)
+        const soulPanelId = `soul-panel-${mugiwara.slug}`
+        const soulTitleId = `soul-title-${mugiwara.slug}`
+        const isSoulOpen = openSoulSlug === mugiwara.slug
+        const hasSoul = Boolean(mugiwara.soul_document?.markdown)
+
+        return (
+          <SurfaceCard key={mugiwara.slug} title={mugiwara.name} elevated eyebrow={profile?.role ?? 'Mugiwara'} accent="sky">
+            <div style={{ display: 'grid', gap: '14px' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                  {profile ? <MugiwaraCrest slug={profile.slug} size="md" accent /> : null}
+                </div>
+                <StatusBadge
+                  status={mapMugiwaraStatusToBadgeStatus(mugiwara.status)}
+                  label={isSnapshotMode && mapMugiwaraStatusToBadgeStatus(mugiwara.status) === 'operativo' ? 'Operativo en último corte' : undefined}
+                />
+              </div>
+
+              <p style={{ margin: 0, color: appTheme.colors.textSecondary, fontSize: '15px', lineHeight: 1.6 }}>
+                {mugiwara.description}
+              </p>
+
+              <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', paddingTop: '2px' }}>
+                {mugiwara.links.map((link) => renderCrewLink(mugiwara, link))}
+                <button
+                  type="button"
+                  aria-expanded={isSoulOpen}
+                  aria-controls={hasSoul ? soulPanelId : undefined}
+                  disabled={!hasSoul}
+                  onClick={() => setOpenSoulSlug(isSoulOpen ? null : mugiwara.slug)}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    border: `1px solid ${isSoulOpen ? appTheme.colors.brandSky500 : appTheme.colors.borderSubtle}`,
+                    borderRadius: '999px',
+                    background: isSoulOpen ? appTheme.colors.bgSurface2 : appTheme.colors.bgSurface1,
+                    color: hasSoul ? appTheme.colors.brandSky500 : appTheme.colors.textMuted,
+                    padding: '8px 12px',
+                    fontSize: '13px',
+                    fontWeight: 800,
+                    cursor: hasSoul ? 'pointer' : 'not-allowed',
+                  }}
+                >
+                  SOUL.md
+                </button>
+              </div>
+
+              {hasSoul && isSoulOpen ? (
+                <div id={soulPanelId} style={{ display: 'grid', gap: '8px', minWidth: 0 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '8px', flexWrap: 'wrap' }}>
+                    <span id={soulTitleId} style={{ color: appTheme.colors.textPrimary, fontSize: '14px', fontWeight: 900 }}>
+                      {mugiwara.soul_document?.title}
+                    </span>
+                    <span style={{ color: appTheme.colors.textSecondary, fontSize: '12px', fontWeight: 700 }}>
+                      {mugiwara.soul_document?.display_path} · Solo lectura
+                    </span>
+                  </div>
+                  <CompactMarkdownDocument markdown={mugiwara.soul_document?.markdown ?? ''} labelId={soulTitleId} />
+                </div>
+              ) : null}
+            </div>
+          </SurfaceCard>
+        )
+      })}
+    </section>
+  )
+}

--- a/apps/web/src/app/mugiwaras/page.tsx
+++ b/apps/web/src/app/mugiwaras/page.tsx
@@ -1,13 +1,10 @@
 import type { ReactNode } from 'react'
-import Link from 'next/link'
 
-import type { CrewRulesDocument, MugiwaraCard, SafeLink } from '@contracts/read-models'
+import type { CrewRulesDocument, MugiwaraCard } from '@contracts/read-models'
 
-import { mapMugiwaraStatusToBadgeStatus } from '@/modules/mugiwaras/view-models/mugiwara-card.mappers'
 import { fetchMugiwarasCatalog, getMugiwarasApiBaseUrl, MugiwarasApiError } from '@/modules/mugiwaras/api/mugiwaras-http'
 import { mugiwaraCardFixture } from '@/modules/mugiwaras/view-models/mugiwara-card.fixture'
-import { getMugiwaraProfile, isMugiwaraSlug } from '@/shared/mugiwara/crest-map'
-import { MugiwaraCrest } from '@/shared/mugiwara/MugiwaraCrest'
+import { MugiwarasClient } from '@/app/mugiwaras/MugiwarasClient'
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
 import { StatePanel } from '@/shared/ui/state/StatePanel'
@@ -87,10 +84,6 @@ async function getMugiwarasViewModel(): Promise<MugiwarasViewModel> {
       },
     }
   }
-}
-
-function getSafeProfile(card: MugiwaraCard) {
-  return isMugiwaraSlug(card.slug) ? getMugiwaraProfile(card.slug) : null
 }
 
 function formatLineCount(markdown: string) {
@@ -314,30 +307,6 @@ function MarkdownDocument({ markdown }: { markdown: string }) {
   )
 }
 
-function renderCrewLink(mugiwara: MugiwaraCard, link: SafeLink) {
-  return (
-    <Link
-      key={`${mugiwara.slug}-${link.href}`}
-      href={link.href}
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        border: `1px solid ${appTheme.colors.borderSubtle}`,
-        borderRadius: '999px',
-        background: appTheme.colors.bgSurface1,
-        color: appTheme.colors.brandSky500,
-        padding: '8px 12px',
-        textDecoration: 'none',
-        fontSize: '13px',
-        fontWeight: 800,
-      }}
-    >
-      {link.label}
-    </Link>
-  )
-}
-
 export default async function MugiwarasPage() {
   const viewModel = await getMugiwarasViewModel()
   const isSnapshotMode = viewModel.state !== 'ready'
@@ -371,38 +340,39 @@ export default async function MugiwarasPage() {
         </section>
       ) : null}
 
-      <section className="section-block layout-grid layout-grid--cards-280">
-        {viewModel.cards.map((mugiwara) => {
-          const profile = getSafeProfile(mugiwara)
-
-          return (
-            <SurfaceCard key={mugiwara.slug} title={mugiwara.name} elevated eyebrow={profile?.role ?? 'Mugiwara'} accent="sky">
-              <div style={{ display: 'grid', gap: '14px' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-                    {profile ? <MugiwaraCrest slug={profile.slug} size="md" accent /> : null}
-                  </div>
-                  <StatusBadge
-                    status={mapMugiwaraStatusToBadgeStatus(mugiwara.status)}
-                    label={isSnapshotMode && mapMugiwaraStatusToBadgeStatus(mugiwara.status) === 'operativo' ? 'Operativo en último corte' : undefined}
-                  />
-                </div>
-
-                <p style={{ margin: 0, color: appTheme.colors.textSecondary, fontSize: '15px', lineHeight: 1.6 }}>
-                  {mugiwara.description}
-                </p>
-
-                <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', paddingTop: '2px' }}>
-                  {mugiwara.links.map((link) => renderCrewLink(mugiwara, link))}
-                </div>
-              </div>
-            </SurfaceCard>
-          )
-        })}
+      <section className="section-block">
+        <SurfaceCard title="Canon operativo" eyebrow="AGENTS.md" accent="gold" elevated>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap' }}>
+            <p style={{ margin: 0, color: appTheme.colors.textSecondary, fontSize: '15px', lineHeight: 1.6 }}>
+              La tripulación usa las cards como índice rápido. El bloque AGENTS.md completo queda al final de la página para consulta read-only.
+            </p>
+            <a
+              href="#agents-md"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                border: `1px solid ${appTheme.colors.borderSubtle}`,
+                borderRadius: '999px',
+                background: appTheme.colors.bgSurface1,
+                color: appTheme.colors.brandSky500,
+                padding: '9px 13px',
+                textDecoration: 'none',
+                fontSize: '13px',
+                fontWeight: 900,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              Leer AGENTS.md
+            </a>
+          </div>
+        </SurfaceCard>
       </section>
 
+      <MugiwarasClient cards={viewModel.cards} isSnapshotMode={isSnapshotMode} />
+
       {viewModel.crewRulesDocument ? (
-        <section className="section-block">
+        <section id="agents-md" className="section-block">
           <SurfaceCard title={viewModel.crewRulesDocument.title} eyebrow="Canon operativo" accent="gold" elevated>
             <div style={{ display: 'grid', gap: '12px' }}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>

--- a/apps/web/src/app/mugiwaras/page.tsx
+++ b/apps/web/src/app/mugiwaras/page.tsx
@@ -372,7 +372,7 @@ export default async function MugiwarasPage() {
       <MugiwarasClient cards={viewModel.cards} isSnapshotMode={isSnapshotMode} />
 
       {viewModel.crewRulesDocument ? (
-        <section id="agents-md" className="section-block">
+        <section id="agents-md" tabIndex={-1} className="section-block">
           <SurfaceCard title={viewModel.crewRulesDocument.title} eyebrow="Canon operativo" accent="gold" elevated>
             <div style={{ display: 'grid', gap: '12px' }}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>

--- a/docs/frontend-ui-spec.md
+++ b/docs/frontend-ui-spec.md
@@ -327,6 +327,9 @@ Estructura:
 - rol
 - hasta 3 señales
 - CTA o affordance de apertura
+- acción local `SOUL.md` con `aria-expanded`/`aria-controls`, sin navegación fuera de la página, para desplegar un visor compacto Markdown read-only dentro de la card
+- links de navegación separados para Memory y Skills
+- en `/mugiwaras`, la referencia superior a `AGENTS.md` debe ser una píldora `Leer AGENTS.md` que apunte al ancla estable `#agents-md` del visor inferior ya renderizado
 
 ### `MugiwaraInlineChip`
 - calavera pequeña

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -13,7 +13,7 @@ Todos los recursos usan la envoltura común:
 ## Modelos por recurso
 ### `mugiwaras.catalog`
 Campos esperados:
-- `items[]` con `slug`, `name`, `status`, `description`, `skills`, `memory_badge` y `links[]` allowlisted
+- `items[]` con `slug`, `name`, `status`, `description`, `skills`, `memory_badge`, `links[]` allowlisted y `soul_document` read-only por agente
 - `crew_rules_document` con el AGENTS canónico read-only servido desde la ruta backend-owned
 
 Uso:
@@ -346,6 +346,22 @@ Campos esperados:
 - `skills`
 - `memory_badge`
 - `links`
+- `soul_document` con el `SOUL.md` allowlisted del perfil Hermes activo, sin ruta interna serializada
+
+### `mugiwara.soul_document`
+Campos esperados:
+- `document_id`
+- `title`
+- `display_path` público con forma `<slug>/SOUL.md`
+- `source_label`
+- `read_only`
+- `canonical`
+- `markdown`
+
+Uso:
+- alimentar el desplegable compacto `SOUL.md` dentro de cada card de `/mugiwaras`
+- endpoint dedicado `GET /api/v1/mugiwaras/{slug}/soul` para lectura allowlisted del mismo documento
+- no aceptar paths desde cliente, no seguir symlinks en componentes del path y no serializar `/home/agentops/.hermes/profiles/...`
 
 ### `mugiwara.crew_rules_document`
 Campos esperados:

--- a/packages/contracts/src/read-models.ts
+++ b/packages/contracts/src/read-models.ts
@@ -41,6 +41,16 @@ export type DashboardSummary = {
   links: SafeLink[]
 }
 
+export type SoulDocument = {
+  document_id: string
+  title: string
+  display_path: string
+  source_label: string
+  read_only: true
+  canonical: false
+  markdown: string
+}
+
 export type MugiwaraCard = {
   slug: string
   name: string
@@ -49,6 +59,7 @@ export type MugiwaraCard = {
   skills: string[]
   memory_badge: string
   links: SafeLink[]
+  soul_document?: SoulDocument
 }
 
 export type CrewRulesDocument = {

--- a/scripts/check-mugiwaras-server-only.mjs
+++ b/scripts/check-mugiwaras-server-only.mjs
@@ -52,6 +52,18 @@ if (mugiwarasPage.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL')) {
   failures.push('mugiwaras/page.tsx must not instruct operators to use the public env var')
 }
 
+if (!mugiwarasPage.includes("href=\"#agents-md\"") || !mugiwarasPage.includes('Leer AGENTS.md') || !mugiwarasPage.includes('id="agents-md"')) {
+  failures.push('mugiwaras/page.tsx must expose a Leer AGENTS.md anchor targeting #agents-md')
+}
+
+if (!mugiwarasPage.includes('MugiwarasClient')) {
+  failures.push('mugiwaras/page.tsx must delegate card rendering to an interactive MugiwarasClient for SOUL.md toggles')
+}
+
+if (!mugiwarasBackendService.includes('DEFAULT_PROFILES_ROOT') || !mugiwarasBackendService.includes('get_soul_document')) {
+  failures.push('backend Mugiwaras service must expose SOUL.md through an allowlisted profile reader')
+}
+
 const activeRoster = ['luffy', 'zoro', 'franky', 'nami', 'robin', 'usopp', 'jinbe', 'sanji', 'chopper', 'brook']
 
 for (const slug of activeRoster) {

--- a/scripts/check-mugiwaras-server-only.mjs
+++ b/scripts/check-mugiwaras-server-only.mjs
@@ -52,8 +52,13 @@ if (mugiwarasPage.includes('NEXT_PUBLIC_MUGIWARA_CONTROL_PANEL_API_URL')) {
   failures.push('mugiwaras/page.tsx must not instruct operators to use the public env var')
 }
 
-if (!mugiwarasPage.includes("href=\"#agents-md\"") || !mugiwarasPage.includes('Leer AGENTS.md') || !mugiwarasPage.includes('id="agents-md"')) {
-  failures.push('mugiwaras/page.tsx must expose a Leer AGENTS.md anchor targeting #agents-md')
+if (
+  !mugiwarasPage.includes("href=\"#agents-md\"") ||
+  !mugiwarasPage.includes('Leer AGENTS.md') ||
+  !mugiwarasPage.includes('id="agents-md"') ||
+  !mugiwarasPage.includes('tabIndex={-1}')
+) {
+  failures.push('mugiwaras/page.tsx must expose a keyboard-focusable Leer AGENTS.md anchor target at #agents-md')
 }
 
 if (!mugiwarasPage.includes('MugiwarasClient')) {


### PR DESCRIPTION
## Resumen
- Añade `soul_document` read-only al catálogo de `/api/v1/mugiwaras` y endpoint `GET /api/v1/mugiwaras/{slug}/soul` para perfiles allowlisted.
- Actualiza `/mugiwaras` con un visor compacto desplegable de `SOUL.md` por card y CTA claro `Leer AGENTS.md` hacia `#agents-md`.
- Mantiene el render Markdown seguro existente, documenta contrato/read-model y amplía el check server-only.

## Seguridad / server-safe
- La página sigue siendo read-only; la interactividad queda aislada en un componente cliente sin lecturas de filesystem.
- La API no serializa rutas internas de perfiles: solo `display_path` tipo `zoro/SOUL.md`.
- Lectura de `SOUL.md` limitada a slugs del catálogo, con rechazo de slug desconocido, anti-symlink, contención de ruta y límite de tamaño.
- Smoke valida ausencia de rutas internas, tracebacks, stdout/stderr y nombres de variables runtime sensibles en API/HTML.

## Verificación ejecutada
```bash
PYTHONPATH=. python3 -m py_compile apps/api/src/modules/mugiwaras/domain.py apps/api/src/modules/mugiwaras/service.py apps/api/src/modules/mugiwaras/router.py && \
PYTHONPATH=. pytest apps/api/tests/test_mugiwaras_api.py -q && \
npm run verify:mugiwaras-server-only && \
npm --prefix apps/web run typecheck && \
npm --prefix apps/web run build && \
git diff --check
```

Resultado: OK.

Smoke local:
- API `GET http://127.0.0.1:8121/api/v1/mugiwaras`: `api-smoke-ok`.
- Web `GET http://127.0.0.1:3121/mugiwaras`: `web-smoke-ok`.
- Browser manual: `/mugiwaras` carga; botón `SOUL.md` abre el visor de Zoro; consola sin errores JS.

Limitación: el análisis visual automatizado de Hermes falló por bug del tooling (`cannot import name 'base_url_host_matches' from 'utils'`), no por la app. Queda cubierto con smoke HTTP + snapshot/browser manual + consola limpia.

## Review solicitada
- Usopp: revisión UI/UX/copy/responsive/accesibilidad básica del visor `SOUL.md` y navegación a `AGENTS.md`.

No auto-mergeo sin revisión.

Closes #131
