### PR TITLE
feat: show allowlisted memory documents

### DIFF
--- a/apps/api/src/modules/memory/AGENTS.md
+++ b/apps/api/src/modules/memory/AGENTS.md
@@ -4,8 +4,8 @@
 Módulo backend read-only para la superficie Memory.
 
 ## Reglas
-- Exponer solo resúmenes saneados, contadores, badges, frescura y links allowlisted.
-- No exponer dumps crudos de memoria, prompts, IDs internos, observaciones completas, sesiones ni secretos.
-- Mantener separadas las fuentes `built-in` y `honcho`; Engram no se mezcla silenciosamente en esta superficie.
-- No leer bases reales de memoria desde paths arbitrarios en esta microfase; usar catálogo seguro backend-owned hasta que exista conector auditado.
+- Exponer solo perfiles Mugiwara allowlisted y documentos `MEMORY.md` resueltos por el backend.
+- No aceptar rutas desde el frontend ni slugs path-like; el cliente pide slugs lógicos y el backend resuelve la ubicación.
+- No exponer prompts, IDs internos, observaciones completas, sesiones, secretos, rutas absolutas ni errores crudos.
+- Mantener separadas las fuentes: esta superficie muestra `MEMORY.md` builtin; no mezcla Honcho, Vault ni Engram.
 - Los errores deben ser semánticos y no filtrar rutas del host ni detalles internos.

--- a/apps/api/src/modules/memory/domain.py
+++ b/apps/api/src/modules/memory/domain.py
@@ -26,12 +26,24 @@ class MemoryAgentSummary:
 
 
 @dataclass(frozen=True)
+class MemoryDocument:
+    status: str
+    display_path: str
+    read_only: bool
+    markdown: str
+    updated_at: str | None
+    size_bytes: int | None
+    message: str
+
+
+@dataclass(frozen=True)
 class MemoryAgentDetail:
     mugiwara_slug: str
     built_in_summary: str
     honcho_facts: list[str]
     freshness: Freshness
     links: list[SafeLink]
+    memory_document: MemoryDocument
 
 
 @dataclass(frozen=True)

--- a/apps/api/src/modules/memory/service.py
+++ b/apps/api/src/modules/memory/service.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import asdict
+from datetime import UTC, datetime
+from pathlib import Path
 
 from fastapi import HTTPException, status
 
-from .domain import Freshness, MemoryAgentDetail, MemoryAgentSummary, MemoryRecord, SafeLink
+from .domain import Freshness, MemoryAgentDetail, MemoryAgentSummary, MemoryDocument, MemoryRecord, SafeLink
+
+DEFAULT_PROFILE_ROOT = Path('/home/agentops/.hermes/profiles')
+MAX_MEMORY_DOCUMENT_BYTES = 64 * 1024
 
 SAFE_MEMORY_RECORDS: tuple[MemoryRecord, ...] = (
     MemoryRecord('luffy', 'Coordina briefs, prioridades y delegación diaria entre especialistas.', 6, '2026-04-24T07:20:00Z', ('orquestación', 'briefs', 'prioridades'), 'Resumen operativo de delegaciones, prioridades activas y criterios de coordinación.', ('Coordina tono y foco entre especialistas.', 'Recoge hábitos de colaboración transversales.', 'No sustituye memoria viva de proyecto.'), 'fresh'),
@@ -21,8 +26,9 @@ SAFE_MEMORY_RECORDS: tuple[MemoryRecord, ...] = (
 
 
 class MemoryService:
-    def __init__(self, *, records: tuple[MemoryRecord, ...] = SAFE_MEMORY_RECORDS) -> None:
+    def __init__(self, *, records: tuple[MemoryRecord, ...] = SAFE_MEMORY_RECORDS, profile_root: Path = DEFAULT_PROFILE_ROOT) -> None:
         self._records = {record.slug: record for record in records}
+        self._profile_root = Path(profile_root)
 
     def catalog_status(self) -> str:
         return 'ready' if self._records else 'not_configured'
@@ -31,6 +37,8 @@ class MemoryService:
         return [asdict(self._to_summary(record)) for record in self._records.values()]
 
     def get_detail(self, slug: str) -> MemoryAgentDetail:
+        if self._is_invalid_slug(slug):
+            raise self._reject(status.HTTP_404_NOT_FOUND, 'not_found', 'Memoria no configurada para el agente solicitado.')
         record = self._records.get(slug)
         if record is None:
             raise self._reject(status.HTTP_404_NOT_FOUND, 'not_found', 'Memoria no configurada para el agente solicitado.')
@@ -40,7 +48,88 @@ class MemoryService:
             honcho_facts=list(record.honcho_facts[:3]),
             freshness=Freshness(status=record.freshness_status, updated_at=record.last_updated, source_label='built-in + honcho summaries'),
             links=[SafeLink(label='Ver Mugiwara', href='/mugiwaras')],
+            memory_document=self._read_memory_document(record.slug),
         )
+
+    def _read_memory_document(self, slug: str) -> MemoryDocument:
+        display_path = f'{slug}/MEMORY.md'
+        memory_path = self._profile_root / slug / 'memories' / 'MEMORY.md'
+
+        try:
+            self._ensure_no_symlink_component(memory_path)
+            resolved = memory_path.expanduser().resolve()
+            expected = (self._profile_root / slug / 'memories' / 'MEMORY.md').expanduser().absolute()
+            if resolved != expected or not resolved.exists():
+                return MemoryDocument(
+                    status='absent',
+                    display_path=display_path,
+                    read_only=True,
+                    markdown='',
+                    updated_at=None,
+                    size_bytes=None,
+                    message='MEMORY.md no disponible para este Mugiwara.',
+                )
+
+            if not resolved.is_file():
+                return MemoryDocument(
+                    status='error',
+                    display_path=display_path,
+                    read_only=True,
+                    markdown='',
+                    updated_at=None,
+                    size_bytes=None,
+                    message='MEMORY.md no está disponible como documento legible.',
+                )
+
+            stat = resolved.stat()
+            if stat.st_size > MAX_MEMORY_DOCUMENT_BYTES:
+                return MemoryDocument(
+                    status='error',
+                    display_path=display_path,
+                    read_only=True,
+                    markdown='',
+                    updated_at=None,
+                    size_bytes=stat.st_size,
+                    message='MEMORY.md supera el tamaño máximo permitido para esta vista.',
+                )
+            raw = resolved.read_text(encoding='utf-8')
+            stat = resolved.stat()
+        except OSError:
+            return MemoryDocument(
+                status='error',
+                display_path=display_path,
+                read_only=True,
+                markdown='',
+                updated_at=None,
+                size_bytes=None,
+                message='Error saneado leyendo MEMORY.md.',
+            )
+
+        document_status = 'empty' if raw == '' else 'available'
+        return MemoryDocument(
+            status=document_status,
+            display_path=display_path,
+            read_only=True,
+            markdown=raw,
+            updated_at=datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat().replace('+00:00', 'Z'),
+            size_bytes=stat.st_size,
+            message='MEMORY.md disponible en solo lectura.' if document_status == 'available' else 'MEMORY.md existe pero está vacío.',
+        )
+
+    def _is_invalid_slug(self, slug: str) -> bool:
+        return any(marker in slug for marker in ('/', '\\', '..', '%2f', '%2F'))
+
+    def _ensure_no_symlink_component(self, path: Path) -> None:
+        expanded = path.expanduser()
+        candidates = [expanded, *expanded.parents]
+        for candidate in candidates:
+            if candidate == candidate.parent:
+                continue
+            try:
+                if candidate.is_symlink():
+                    raise OSError('symlink component rejected')
+            except OSError:
+                raise
 
     def _to_summary(self, record: MemoryRecord) -> MemoryAgentSummary:
         return MemoryAgentSummary(

--- a/apps/api/tests/test_memory_api.py
+++ b/apps/api/tests/test_memory_api.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 
 from apps.api.src.main import app
+from apps.api.src.modules.memory.domain import MemoryRecord
 from apps.api.src.modules.memory.service import MemoryService
 
 client = TestClient(app)
@@ -54,6 +55,18 @@ def test_memory_detail_returns_summary_without_raw_memory_dump():
     assert 1 <= len(data['honcho_facts']) <= 3
     assert data['freshness']['status'] in {'fresh', 'stale', 'unknown'}
     assert data['links'] == [{'label': 'Ver Mugiwara', 'href': '/mugiwaras'}]
+    assert set(data['memory_document'].keys()) == {
+        'status',
+        'display_path',
+        'read_only',
+        'markdown',
+        'updated_at',
+        'size_bytes',
+        'message',
+    }
+    assert data['memory_document']['read_only'] is True
+    assert data['memory_document']['display_path'] == 'zoro/MEMORY.md'
+    assert not data['memory_document']['display_path'].startswith(('/srv/', '/home/'))
     _assert_no_sensitive_keys(payload)
 
 
@@ -74,3 +87,74 @@ def test_memory_service_empty_source_is_not_configured():
     assert service.list_summary() == []
     status = service.catalog_status()
     assert status == 'not_configured'
+
+
+def test_memory_service_reads_allowlisted_memory_document_from_profile_root(tmp_path):
+    profile_root = tmp_path / 'profiles'
+    memory_file = profile_root / 'zoro' / 'memories' / 'MEMORY.md'
+    memory_file.parent.mkdir(parents=True)
+    memory_file.write_text('# Zoro\n\n- Continuidad técnica viva\n', encoding='utf-8')
+    records = (
+        MemoryRecord('zoro', 'summary', 1, None, ('software',), 'built-in', (), 'fresh'),
+    )
+    service = MemoryService(records=records, profile_root=profile_root)
+
+    detail = service.get_detail('zoro')
+
+    assert detail.memory_document.status == 'available'
+    assert detail.memory_document.display_path == 'zoro/MEMORY.md'
+    assert detail.memory_document.read_only is True
+    assert detail.memory_document.markdown == '# Zoro\n\n- Continuidad técnica viva\n'
+    assert detail.memory_document.size_bytes > 0
+    assert detail.memory_document.updated_at is not None
+
+
+def test_memory_service_reports_absent_and_empty_memory_documents(tmp_path):
+    profile_root = tmp_path / 'profiles'
+    (profile_root / 'luffy' / 'memories').mkdir(parents=True)
+    (profile_root / 'luffy' / 'memories' / 'MEMORY.md').write_text('', encoding='utf-8')
+    records = (
+        MemoryRecord('luffy', 'summary', 1, None, (), 'built-in', (), 'fresh'),
+        MemoryRecord('zoro', 'summary', 1, None, (), 'built-in', (), 'fresh'),
+    )
+    service = MemoryService(records=records, profile_root=profile_root)
+
+    empty_detail = service.get_detail('luffy')
+    absent_detail = service.get_detail('zoro')
+
+    assert empty_detail.memory_document.status == 'empty'
+    assert empty_detail.memory_document.markdown == ''
+    assert absent_detail.memory_document.status == 'absent'
+    assert absent_detail.memory_document.markdown == ''
+    assert 'MEMORY.md' in absent_detail.memory_document.message
+
+
+def test_memory_service_rejects_symlink_memory_document(tmp_path):
+    profile_root = tmp_path / 'profiles'
+    profile_memory = profile_root / 'zoro' / 'memories'
+    profile_memory.mkdir(parents=True)
+    target = tmp_path / 'outside.md'
+    target.write_text('# outside\n', encoding='utf-8')
+    (profile_memory / 'MEMORY.md').symlink_to(target)
+    records = (
+        MemoryRecord('zoro', 'summary', 1, None, (), 'built-in', (), 'fresh'),
+    )
+    service = MemoryService(records=records, profile_root=profile_root)
+
+    detail = service.get_detail('zoro')
+
+    assert detail.memory_document.status == 'error'
+    assert detail.memory_document.markdown == ''
+    assert detail.memory_document.display_path == 'zoro/MEMORY.md'
+    assert '/tmp/' not in detail.memory_document.message
+
+
+def test_memory_api_rejects_path_like_slug_without_paths():
+    response = client.get('/api/v1/memory/..zoro')
+
+    assert response.status_code == 404
+    detail = response.json()['detail']
+    assert detail['code'] == 'not_found'
+    assert '/srv/' not in detail['message']
+    assert '/home/' not in detail['message']
+    assert '..' not in detail['message']

--- a/apps/web/src/app/memory/MemoryClient.tsx
+++ b/apps/web/src/app/memory/MemoryClient.tsx
@@ -188,7 +188,23 @@ export function MemoryClient({ apiSummaries, apiDetails, apiState, apiNotice }: 
           </SurfaceCard>
         </aside>
 
-        <main style={{ display: 'grid', gap: '14px' }}>
+        <section aria-labelledby="memory-document-heading" style={{ display: 'grid', gap: '14px' }}>
+          <h2
+            id="memory-document-heading"
+            style={{
+              position: 'absolute',
+              width: '1px',
+              height: '1px',
+              padding: 0,
+              margin: '-1px',
+              overflow: 'hidden',
+              clip: 'rect(0, 0, 0, 0)',
+              whiteSpace: 'nowrap',
+              border: 0,
+            }}
+          >
+            Documento MEMORY.md seleccionado
+          </h2>
           <SurfaceCard title="Estado del documento" elevated eyebrow="Read-only" accent="sky">
             <div style={{ display: 'grid', gap: '12px' }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap', alignItems: 'center' }}>
@@ -258,7 +274,7 @@ export function MemoryClient({ apiSummaries, apiDetails, apiState, apiNotice }: 
               />
             )}
           </SurfaceCard>
-        </main>
+        </section>
       </section>
     </>
   )

--- a/apps/web/src/app/memory/MemoryClient.tsx
+++ b/apps/web/src/app/memory/MemoryClient.tsx
@@ -2,22 +2,15 @@
 
 import { useState } from 'react'
 
-import type { MemoryAgentDetail as ApiMemoryAgentDetail, MemoryAgentSummary as ApiMemoryAgentSummary } from '@contracts/read-models'
-import { memoryAgentDetailFixture, type MemoryAgentDetail, type MemorySourceKey, type MemorySourceSnapshot, type MemorySourceState } from '@/modules/memory/view-models/memory-agent-detail.fixture'
+import type { MemoryAgentDetail as ApiMemoryAgentDetail, MemoryAgentSummary as ApiMemoryAgentSummary, MemoryDocument } from '@contracts/read-models'
 import { memoryAgentSummaryFixture } from '@/modules/memory/view-models/memory-agent-summary.fixture'
 import { getMugiwaraProfile, MUGIWARA_SLUGS, type MugiwaraSlug } from '@/shared/mugiwara/crest-map'
 import { MugiwaraCrest } from '@/shared/mugiwara/MugiwaraCrest'
 import { PageHeader } from '@/shared/ui/app-shell/PageHeader'
 import { SurfaceCard } from '@/shared/ui/cards/SurfaceCard'
 import { StatePanel } from '@/shared/ui/state/StatePanel'
-import { SourceStatePills } from '@/shared/ui/status/SourceStatePills'
 import { StatusBadge } from '@/shared/ui/status/StatusBadge'
 import { appTheme, type AppStatus } from '@/shared/theme/tokens'
-
-const sourceLabelMap: Record<MemorySourceKey, string> = {
-  'built-in': 'Built-in',
-  honcho: 'Honcho',
-}
 
 function formatTimestamp(value: string | null) {
   if (!value) {
@@ -36,81 +29,71 @@ function formatTimestamp(value: string | null) {
   }).format(date)
 }
 
-function mapSourceStateToStatus(state: MemorySourceState): AppStatus {
-  switch (state) {
-    case 'initialized':
+function formatSize(value: number | null) {
+  if (value === null) {
+    return 'sin tamaño'
+  }
+
+  if (value < 1024) {
+    return `${value} B`
+  }
+
+  return `${(value / 1024).toFixed(1)} KB`
+}
+
+function mapDocumentStatusToAppStatus(status: MemoryDocument['status'] | 'fallback'): AppStatus {
+  switch (status) {
+    case 'available':
       return 'operativo'
-    case 'stale':
-      return 'stale'
+    case 'empty':
+      return 'sin-datos'
+    case 'absent':
+      return 'revision'
     case 'error':
       return 'incidencia'
-    case 'unavailable':
+    case 'fallback':
     default:
-      return 'sin-datos'
-  }
-}
-
-function mapFreshnessToSourceState(status: ApiMemoryAgentDetail['freshness']['status']): MemorySourceState {
-  switch (status) {
-    case 'fresh':
-      return 'initialized'
-    case 'stale':
       return 'stale'
-    case 'unknown':
-    default:
-      return 'unavailable'
   }
 }
 
-function mapApiDetailToViewModel(detail: ApiMemoryAgentDetail): MemoryAgentDetail {
-  const sourceState = mapFreshnessToSourceState(detail.freshness.status)
-  const updatedAt = detail.freshness.updated_at ?? new Date(0).toISOString()
+function getDocumentNotice(document: MemoryDocument | null, mugiwaraName: string) {
+  if (!document) {
+    return {
+      status: 'stale' as AppStatus,
+      title: 'MEMORY.md no cargado desde API',
+      description: `No hay lectura real de MEMORY.md para ${mugiwaraName}. La página mantiene solo el selector allowlisted y el resumen saneado.`,
+      detail: 'Configura MUGIWARA_CONTROL_PANEL_API_URL en el runtime server-only para lectura real.',
+    }
+  }
+
+  if (document.status === 'available') {
+    return null
+  }
+
+  if (document.status === 'empty') {
+    return {
+      status: 'sin-datos' as AppStatus,
+      title: 'MEMORY.md vacío',
+      description: `El fichero MEMORY.md de ${mugiwaraName} existe, pero no contiene texto visible.`,
+      detail: document.message,
+    }
+  }
+
+  if (document.status === 'absent') {
+    return {
+      status: 'revision' as AppStatus,
+      title: 'MEMORY.md ausente',
+      description: `No se ha encontrado MEMORY.md para ${mugiwaraName} dentro del catálogo allowlisted del backend.`,
+      detail: document.message,
+    }
+  }
 
   return {
-    mugiwara_slug: detail.mugiwara_slug as MugiwaraSlug,
-    built_in: {
-      state: sourceState,
-      updated_at: updatedAt,
-      summary: detail.built_in_summary,
-      availability: detail.freshness.source_label ?? 'Resumen built-in saneado desde API.',
-      facts: detail.built_in_summary ? [detail.built_in_summary] : [],
-    },
-    honcho: {
-      state: detail.honcho_facts.length > 0 ? sourceState : 'unavailable',
-      updated_at: updatedAt,
-      summary: detail.honcho_facts.length > 0 ? 'Facts Honcho resumidos y allowlisted desde API.' : 'Sin facts Honcho resumidos disponibles.',
-      availability: detail.honcho_facts.length > 0 ? 'Resumen Honcho saneado desde API.' : 'Honcho no configurado para esta vista saneada.',
-      facts: detail.honcho_facts,
-    },
-  }
-}
-
-function getMemoryStateNotice(snapshot: MemorySourceSnapshot, sourceLabel: string, mugiwaraName: string) {
-  switch (snapshot.state) {
-    case 'stale':
-      return {
-        status: 'stale' as const,
-        title: `${sourceLabel} disponible pero desactualizada`,
-        description: `La fuente sigue siendo legible para ${mugiwaraName}, pero conviene refrescarla antes de usarla como referencia operativa fuerte.`,
-        detail: snapshot.availability,
-      }
-    case 'error':
-      return {
-        status: 'incidencia' as const,
-        title: `${sourceLabel} con incidencia activa`,
-        description: `La última sincronización de ${sourceLabel} falló para ${mugiwaraName}. La lectura actual no debe tomarse como síntesis fiable hasta reintentar la generación.`,
-        detail: snapshot.availability,
-      }
-    case 'unavailable':
-      return {
-        status: 'sin-datos' as const,
-        title: `${sourceLabel} todavía no inicializada`,
-        description: `No hay contexto suficiente para mostrar una vista completa de ${sourceLabel} en ${mugiwaraName}. El resto del workspace debe seguir siendo navegable sin romper la superficie.`,
-        detail: snapshot.availability,
-      }
-    case 'initialized':
-    default:
-      return null
+    status: 'incidencia' as AppStatus,
+    title: 'MEMORY.md no legible',
+    description: `El backend no puede leer MEMORY.md para ${mugiwaraName} sin exponer detalles internos del host.`,
+    detail: document.message,
   }
 }
 
@@ -125,28 +108,20 @@ type MemoryClientProps = {
 
 export function MemoryClient({ apiSummaries, apiDetails, apiState, apiNotice }: MemoryClientProps) {
   const [selectedMugiwara, setSelectedMugiwara] = useState<MugiwaraSlug>('zoro')
-  const [selectedSource, setSelectedSource] = useState<MemorySourceKey>('built-in')
-
   const summaries = apiSummaries ?? memoryAgentSummaryFixture
-  const selectedApiDetail = apiDetails[selectedMugiwara]
-  const selectedDetail = selectedApiDetail
-    ? mapApiDetailToViewModel(selectedApiDetail)
-    : memoryAgentDetailFixture.find((item) => item.mugiwara_slug === selectedMugiwara) ?? memoryAgentDetailFixture[0]
-
-  const selectedSnapshot = selectedSource === 'built-in' ? selectedDetail.built_in : selectedDetail.honcho
   const selectedProfile = getMugiwaraProfile(selectedMugiwara)
   const selectedSummary = summaries.find((item) => item.mugiwara_slug === selectedMugiwara)
-  const selectedBadges = selectedSummary?.badges ?? []
-  const sourceNotice = getMemoryStateNotice(selectedSnapshot, sourceLabelMap[selectedSource], selectedProfile.name)
-  const isSnapshotMode = apiState !== 'ready'
+  const selectedDetail = apiDetails[selectedMugiwara] ?? null
+  const document = selectedDetail?.memory_document ?? null
+  const documentNotice = getDocumentNotice(document, selectedProfile.name)
 
   return (
     <>
       <PageHeader
         eyebrow="Memory"
-        title="Memoria operativa"
-        subtitle="Selector por Mugiwara, tabs Built-in/Honcho y lectura resumida de fuente, manteniendo separación explícita respecto a Vault."
-        detailPills={['Continuidad viva', 'Fuentes separadas', apiState === 'ready' ? 'API solo lectura' : 'Fallback saneado']}
+        title="MEMORY.md por Mugiwara"
+        subtitle="Selector allowlisted y visor read-only del MEMORY.md builtin de cada perfil. Sin Honcho, sin Vault, sin Engram y sin rutas internas visibles."
+        detailPills={[apiState === 'ready' ? 'API solo lectura' : 'Fallback saneado', 'Allowlist cerrada', 'Markdown read-only']}
       />
 
       {apiNotice ? (
@@ -156,55 +131,20 @@ export function MemoryClient({ apiSummaries, apiDetails, apiState, apiNotice }: 
             title={apiNotice.title}
             description={apiNotice.description}
             detail={apiNotice.detail}
-            eyebrow="Estado de fuente"
-          >
-            <SourceStatePills
-              items={[
-                { label: 'Modo fallback local', tone: 'fallback' },
-                { label: 'Snapshot saneado', tone: 'snapshot' },
-                { label: 'No tiempo real', tone: 'not-realtime' },
-              ]}
-            />
-          </StatePanel>
+            eyebrow="Estado de API"
+          />
         </section>
       ) : null}
 
       <section className="layout-grid layout-grid--sidebar-detail">
-        <div style={{ display: 'grid', gap: '14px' }}>
-          <SurfaceCard title="Memoria operativa" elevated eyebrow="Contexto" accent="sky">
-            <div style={{ display: 'grid', gap: '10px' }}>
-              <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
-                Memory muestra continuidad por Mugiwara y estado resumido de fuentes. No es una superficie editable ni se mezcla con el canon curado del Vault.
-              </p>
-              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                <StatusBadge
-                  status={apiState === 'ready' ? 'operativo' : 'revision'}
-                  label={isSnapshotMode ? 'Snapshot local visible' : undefined}
-                />
-                <span
-                  style={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    borderRadius: '999px',
-                    padding: '4px 10px',
-                    background: appTheme.colors.bgSurface1,
-                    border: `1px solid ${appTheme.colors.borderSubtle}`,
-                    color: appTheme.colors.brandSky500,
-                    fontSize: '12px',
-                    fontWeight: 700,
-                  }}
-                >
-                  Solo lectura
-                </span>
-              </div>
-            </div>
-          </SurfaceCard>
-
+        <aside style={{ display: 'grid', gap: '14px' }}>
           <SurfaceCard title="Selector de Mugiwara" elevated eyebrow="Tripulación" accent="gold">
             <div style={{ display: 'grid', gap: '10px' }}>
               {MUGIWARA_SLUGS.map((slug) => {
                 const profile = getMugiwaraProfile(slug)
                 const summary = summaries.find((item) => item.mugiwara_slug === slug)
+                const detail = apiDetails[slug]
+                const status = mapDocumentStatusToAppStatus(detail?.memory_document.status ?? 'fallback')
                 const isSelected = slug === selectedMugiwara
 
                 return (
@@ -233,32 +173,25 @@ export function MemoryClient({ apiSummaries, apiDetails, apiState, apiNotice }: 
                           <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>{profile.role}</span>
                         </div>
                       </div>
-                      <StatusBadge
-                        status={summary && summary.fact_count >= 5 ? 'operativo' : 'revision'}
-                        label={isSnapshotMode && summary && summary.fact_count >= 5 ? 'Operativo en último corte' : undefined}
-                      />
+                      <StatusBadge status={status} />
                     </div>
-                    {summary ? (
-                      <>
-                        <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{summary.summary}</span>
-                        <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>
-                          {summary.fact_count} facts · {isSnapshotMode ? 'corte del snapshot' : 'actualizado'} {formatTimestamp(summary.last_updated)}
-                        </span>
-                      </>
-                    ) : (
-                      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>Sin resumen cargado.</span>
-                    )}
+                    <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
+                      {summary?.summary ?? 'Sin resumen cargado.'}
+                    </span>
+                    <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>
+                      {detail?.memory_document.display_path ?? `${slug}/MEMORY.md`} · {detail?.memory_document.message ?? 'lectura real no disponible'}
+                    </span>
                   </button>
                 )
               })}
             </div>
           </SurfaceCard>
-        </div>
+        </aside>
 
-        <div style={{ display: 'grid', gap: '14px' }}>
-          <SurfaceCard title="Fuentes de memoria" elevated eyebrow="Fuentes" accent="sky">
+        <main style={{ display: 'grid', gap: '14px' }}>
+          <SurfaceCard title="Estado del documento" elevated eyebrow="Read-only" accent="sky">
             <div style={{ display: 'grid', gap: '12px' }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap', alignItems: 'center' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap', alignItems: 'center' }}>
                 <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
                   <MugiwaraCrest slug={selectedMugiwara} size="md" accent />
                   <div style={{ display: 'grid', gap: '2px' }}>
@@ -266,137 +199,79 @@ export function MemoryClient({ apiSummaries, apiDetails, apiState, apiNotice }: 
                     <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>{selectedProfile.role}</span>
                   </div>
                 </div>
-                <StatusBadge
-                  status={mapSourceStateToStatus(selectedSnapshot.state)}
-                  label={isSnapshotMode && mapSourceStateToStatus(selectedSnapshot.state) === 'operativo' ? 'Operativo en último corte' : undefined}
-                />
+                <StatusBadge status={mapDocumentStatusToAppStatus(document?.status ?? 'fallback')} />
               </div>
 
-              <div role="tablist" aria-label="Fuente de memoria" style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                {(['built-in', 'honcho'] as MemorySourceKey[]).map((source) => {
-                  const active = source === selectedSource
-                  return (
-                    <button
-                      key={source}
-                      type="button"
-                      role="tab"
-                      aria-selected={active}
-                      onClick={() => setSelectedSource(source)}
-                      style={{
-                        borderRadius: '999px',
-                        border: `1px solid ${active ? appTheme.colors.brandSky500 : appTheme.colors.borderSubtle}`,
-                        background: active ? appTheme.colors.bgSurface2 : appTheme.colors.bgSurface1,
-                        color: active ? appTheme.colors.brandSky500 : appTheme.colors.textSecondary,
-                        padding: '8px 14px',
-                        fontWeight: 700,
-                        cursor: 'pointer',
-                      }}
-                    >
-                      {sourceLabelMap[source]}
-                    </button>
-                  )
-                })}
+              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                <span style={pillStyle}>Path seguro: {document?.display_path ?? `${selectedMugiwara}/MEMORY.md`}</span>
+                <span style={pillStyle}>Solo lectura</span>
+                <span style={pillStyle}>Actualizado: {formatTimestamp(document?.updated_at ?? null)}</span>
+                <span style={pillStyle}>Tamaño: {formatSize(document?.size_bytes ?? null)}</span>
               </div>
 
-              <div
-                style={{
-                  display: 'grid',
-                  gap: '10px',
-                  padding: '12px',
-                  borderRadius: '12px',
-                  background: appTheme.colors.bgSurface1,
-                  border: `1px solid ${appTheme.colors.borderSubtle}`,
-                }}
-              >
-                <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Estado de fuente</span>
-                <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
-                  <StatusBadge
-                    status={mapSourceStateToStatus(selectedSnapshot.state)}
-                    label={isSnapshotMode && mapSourceStateToStatus(selectedSnapshot.state) === 'operativo' ? 'Operativo en último corte' : undefined}
-                  />
-                  <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{selectedSnapshot.availability}</span>
-                  <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>
-                    {isSnapshotMode ? 'Corte del snapshot' : 'Última actualización'}: {formatTimestamp(selectedSnapshot.updated_at)}
-                  </span>
-                </div>
-                <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>{selectedSnapshot.summary}</p>
-              </div>
-
-              {sourceNotice ? (
-                <StatePanel
-                  status={sourceNotice.status}
-                  title={sourceNotice.title}
-                  description={sourceNotice.description}
-                  detail={sourceNotice.detail}
-                  eyebrow="Estado de fuente"
-                />
-              ) : null}
-            </div>
-          </SurfaceCard>
-
-          <SurfaceCard title="Contenido resumido" elevated eyebrow="Lectura viva" accent="gold">
-            <div style={{ display: 'grid', gap: '12px' }}>
               <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>
-                Vista legible y resumida de la memoria {sourceLabelMap[selectedSource]} para {selectedProfile.name}. El detalle sigue siendo operacional y no documental.
+                {document?.message ?? 'La vista conserva el fallback saneado hasta que la API privada esté disponible en runtime server-only.'}
               </p>
-
-              {selectedBadges.length > 0 ? (
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
-                  {selectedBadges.map((badge) => (
-                    <span
-                      key={badge}
-                      style={{
-                        border: `1px solid ${appTheme.colors.borderSubtle}`,
-                        borderRadius: '999px',
-                        padding: '4px 10px',
-                        color: appTheme.colors.textSecondary,
-                        fontSize: '12px',
-                        background: appTheme.colors.bgSurface1,
-                      }}
-                    >
-                      {badge}
-                    </span>
-                  ))}
-                </div>
-              ) : (
-                <StatePanel
-                  status="sin-datos"
-                  title="Sin etiquetas visibles"
-                  description={`Todavía no hay badges resumidos para ${selectedProfile.name}. La ausencia de etiquetas no debe romper la lectura del resto del contenido.`}
-                  eyebrow="Estado vacío"
-                />
-              )}
-
-              <div style={{ display: 'grid', gap: '8px' }}>
-                {selectedSnapshot.facts.length > 0 ? (
-                  selectedSnapshot.facts.map((fact) => (
-                    <div
-                      key={fact}
-                      style={{
-                        borderRadius: '12px',
-                        border: `1px solid ${appTheme.colors.borderSubtle}`,
-                        padding: '12px',
-                        background: appTheme.colors.bgSurface1,
-                        color: appTheme.colors.textSecondary,
-                      }}
-                    >
-                      {fact}
-                    </div>
-                  ))
-                ) : (
-                  <StatePanel
-                    status={sourceNotice?.status ?? 'sin-datos'}
-                    title="Sin facts resumidos"
-                    description={`No hay hechos operativos visibles para la combinación ${selectedProfile.name} + ${sourceLabelMap[selectedSource]}.`}
-                    detail={selectedSnapshot.availability}
-                    eyebrow="Estado vacío"
-                  />
-                )}
-              </div>
             </div>
           </SurfaceCard>
-        </div>
+
+          {documentNotice ? (
+            <StatePanel
+              status={documentNotice.status}
+              title={documentNotice.title}
+              description={documentNotice.description}
+              detail={documentNotice.detail}
+              eyebrow="Estado del fichero"
+            />
+          ) : null}
+
+          <SurfaceCard title="Visor MEMORY.md" elevated eyebrow="Markdown" accent="gold">
+            {document?.markdown ? (
+              <article aria-label={`MEMORY.md de ${selectedProfile.name}`} style={{ display: 'grid', gap: '10px' }}>
+                <pre
+                  style={{
+                    margin: 0,
+                    whiteSpace: 'pre-wrap',
+                    overflowWrap: 'anywhere',
+                    color: appTheme.colors.textSecondary,
+                    background: appTheme.colors.bgSurface1,
+                    border: `1px solid ${appTheme.colors.borderSubtle}`,
+                    borderRadius: '14px',
+                    padding: '16px',
+                    lineHeight: 1.55,
+                    maxHeight: '62vh',
+                    overflow: 'auto',
+                    fontFamily: 'var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+                    fontSize: '13px',
+                  }}
+                >
+                  {document.markdown}
+                </pre>
+              </article>
+            ) : (
+              <StatePanel
+                status={documentNotice?.status ?? 'sin-datos'}
+                title="Sin contenido Markdown visible"
+                description="El visor queda vacío sin intentar leer rutas desde el navegador ni mostrar errores crudos."
+                detail={document?.message}
+                eyebrow="Visor vacío"
+              />
+            )}
+          </SurfaceCard>
+        </main>
       </section>
     </>
   )
 }
+
+const pillStyle = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  borderRadius: '999px',
+  padding: '4px 10px',
+  background: appTheme.colors.bgSurface1,
+  border: `1px solid ${appTheme.colors.borderSubtle}`,
+  color: appTheme.colors.textSecondary,
+  fontSize: '12px',
+  fontWeight: 700,
+} as const

--- a/apps/web/src/app/memory/page.tsx
+++ b/apps/web/src/app/memory/page.tsx
@@ -75,7 +75,7 @@ async function getInitialMemoryData(): Promise<InitialMemoryData> {
               : 'API Memory no disponible',
         description:
           apiError?.code === 'not_configured'
-            ? 'Mostrando snapshot local saneado. Estos resúmenes sostienen la navegación, pero no son lectura real ni tiempo real.'
+            ? 'Mostrando snapshot local saneado. Configura MUGIWARA_CONTROL_PANEL_API_URL en el runtime server-only para leer MEMORY.md real.'
             : 'La página mantiene el fallback saneado local. No se muestran dumps crudos ni detalles técnicos de memoria.',
         detail: apiError?.code ? `Estado técnico: ${apiError.code}` : undefined,
       },

--- a/packages/contracts/src/read-models.ts
+++ b/packages/contracts/src/read-models.ts
@@ -94,12 +94,23 @@ export type MemoryAgentSummary = {
   badges: string[]
 }
 
+export type MemoryDocument = {
+  status: 'available' | 'empty' | 'absent' | 'error'
+  display_path: string
+  read_only: true
+  markdown: string
+  updated_at: string | null
+  size_bytes: number | null
+  message: string
+}
+
 export type MemoryAgentDetail = {
   mugiwara_slug: string
   built_in_summary: string
   honcho_facts: string[]
   freshness: Freshness
   links: SafeLink[]
+  memory_document: MemoryDocument
 }
 
 export type VaultIndex = {


### PR DESCRIPTION
## Summary
- Reworks `/memory` around the issue #128 direction: Mugiwara selector + read-only `MEMORY.md` viewer.
- Adds backend `memory_document` read-model resolved from allowlisted profile slugs, never from frontend paths.
- Reports document states: available, empty, absent and error, with safe display path (`<slug>/MEMORY.md`).
- Removes the visible Built-in/Honcho tab model from the page and makes the UI focus on builtin `MEMORY.md` only.

## Safety / boundaries
- Frontend sends only allowlisted slugs.
- Backend rejects path-like slugs and symlink components.
- Backend returns semantic messages without host paths or raw exceptions.
- No write surface added.
- No Honcho, Vault or Engram content is mixed into the Memory page.

## Verification
- `PYTHONPATH=. pytest apps/api/tests/test_memory_api.py -q` → 8 passed
- `npm run verify:memory-server-only` → passed
- `npm --prefix apps/web run typecheck` → passed
- `npm --prefix apps/web run build` → passed
- `git diff --check` → passed
- Smoke API: `GET /api/v1/memory/zoro` returned `memory_document.status=available`, `display_path=zoro/MEMORY.md`.
- Smoke browser `/memory`: selector renders, Zoro document renders, Jinbe absent state renders, console clean.

Closes #128

Mugiwara-Agent: zoro
Signed-off-by: zoro <asistentes.mugiwara@gmail.com>
