### PR TITLE
feat: rework healthcheck operational panel

### DIFF
--- a/.engram/issue-129-healthcheck-operational-panel-closeout.md
+++ b/.engram/issue-129-healthcheck-operational-panel-closeout.md
@@ -1,0 +1,16 @@
+# Issue #129 — Healthcheck operational panel closeout
+
+## Resultado técnico
+- Backend: `GET /api/v1/healthcheck` ya no conserva un `HealthcheckService` global creado en import time; cada request construye servicio nuevo y relee fuentes fijas.
+- Contrato: `healthcheck.workspace.data.operational_checks[]` fija seis checks saneados (`gateways`, `honcho`, `docker_runtime`, `cronjobs`, `vault_sync`, `backup`).
+- Frontend: `/healthcheck` pasa a panel operativo con seis cards, estado agregado y prioridad actual; se retira la bitácora/historial visible.
+- Seguridad: Honcho y Docker quedan como estados `unknown` si no hay manifiesto saneado y no exponen datos internos, datos internos, PIDs, rutas, comandos ni logs.
+
+## Verify ejecutado
+- `PYTHONPATH=. pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` — 50 passed.
+- `npm run verify:healthcheck-review-clarity` — passed.
+- `npm --prefix apps/web run typecheck` — passed.
+
+## Pendiente antes de merge
+- Build web y smoke API/HTML/DOM.
+- PR con reviews Franky + Chopper + Usopp; no mergear sin revisión.

--- a/apps/api/src/modules/healthcheck/domain.py
+++ b/apps/api/src/modules/healthcheck/domain.py
@@ -30,6 +30,15 @@ HEALTHCHECK_SOURCE_FAMILY_IDS: tuple[str, ...] = (
     'cronjobs',
 )
 
+HEALTHCHECK_OPERATIONAL_CHECK_IDS: tuple[str, ...] = (
+    'gateways',
+    'honcho',
+    'docker_runtime',
+    'cronjobs',
+    'vault_sync',
+    'backup',
+)
+
 HEALTHCHECK_CHECK_ID_BY_SOURCE_ID: dict[str, str] = {
     'vault-sync': 'vault-sync.last-sync',
     'project-health': 'project-health.workspace',
@@ -198,6 +207,17 @@ class HealthcheckModuleCard:
     severity: str
     updated_at: str
     summary: str
+
+
+@dataclass(frozen=True)
+class HealthcheckOperationalCheck:
+    check_id: str
+    label: str
+    status: str
+    severity: str
+    updated_at: str | None
+    summary: str
+    freshness: HealthcheckFreshness
 
 
 @dataclass(frozen=True)

--- a/apps/api/src/modules/healthcheck/router.py
+++ b/apps/api/src/modules/healthcheck/router.py
@@ -6,11 +6,12 @@ from ...shared.contracts import resource_response
 from .service import HealthcheckService
 
 router = APIRouter(prefix='/api/v1/healthcheck', tags=['healthcheck'])
-_service = HealthcheckService()
 
 
 def get_healthcheck_service() -> HealthcheckService:
-    return _service
+    # Build a fresh service per request so fixed manifests are re-read live and
+    # the API cannot keep stale snapshots from router import time.
+    return HealthcheckService()
 
 
 @router.get('')

--- a/apps/api/src/modules/healthcheck/service.py
+++ b/apps/api/src/modules/healthcheck/service.py
@@ -9,6 +9,7 @@ from .domain import (
     HealthcheckEvent,
     HealthcheckFreshness,
     HealthcheckModuleCard,
+    HealthcheckOperationalCheck,
     HealthcheckRecord,
     HealthcheckSummaryBar,
     HealthcheckSummaryItem,
@@ -94,11 +95,113 @@ class HealthcheckService:
         events = self._events if self._records else ()
         return {
             'summary_bar': asdict(summary_bar),
+            'operational_checks': [asdict(check) for check in self._operational_checks()],
             'modules': [asdict(module) for module in modules],
             'events': [asdict(event) for event in events],
             'principles': list(SAFE_PRINCIPLES),
             'signals': [asdict(signal) for signal in signals],
         }
+
+
+    def _operational_checks(self) -> list[HealthcheckOperationalCheck]:
+        records_by_id = {record.module_id: record for record in self._records}
+        return [
+            self._aggregate_operational_check(
+                'gateways',
+                'Gateways',
+                [record for record in self._records if record.module_id == 'hermes-gateways' or record.module_id.startswith('gateway.')],
+                empty_summary='Gateways sin manifiesto operativo agregado.',
+            ),
+            self._static_operational_check(
+                'honcho',
+                'Honcho',
+                'unknown',
+                'unknown',
+                'Honcho no expone datos internos en Healthcheck; falta manifiesto operativo saneado.',
+            ),
+            self._static_operational_check(
+                'docker_runtime',
+                'Docker runtime',
+                'unknown',
+                'unknown',
+                'Docker runtime no expone detalles internos; falta manifiesto operativo saneado.',
+            ),
+            self._operational_check_from_record(
+                'cronjobs',
+                'Cronjobs',
+                records_by_id.get('cronjobs'),
+                empty_summary='Cronjobs sin registro operativo allowlisted.',
+            ),
+            self._operational_check_from_record(
+                'vault_sync',
+                'Vault sync',
+                records_by_id.get('vault-sync'),
+                empty_summary='Vault sync sin manifiesto operativo saneado.',
+            ),
+            self._operational_check_from_record(
+                'backup',
+                'Backup',
+                records_by_id.get('backup-health'),
+                empty_summary='Backup sin manifiesto operativo saneado.',
+            ),
+        ]
+
+    def _aggregate_operational_check(
+        self,
+        check_id: str,
+        label: str,
+        records: list[HealthcheckRecord],
+        *,
+        empty_summary: str,
+    ) -> HealthcheckOperationalCheck:
+        if not records:
+            return self._static_operational_check(check_id, label, 'not_configured', 'unknown', empty_summary)
+        record = max(records, key=lambda candidate: _STATUS_ORDER[candidate.status])
+        return self._operational_check_from_record(check_id, label, record, empty_summary=empty_summary)
+
+    def _operational_check_from_record(
+        self,
+        check_id: str,
+        label: str,
+        record: HealthcheckRecord | None,
+        *,
+        empty_summary: str,
+    ) -> HealthcheckOperationalCheck:
+        if record is None:
+            return self._static_operational_check(check_id, label, 'not_configured', 'unknown', empty_summary)
+        self._validate_record(record)
+        freshness_state = self._freshness_state_by_module.get(record.module_id, 'stale' if record.status == 'stale' else 'fresh')
+        validate_healthcheck_freshness_state(freshness_state)
+        return HealthcheckOperationalCheck(
+            check_id=check_id,
+            label=label,
+            status=record.status,
+            severity=record.severity,
+            updated_at=record.updated_at or None,
+            summary=record.summary,
+            freshness=HealthcheckFreshness(updated_at=record.updated_at or None, label=record.freshness_label, state=freshness_state),
+        )
+
+    def _static_operational_check(
+        self,
+        check_id: str,
+        label: str,
+        status: str,
+        severity: str,
+        summary: str,
+    ) -> HealthcheckOperationalCheck:
+        validate_healthcheck_status(status)
+        validate_healthcheck_severity(severity)
+        return HealthcheckOperationalCheck(
+            check_id=check_id,
+            label=label,
+            status=status,
+            severity=severity,
+            updated_at=None,
+            summary=summary,
+            freshness=HealthcheckFreshness(updated_at=None, label='Frescura desconocida', state='unknown'),
+        )
+
 
     def _summary_bar(self, modules: list[HealthcheckModuleCard]) -> HealthcheckSummaryBar:
         if not modules:

--- a/apps/api/tests/test_healthcheck_dashboard_api.py
+++ b/apps/api/tests/test_healthcheck_dashboard_api.py
@@ -16,6 +16,7 @@ from apps.api.src.modules.healthcheck.domain import (
     HealthcheckRecord,
 )
 from apps.api.src.modules.healthcheck.registry import HealthcheckSourceRegistry
+from apps.api.src.modules.healthcheck.router import get_healthcheck_service
 from apps.api.src.modules.healthcheck.source_adapters import BackupHealthManifestAdapter, CronjobsManifestAdapter, GatewayStatusManifestAdapter, ProjectHealthManifestAdapter, VaultSyncManifestAdapter
 from apps.api.src.modules.healthcheck.service import HealthcheckService
 from apps.api.src.modules.dashboard.service import DashboardService
@@ -48,7 +49,7 @@ def _record_event(event_id, source, status, timestamp):
 
 
 def _assert_no_sensitive_host_output(value):
-    forbidden = ('/srv/', '/home/', '.env', 'token', 'secret', 'password', 'raw_output', 'stdout', 'stderr', 'command')
+    forbidden = ('/srv/', '/home/', '.env', 'token', 'secret', 'password', 'raw_output', 'stdout', 'stderr', 'command', 'pid', 'container_id', 'docker_id', 'mount', 'remote_url', 'prompt_body', 'chat_id', 'delivery_target')
     if isinstance(value, dict):
         for key, item in value.items():
             assert all(term not in str(key).lower() for term in forbidden)
@@ -747,6 +748,15 @@ def test_healthcheck_returns_sanitized_workspace():
     assert data['summary_bar']['warnings'] >= 0
     assert data['summary_bar']['incidents'] >= 0
     assert data['modules']
+    assert data['operational_checks']
+    assert [check['check_id'] for check in data['operational_checks']] == [
+        'gateways',
+        'honcho',
+        'docker_runtime',
+        'cronjobs',
+        'vault_sync',
+        'backup',
+    ]
     assert data['events']
     assert isinstance(data['signals'], list)
     assert {'Repo público', 'Deny by default', 'Sin shell remoto'}.issubset(set(data['principles']))
@@ -757,11 +767,30 @@ def test_healthcheck_empty_source_is_not_configured():
     service = HealthcheckService(records=())
 
     assert service.workspace_status() == 'not_configured'
-    assert service.get_workspace()['summary_bar']['checks_total'] == 0
-    assert service.get_workspace()['summary_bar']['current_cause'] is None
-    assert service.get_workspace()['modules'] == []
-    assert service.get_workspace()['events'] == []
-    assert service.get_workspace()['signals'] == []
+    workspace = service.get_workspace()
+    assert workspace['summary_bar']['checks_total'] == 0
+    assert workspace['summary_bar']['current_cause'] is None
+    assert workspace['modules'] == []
+    assert workspace['events'] == []
+    assert workspace['signals'] == []
+    assert [check['check_id'] for check in workspace['operational_checks']] == [
+        'gateways',
+        'honcho',
+        'docker_runtime',
+        'cronjobs',
+        'vault_sync',
+        'backup',
+    ]
+    assert all(check['status'] in {'not_configured', 'unknown'} for check in workspace['operational_checks'])
+
+
+def test_healthcheck_router_builds_live_service_per_request():
+    first = get_healthcheck_service()
+    second = get_healthcheck_service()
+
+    assert isinstance(first, HealthcheckService)
+    assert isinstance(second, HealthcheckService)
+    assert first is not second
 
 
 def test_healthcheck_current_cause_is_derived_from_current_records_not_historical_events():

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,5 +1,7 @@
 import { redirect } from 'next/navigation'
 
+export const dynamic = 'force-dynamic'
+
 export default function DashboardAliasPage() {
   redirect('/')
 }

--- a/apps/web/src/app/healthcheck/page.tsx
+++ b/apps/web/src/app/healthcheck/page.tsx
@@ -9,9 +9,8 @@ import {
 import { fetchHealthcheckWorkspace, HealthcheckApiError } from '@/modules/healthcheck/api/healthcheck-http'
 import {
   healthcheckWorkspaceFixture,
-  type HealthcheckCurrentCause,
   type HealthcheckModuleCard,
-  type HealthcheckSummaryItem,
+  type HealthcheckOperationalCheck,
   type HealthcheckWorkspace,
 } from '@/modules/healthcheck/view-models/healthcheck-summary.fixture'
 import type { AppStatus } from '@/shared/theme/tokens'
@@ -41,7 +40,7 @@ async function getInitialHealthcheckData(): Promise<{ workspace: HealthcheckWork
         apiNotice: {
           status: 'revision',
           title: 'Healthcheck en modo fallback local',
-          description: 'La API respondió sin catálogo disponible. Se muestra un snapshot local saneado para conservar la lectura, pero no representa señales en tiempo real.',
+          description: 'La API respondió sin catálogo operativo disponible. Se muestra un snapshot local saneado para conservar la lectura, pero no representa señales en tiempo real.',
           detail: `Estado técnico: ${response.status}`,
         },
       }
@@ -71,7 +70,6 @@ async function getInitialHealthcheckData(): Promise<{ workspace: HealthcheckWork
   }
 }
 
-
 function getHealthcheckAccent(status: HealthcheckModuleCard['status'], severity: HealthcheckModuleCard['severity']) {
   if (status === 'fail' || severity === 'critical' || severity === 'high') {
     return 'danger' as const
@@ -93,7 +91,7 @@ function getHealthcheckCardTone(status: HealthcheckModuleCard['status'], severit
     return {
       borderColor: 'rgba(255,255,255,0.08)',
       background: 'rgba(255,255,255,0.015)',
-      opacity: 0.86,
+      opacity: 0.9,
     }
   }
 
@@ -127,88 +125,6 @@ function sortByHealthcheckTriage<T extends { status: HealthcheckModuleCard['stat
   })
 }
 
-function getCurrentCauseCopy(cause: HealthcheckCurrentCause | null) {
-  if (!cause) {
-    return null
-  }
-
-  const status = mapHealthcheckStatusToBadgeStatus(cause.status)
-  const causeLabel = cause.status === 'warn' ? `En revisión por ${cause.label}` : `${getHealthcheckStatusLabel(cause.status)} por ${cause.label}`
-  const reason = cause.warning_text && cause.warning_text !== 'Sin alerta activa.' ? cause.warning_text : cause.summary
-
-  return {
-    status,
-    title: causeLabel,
-    description: reason,
-    detail: `Causa del estado actual · Severidad ${getHealthcheckSeverityLabel(cause.severity)} · No procede de la bitácora histórica`,
-  }
-}
-
-function getPriorityCopy(module: HealthcheckModuleCard | null) {
-  if (!module) {
-    return null
-  }
-
-  if (module.status === 'fail' || module.severity === 'critical' || module.severity === 'high') {
-    return {
-      status: 'incidencia' as const,
-      title: `Prioridad actual: ${module.label}`,
-      description: module.summary,
-      detail: `${getHealthcheckStatusLabel(module.status)} · Severidad ${getHealthcheckSeverityLabel(module.severity)} · ${formatTimestamp(module.updated_at)}`,
-    }
-  }
-
-  if (module.status === 'warn' || module.status === 'stale' || module.severity === 'medium') {
-    return {
-      status: module.status === 'stale' ? ('stale' as const) : ('revision' as const),
-      title: `Acción requerida: revisar ${module.label}`,
-      description: module.summary,
-      detail: `${getHealthcheckStatusLabel(module.status)} · Severidad ${getHealthcheckSeverityLabel(module.severity)} · ${formatTimestamp(module.updated_at)}`,
-    }
-  }
-
-  return null
-}
-
-function getSnapshotAwareHealthcheckStatusLabel(status: HealthcheckModuleCard['status'], isSnapshotMode: boolean) {
-  if (!isSnapshotMode) {
-    return getHealthcheckStatusLabel(status)
-  }
-
-  return status === 'pass' ? 'Operativo en último corte' : getHealthcheckStatusLabel(status)
-}
-
-function HealthcheckStatusBadges({ status, severity, isSnapshotMode = false }: Pick<HealthcheckModuleCard | HealthcheckSummaryItem, 'status' | 'severity'> & { isSnapshotMode?: boolean }) {
-  const statusBadge = mapHealthcheckStatusToBadgeStatus(status)
-  const severityBadge = mapHealthcheckSeverityToBadgeStatus(severity)
-
-  return (
-    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
-      <StatusBadge
-        status={statusBadge}
-        label={isSnapshotMode && statusBadge === 'operativo' ? 'Operativo en último corte' : undefined}
-      />
-      {shouldRenderSeparateSeverityBadge(status, severity) ? <StatusBadge status={severityBadge} /> : null}
-      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 700 }}>
-        Severidad {getHealthcheckSeverityLabel(severity)}
-      </span>
-    </div>
-  )
-}
-
-function getHistoricalEventBadgeLabel(status: HealthcheckModuleCard['status']) {
-  const map: Record<HealthcheckModuleCard['status'], string> = {
-    pass: 'Evento histórico: operativo',
-    warn: 'Evento histórico: en revisión',
-    fail: 'Incidencia histórica',
-    stale: 'Evento histórico: desactualizado',
-    not_configured: 'Evento histórico: fuente no configurada',
-    unknown: 'Evento histórico: estado desconocido',
-  }
-
-  return map[status]
-}
-
 function formatTimestamp(value: string | null) {
   if (!value) {
     return 'Sin actualización'
@@ -226,37 +142,66 @@ function formatTimestamp(value: string | null) {
   }).format(date)
 }
 
+function HealthcheckStatusBadges({ status, severity, isSnapshotMode = false }: Pick<HealthcheckOperationalCheck, 'status' | 'severity'> & { isSnapshotMode?: boolean }) {
+  const statusBadge = mapHealthcheckStatusToBadgeStatus(status)
+  const severityBadge = mapHealthcheckSeverityToBadgeStatus(severity)
+
+  return (
+    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
+      <StatusBadge
+        status={statusBadge}
+        label={isSnapshotMode && statusBadge === 'operativo' ? 'Operativo en último corte' : undefined}
+      />
+      {shouldRenderSeparateSeverityBadge(status, severity) ? <StatusBadge status={severityBadge} /> : null}
+      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 700 }}>
+        Severidad {getHealthcheckSeverityLabel(severity)}
+      </span>
+    </div>
+  )
+}
+
+function getOperationalHeadline(workspace: HealthcheckWorkspace, checks: HealthcheckOperationalCheck[]) {
+  const priority = checks[0]
+  const isHealthy = workspace.summary_bar.incidents === 0 && workspace.summary_bar.warnings === 0
+
+  if (!priority || isHealthy) {
+    return {
+      status: 'operativo' as const,
+      title: 'Perímetro operativo sin degradación activa',
+      description: 'Los seis checks saneados están en estado operativo. La lectura es live por request cuando la API está disponible.',
+      detail: `${workspace.summary_bar.checks_total} checks operativos`,
+    }
+  }
+
+  return {
+    status: priority.status === 'fail' ? ('incidencia' as const) : priority.status === 'stale' ? ('stale' as const) : ('revision' as const),
+    title: `Prioridad actual: ${priority.label}`,
+    description: priority.summary,
+    detail: `${getHealthcheckStatusLabel(priority.status)} · Severidad ${getHealthcheckSeverityLabel(priority.severity)} · ${priority.freshness.label}`,
+  }
+}
+
 export default async function HealthcheckPage() {
   const { workspace, apiNotice } = await getInitialHealthcheckData()
   const isSnapshotMode = Boolean(apiNotice)
-  const sortedModules = sortByHealthcheckTriage(workspace.modules)
-  const sortedSignals = sortByHealthcheckTriage(workspace.signals)
-  const currentCauseNotice = getCurrentCauseCopy(workspace.summary_bar.current_cause)
-  const priorityNotice = currentCauseNotice ?? getPriorityCopy(sortedModules[0] ?? null)
-  const healthSummaryNotice =
-    workspace.summary_bar.incidents > 0
-      ? {
-          status: 'incidencia' as const,
-          title: 'Hay incidencias abiertas en el perímetro',
-          description: 'El resumen general ya no se limita a métricas: la página hace explícito que existen checks degradados que requieren atención prioritaria antes de considerar el sistema estable.',
-          detail: `${workspace.summary_bar.incidents} incidencia(s) · ${workspace.summary_bar.warnings} advertencia(s) activas`,
-        }
-      : workspace.summary_bar.warnings > 0 || workspace.summary_bar.overall_status === 'stale'
-        ? {
-            status: workspace.summary_bar.overall_status === 'stale' ? ('stale' as const) : ('revision' as const),
-            title: 'Hay advertencias operativas pendientes',
-            description: 'La superficie sigue siendo utilizable, pero conviene revisar los módulos marcados antes de cerrar la ventana de observación.',
-            detail: `${workspace.summary_bar.warnings} advertencia(s) activas`,
-          }
-        : null
+  const operationalChecks = sortByHealthcheckTriage(workspace.operational_checks ?? workspace.modules.map((module) => ({
+    check_id: module.module_id,
+    label: module.label,
+    status: module.status,
+    severity: module.severity,
+    updated_at: module.updated_at,
+    summary: module.summary,
+    freshness: { updated_at: module.updated_at, label: formatTimestamp(module.updated_at), state: module.status === 'stale' ? 'stale' : 'fresh' },
+  })))
+  const headline = getOperationalHeadline(workspace, operationalChecks)
 
   return (
     <>
       <PageHeader
         eyebrow="Healthcheck"
-        title="Salud del sistema"
-        subtitle="Resumen operativo del perímetro: estado actual, causa visible y bitácora histórica separada sin exponer metadata sensible del host."
-        detailPills={['Perímetro', 'Señales saneadas', 'Respuesta priorizada']}
+        title="Panel operativo"
+        subtitle="Seis checks vivos y saneados para leer el estado actual de Mugiwara sin historial, logs ni detalles internos del host."
+        detailPills={['Live por request', '6 checks', 'Sin datos sensibles']}
       />
 
       {apiNotice ? (
@@ -277,74 +222,52 @@ export default async function HealthcheckPage() {
         </StatePanel>
       ) : null}
 
-      <SurfaceCard title="Estado actual del Healthcheck" elevated eyebrow="Puesto médico" accent="danger">
+      <SurfaceCard title="Estado operativo actual" elevated eyebrow="Lectura live" accent={headline.status === 'incidencia' ? 'danger' : headline.status === 'revision' ? 'warning' : 'sky'}>
         <div style={{ display: 'grid', gap: '14px' }}>
           <div className="layout-grid layout-grid--cards-180" style={{ gap: '12px' }}>
             <div style={{ display: 'grid', gap: '8px' }}>
               <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Estado general</span>
               <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
-                <StatusBadge
-                  status={mapHealthcheckStatusToBadgeStatus(workspace.summary_bar.overall_status)}
-                  label={
-                    isSnapshotMode && mapHealthcheckStatusToBadgeStatus(workspace.summary_bar.overall_status) === 'operativo'
-                      ? 'Operativo en último corte'
-                      : undefined
-                  }
-                />
-                <span style={{ color: appTheme.colors.textSecondary }}>{getSnapshotAwareHealthcheckStatusLabel(workspace.summary_bar.overall_status, isSnapshotMode)}</span>
+                <StatusBadge status={mapHealthcheckStatusToBadgeStatus(workspace.summary_bar.overall_status)} />
+                <span style={{ color: appTheme.colors.textSecondary }}>{getHealthcheckStatusLabel(workspace.summary_bar.overall_status)}</span>
               </div>
             </div>
-
             <div style={{ display: 'grid', gap: '8px' }}>
-              <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Comprobaciones</span>
-              <strong style={{ fontSize: '24px' }}>{workspace.summary_bar.checks_total}</strong>
+              <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Checks</span>
+              <strong style={{ fontSize: '24px' }}>{operationalChecks.length}</strong>
             </div>
-
             <div style={{ display: 'grid', gap: '8px' }}>
               <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Advertencias</span>
               <strong style={{ fontSize: '24px' }}>{workspace.summary_bar.warnings}</strong>
             </div>
-
             <div style={{ display: 'grid', gap: '8px' }}>
               <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>Incidencias</span>
               <strong style={{ fontSize: '24px' }}>{workspace.summary_bar.incidents}</strong>
             </div>
-
             <div style={{ display: 'grid', gap: '8px' }}>
               <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>{isSnapshotMode ? 'Corte del snapshot' : 'Actualizado'}</span>
               <span style={{ color: appTheme.colors.textSecondary }}>{formatTimestamp(workspace.summary_bar.updated_at)}</span>
             </div>
           </div>
 
-          {priorityNotice ? (
-            <StatePanel
-              status={priorityNotice.status}
-              title={priorityNotice.title}
-              description={priorityNotice.description}
-              detail={priorityNotice.detail}
-              eyebrow={currentCauseNotice ? 'Causa actual' : 'Acción requerida'}
-              ariaRole={priorityNotice.status === 'incidencia' ? 'alert' : 'region'}
-              ariaLabel={currentCauseNotice ? 'Causa actual de Healthcheck' : 'Prioridad actual de Healthcheck'}
-            />
-          ) : healthSummaryNotice ? (
-            <StatePanel
-              status={healthSummaryNotice.status}
-              title={healthSummaryNotice.title}
-              description={healthSummaryNotice.description}
-              detail={healthSummaryNotice.detail}
-              eyebrow="Estado agregado"
-            />
-          ) : null}
+          <StatePanel
+            status={headline.status}
+            title={headline.title}
+            description={headline.description}
+            detail={headline.detail}
+            eyebrow="Prioridad actual"
+            ariaRole={headline.status === 'incidencia' ? 'alert' : 'region'}
+            ariaLabel="Prioridad operativa actual de Healthcheck"
+          />
         </div>
       </SurfaceCard>
 
-      <section className="section-block layout-grid layout-grid--cards-240" aria-label="Checks priorizados">
-        {sortedModules.map((module, index) => {
-          const tone = getHealthcheckCardTone(module.status, module.severity)
-
+      <section className="section-block layout-grid layout-grid--cards-240" aria-label="Operational checks">
+        {operationalChecks.map((check) => {
+          const tone = getHealthcheckCardTone(check.status, check.severity)
           return (
             <div
-              key={module.module_id}
+              key={check.check_id}
               style={{
                 border: `1px solid ${tone.borderColor}`,
                 borderRadius: appTheme.radius.lg,
@@ -352,121 +275,21 @@ export default async function HealthcheckPage() {
                 opacity: tone.opacity,
               }}
             >
-              <SurfaceCard title={module.label} elevated={index < 3} eyebrow={index === 0 ? 'Prioridad actual' : 'Check'} accent={getHealthcheckAccent(module.status, module.severity)}>
+              <SurfaceCard title={check.label} elevated eyebrow="Operational check" accent={getHealthcheckAccent(check.status, check.severity)}>
                 <div style={{ display: 'grid', gap: '10px' }}>
-                  <HealthcheckStatusBadges status={module.status} severity={module.severity} isSnapshotMode={isSnapshotMode} />
+                  <HealthcheckStatusBadges status={check.status} severity={check.severity} isSnapshotMode={isSnapshotMode} />
                   <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
-                    Estado: <strong>{getSnapshotAwareHealthcheckStatusLabel(module.status, isSnapshotMode)}</strong>
+                    Estado: <strong>{getHealthcheckStatusLabel(check.status)}</strong>
                   </span>
                   <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>
-                    {isSnapshotMode ? 'Última señal del snapshot' : 'Última señal'}: {formatTimestamp(module.updated_at)}
+                    Última señal: {formatTimestamp(check.updated_at)} · {check.freshness.label}
                   </span>
-                  <p style={{ margin: 0, color: module.status === 'pass' && module.severity === 'low' ? appTheme.colors.textMuted : appTheme.colors.textSecondary }}>{module.summary}</p>
+                  <p style={{ margin: 0, color: check.status === 'pass' && check.severity === 'low' ? appTheme.colors.textMuted : appTheme.colors.textSecondary }}>{check.summary}</p>
                 </div>
               </SurfaceCard>
             </div>
           )
         })}
-      </section>
-
-      <section className="section-block layout-grid layout-grid--content-aside">
-        <SurfaceCard title="Bitácora histórica" elevated eyebrow={isSnapshotMode ? 'Snapshot histórico' : 'Histórico'} accent="gold">
-          <p style={{ margin: '0 0 14px', color: appTheme.colors.textMuted, fontSize: '13px' }}>
-            Eventos anteriores saneados. No representan necesariamente el estado activo ni participan en la causa actual.
-          </p>
-          {workspace.events.length > 0 ? (
-            <div style={{ display: 'grid', gap: '10px' }}>
-              {workspace.events.map((event) => (
-                <article
-                  key={event.event_id}
-                  style={{
-                    border: `1px solid ${appTheme.colors.borderSubtle}`,
-                    borderRadius: appTheme.radius.md,
-                    padding: '12px',
-                    display: 'grid',
-                    gap: '8px',
-                  }}
-                >
-                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
-                    <strong>{event.source}</strong>
-                    <StatusBadge
-                      status={mapHealthcheckStatusToBadgeStatus(event.status)}
-                      label={getHistoricalEventBadgeLabel(event.status)}
-                    />
-                  </div>
-                  <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>Histórico · {formatTimestamp(event.timestamp)}</span>
-                  <p style={{ margin: 0, color: appTheme.colors.textSecondary }}>{event.detail}</p>
-                </article>
-              ))}
-            </div>
-          ) : (
-            <StatePanel
-              status="sin-datos"
-              title="Sin eventos históricos"
-              description="No hay eventos saneados visibles en la bitácora histórica. La ausencia de eventos debe expresarse explícitamente en vez de dejar un panel vacío."
-              eyebrow="Estado vacío"
-            />
-          )}
-        </SurfaceCard>
-
-        <div style={{ display: 'grid', gap: '14px' }}>
-          <SurfaceCard title="Señales del sistema" elevated eyebrow="Diagnóstico" accent="sky">
-            {workspace.signals.length > 0 ? (
-              <div style={{ display: 'grid', gap: '10px' }}>
-                {sortedSignals.map((check) => (
-                  <div
-                    key={check.check_id}
-                    style={{
-                      border: `1px solid ${appTheme.colors.borderSubtle}`,
-                      borderRadius: '12px',
-                      padding: '12px',
-                      display: 'grid',
-                      gap: '8px',
-                    }}
-                  >
-                    <div style={{ display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
-                      <strong>{check.label}</strong>
-                      <code style={{ fontSize: '12px', color: appTheme.colors.textMuted }}>{check.check_id}</code>
-                    </div>
-                    <HealthcheckStatusBadges status={check.status} severity={check.severity} isSnapshotMode={isSnapshotMode} />
-                    <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>{check.warning_text}</span>
-                    <span style={{ color: appTheme.colors.textMuted, fontSize: '12px' }}>
-                      {check.source_label} · {check.freshness.label}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <StatePanel
-                status="sin-datos"
-                title="Sin señales visibles"
-                description="Todavía no hay checks saneados para este bloque. El módulo debe conservar el marco de lectura sin fingir datos inexistentes."
-                eyebrow="Estado vacío"
-              />
-            )}
-          </SurfaceCard>
-
-          <SurfaceCard title="Principios de seguridad" elevated eyebrow="Doctrina" accent="gold">
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
-              {workspace.principles.map((principle) => (
-                <span
-                  key={principle}
-                  style={{
-                    border: `1px solid ${appTheme.colors.borderSubtle}`,
-                    borderRadius: '999px',
-                    padding: '6px 12px',
-                    background: appTheme.colors.bgSurface1,
-                    color: appTheme.colors.textSecondary,
-                    fontSize: '12px',
-                    fontWeight: 600,
-                  }}
-                >
-                  {principle}
-                </span>
-              ))}
-            </div>
-          </SurfaceCard>
-        </div>
       </section>
     </>
   )

--- a/apps/web/src/modules/healthcheck/view-models/healthcheck-summary.fixture.ts
+++ b/apps/web/src/modules/healthcheck/view-models/healthcheck-summary.fixture.ts
@@ -35,6 +35,16 @@ export type HealthcheckModuleCard = {
   summary: string
 }
 
+export type HealthcheckOperationalCheck = {
+  check_id: 'gateways' | 'honcho' | 'docker_runtime' | 'cronjobs' | 'vault_sync' | 'backup' | string
+  label: string
+  status: HealthcheckStatus
+  severity: HealthcheckSeverity
+  updated_at: string | null
+  summary: string
+  freshness: HealthcheckFreshness
+}
+
 export type HealthcheckEvent = {
   event_id: string
   source: string
@@ -56,157 +66,114 @@ export type HealthcheckSummaryItem = {
 
 export type HealthcheckWorkspace = {
   summary_bar: HealthcheckSummaryBar
+  operational_checks: HealthcheckOperationalCheck[]
   modules: HealthcheckModuleCard[]
   events: HealthcheckEvent[]
   principles: string[]
   signals: HealthcheckSummaryItem[]
 }
 
+const operationalChecks: HealthcheckOperationalCheck[] = [
+  {
+    check_id: 'gateways',
+    label: 'Gateways',
+    status: 'warn',
+    severity: 'medium',
+    updated_at: '2026-04-24T07:44:00Z',
+    summary: 'Gateway con advertencia operativa saneada en el último corte disponible.',
+    freshness: { updated_at: '2026-04-24T07:44:00Z', label: 'Actualizado hace 2 min', state: 'stale' },
+  },
+  {
+    check_id: 'honcho',
+    label: 'Honcho',
+    status: 'unknown',
+    severity: 'unknown',
+    updated_at: null,
+    summary: 'Honcho no expone datos internos en Healthcheck; falta manifiesto operativo saneado.',
+    freshness: { updated_at: null, label: 'Frescura desconocida', state: 'unknown' },
+  },
+  {
+    check_id: 'docker_runtime',
+    label: 'Docker runtime',
+    status: 'unknown',
+    severity: 'unknown',
+    updated_at: null,
+    summary: 'Docker runtime no expone detalles internos; falta manifiesto operativo saneado.',
+    freshness: { updated_at: null, label: 'Frescura desconocida', state: 'unknown' },
+  },
+  {
+    check_id: 'cronjobs',
+    label: 'Cronjobs',
+    status: 'warn',
+    severity: 'medium',
+    updated_at: '2026-04-24T07:41:00Z',
+    summary: 'La revisión nocturna ejecutó, pero queda una advertencia operativa menor en skills del job.',
+    freshness: { updated_at: '2026-04-24T07:41:00Z', label: 'Actualizado hace 5 min', state: 'stale' },
+  },
+  {
+    check_id: 'vault_sync',
+    label: 'Vault sync',
+    status: 'stale',
+    severity: 'medium',
+    updated_at: '2026-04-24T07:22:00Z',
+    summary: 'Parte del estado documental está disponible, pero algunos resúmenes necesitan refresco.',
+    freshness: { updated_at: '2026-04-24T07:22:00Z', label: 'Actualizado hace 24 min', state: 'stale' },
+  },
+  {
+    check_id: 'backup',
+    label: 'Backup',
+    status: 'pass',
+    severity: 'low',
+    updated_at: '2026-04-24T07:35:00Z',
+    summary: 'Último backup local completado y checksum disponible.',
+    freshness: { updated_at: '2026-04-24T07:35:00Z', label: 'Actualizado hace 11 min', state: 'fresh' },
+  },
+]
+
 export const healthcheckWorkspaceFixture: HealthcheckWorkspace = {
   summary_bar: {
-    overall_status: 'fail',
+    overall_status: 'stale',
     checks_total: 6,
-    warnings: 2,
-    incidents: 1,
+    warnings: 4,
+    incidents: 0,
     updated_at: '2026-04-24T07:46:00Z',
     current_cause: {
-      source_id: 'system',
-      label: 'System',
-      status: 'fail',
-      severity: 'high',
-      summary: 'Se detectó una incidencia abierta de capacidad que requiere revisión prioritaria.',
+      source_id: 'vault-sync',
+      label: 'Vault sync',
+      status: 'stale',
+      severity: 'medium',
+      summary: 'Parte del estado documental está disponible, pero algunos resúmenes necesitan refresco.',
       warning_text: 'Causa principal del snapshot saneado; no representa lectura real.',
       freshness_state: 'stale',
     },
   },
-  modules: [
-    {
-      module_id: 'cronjobs',
-      label: 'Cronjobs',
-      status: 'warn',
-      severity: 'medium',
-      updated_at: '2026-04-24T07:41:00Z',
-      summary: 'La revisión nocturna ejecutó, pero queda una advertencia operativa menor en skills del job.',
-    },
-    {
-      module_id: 'backups',
-      label: 'Backups',
-      status: 'pass',
-      severity: 'low',
-      updated_at: '2026-04-24T07:35:00Z',
-      summary: 'Último backup local completado y checksum disponible.',
-    },
-    {
-      module_id: 'gateways',
-      label: 'Gateways',
-      status: 'warn',
-      severity: 'medium',
-      updated_at: '2026-04-24T07:44:00Z',
-      summary: 'Latencia por encima del umbral recomendado en la puerta principal.',
-    },
-    {
-      module_id: 'honcho',
-      label: 'Honcho',
-      status: 'stale',
-      severity: 'medium',
-      updated_at: '2026-04-24T07:22:00Z',
-      summary: 'Parte del contexto relacional está disponible, pero algunos resúmenes necesitan refresco.',
-    },
-    {
-      module_id: 'docker',
-      label: 'Docker',
-      status: 'pass',
-      severity: 'low',
-      updated_at: '2026-04-24T07:32:00Z',
-      summary: 'Servicios contenedorizados sin incidencias visibles en este corte.',
-    },
-    {
-      module_id: 'system',
-      label: 'System',
-      status: 'fail',
-      severity: 'high',
-      updated_at: '2026-04-24T07:39:00Z',
-      summary: 'Se detectó una incidencia abierta de capacidad que requiere revisión prioritaria.',
-    },
-  ],
-  events: [
-    {
-      event_id: 'evt-cron-nightly',
-      source: 'cronjobs',
-      status: 'warn',
-      timestamp: '2026-04-24T01:33:40+02:00',
-      detail: 'Ejecución nocturna completada con advertencia saneada pendiente de revisión.',
-      kind: 'historical',
-    },
-    {
-      event_id: 'evt-gateway-latency',
-      source: 'gateways',
-      status: 'warn',
-      timestamp: '2026-04-24T07:44:00Z',
-      detail: 'Latencia sostenida por encima del umbral objetivo durante una ventana de observación anterior.',
-      kind: 'historical',
-    },
-    {
-      event_id: 'evt-system-capacity',
-      source: 'system',
-      status: 'fail',
-      timestamp: '2026-04-24T07:39:00Z',
-      detail: 'Incidencia saneada registrada en una revisión anterior; no representa por sí sola el estado activo.',
-      kind: 'historical',
-    },
-    {
-      event_id: 'evt-backup-checksum',
-      source: 'backups',
-      status: 'pass',
-      timestamp: '2026-04-24T07:35:00Z',
-      detail: 'Backup validado en una revisión anterior sin desviaciones visibles.',
-      kind: 'historical',
-    },
-  ],
+  operational_checks: operationalChecks,
+  modules: operationalChecks.map((check) => ({
+    module_id: check.check_id,
+    label: check.label,
+    status: check.status,
+    severity: check.severity,
+    updated_at: check.updated_at ?? '',
+    summary: check.summary,
+  })),
+  events: [],
   principles: [
     'Repo público',
     'Deny by default',
     'Allowlists explícitas',
     'Sin acceso arbitrario al host',
   ],
-  signals: [
-    {
-      check_id: 'api-gateway-latency',
-      label: 'API gateway latency',
-      severity: 'medium',
-      status: 'warn',
-      freshness: {
-        updated_at: '2026-04-24T07:44:00Z',
-        label: 'Actualizado hace 2 min',
-      },
-      warning_text: 'Latencia por encima del umbral recomendado.',
-      source_label: 'Gateway monitor',
-    },
-    {
-      check_id: 'memory-sync-window',
-      label: 'Memory sync window',
-      severity: 'low',
-      status: 'pass',
-      freshness: {
-        updated_at: '2026-04-24T07:43:00Z',
-        label: 'Actualizado hace 3 min',
-      },
-      warning_text: 'Sin alerta activa.',
-      source_label: 'Memory coordinator',
-    },
-    {
-      check_id: 'vault-index-refresh',
-      label: 'Vault index refresh',
-      severity: 'medium',
-      status: 'stale',
-      freshness: {
-        updated_at: '2026-04-24T07:22:00Z',
-        label: 'Actualizado hace 24 min',
-      },
-      warning_text: 'Índice desactualizado, pendiente de ciclo regular.',
-      source_label: 'Vault index service',
-    },
-  ],
+  signals: operationalChecks
+    .filter((check) => check.status !== 'pass')
+    .map((check) => ({
+      check_id: check.check_id,
+      label: check.label,
+      severity: check.severity,
+      status: check.status,
+      freshness: check.freshness,
+      warning_text: check.summary,
+      source_label: 'Healthcheck fallback saneado',
+    })),
 }
 
 export const healthcheckSummaryFixture: HealthcheckSummaryItem[] = healthcheckWorkspaceFixture.signals

--- a/docs/read-models.md
+++ b/docs/read-models.md
@@ -38,12 +38,18 @@ Uso:
 ### `healthcheck.workspace`
 Campos esperados:
 - `summary_bar` con `overall_status`, contadores, `updated_at` y `current_cause` saneado cuando el estado actual no es `pass`.
-- `modules[]` como estado vivo/current de cada fuente allowlisted.
-- `events[]` como eventos históricos saneados (`kind: historical`); no participan en `overall_status`, `warnings`, `incidents` ni `current_cause`.
+- `operational_checks[]` como contrato UI principal de seis checks saneados: `gateways`, `honcho`, `docker_runtime`, `cronjobs`, `vault_sync`, `backup`.
+- `modules[]` como estado vivo/current de cada fuente allowlisted backend-owned.
+- `events[]` se conserva solo por compatibilidad de contrato legacy y no debe renderizarse en `/healthcheck`.
 - `principles[]`
 - `signals[]` como motivos/causas actuales degradadas derivados de módulos vivos.
 
-Semántica issue #104:
+Semántica issue #129:
+- `/healthcheck` es un panel operativo vivo, simple y seguro: seis cards mobile-first basadas en `operational_checks[]`, sin historial ni bitácora visible.
+- El router construye `HealthcheckService()` por request para evitar snapshots stale de manifiestos fijos leídos en import time.
+- `honcho` y `docker_runtime` degradan de forma explícita a `unknown` cuando no existe manifiesto saneado; nunca exponen datos Honcho, datos Docker internos, PIDs, comandos, logs, rutas, remotes internos ni variables de entorno.
+
+Semántica issue #104 legacy:
 - `En revisión` (`warn`) significa que una fuente actual requiere atención, normalmente por estado operativo revisable, freshness próxima/stale, severidad media, fuente parcial/no configurada o manifiesto desconocido. La causa visible debe salir de `summary_bar.current_cause`/`signals`, no de la bitácora.
 - `current_cause` apunta al registro vivo de mayor prioridad y expone solo `source_id`, `label`, `status`, `severity`, `summary`, `warning_text` y `freshness_state` saneados.
 - La bitácora histórica puede contener eventos `fail` antiguos, pero esos eventos no elevan el estado actual ni deben mostrarse como incidencia activa.

--- a/openspec/issue-129-healthcheck-operational-panel-verify-checklist.md
+++ b/openspec/issue-129-healthcheck-operational-panel-verify-checklist.md
@@ -1,0 +1,10 @@
+# Issue #129 — verify checklist
+
+- [x] Backend evita snapshots stale creando `HealthcheckService()` por request en el router.
+- [x] `operational_checks[]` existe y contiene `gateways`, `honcho`, `docker_runtime`, `cronjobs`, `vault_sync`, `backup`.
+- [x] `/healthcheck` renderiza las seis cards operativas y elimina la bitácora/historial visible.
+- [x] Tests backend cubren contrato, degradación y ausencia de exposición sensible recursiva.
+- [x] Guardrail estático bloquea copy legacy de `Bitácora histórica` y marcadores sensibles en página.
+- [ ] `npm --prefix apps/web run build` ejecutado.
+- [ ] Smoke API/HTML/DOM ejecutado.
+- [ ] Reviews Franky/Chopper/Usopp completadas antes de merge.

--- a/openspec/issue-129-healthcheck-operational-panel.md
+++ b/openspec/issue-129-healthcheck-operational-panel.md
@@ -1,0 +1,35 @@
+# Issue #129 — Healthcheck operational panel
+
+## Objetivo
+Replantear `/healthcheck` como panel operativo vivo, simple y seguro.
+
+## Scope
+- Backend Healthcheck sin snapshots stale: el router crea `HealthcheckService()` por request para releer manifiestos fijos actuales.
+- Contrato saneado `operational_checks[]` con exactamente seis checks UI: `gateways`, `honcho`, `docker_runtime`, `cronjobs`, `vault_sync`, `backup`.
+- Frontend `/healthcheck` como seis cards simples mobile-first, sin historial ni bitácora visible.
+- Guardrails de no exposición para logs, rutas, comandos, PIDs, env vars, IDs Docker, mounts, remotes internos y datos Honcho.
+
+## Fuera de alcance
+- Ejecutar Docker, systemd, shell o Honcho desde backend.
+- Exponer registros internos de Honcho o detalles de contenedores Docker.
+- Añadir historial, eventos, bitácora o timeline visual.
+- Merge sin reviews de Franky, Chopper y Usopp.
+
+## Diseño
+- Se conserva `modules[]`/`events[]` como compatibilidad legacy, pero la UI usa `operational_checks[]`.
+- Los checks `honcho` y `docker_runtime` degradan a `unknown` si no hay manifiesto saneado, con copy seguro y sin datos internos.
+- `gateways` agrega la peor señal entre `hermes-gateways` y `gateway.<slug>`.
+- `cronjobs`, `vault_sync` y `backup` derivan de fuentes allowlisted ya existentes.
+
+## Verificación esperada
+- `PYTHONPATH=. pytest apps/api/tests/test_healthcheck_dashboard_api.py -q`
+- `npm run verify:healthcheck-review-clarity`
+- `npm run verify:health-dashboard-server-only`
+- `npm --prefix apps/web run typecheck`
+- `npm --prefix apps/web run build`
+- Smoke API/HTML/DOM confirmando `operational_checks`, seis cards y ausencia de `Bitácora histórica`.
+
+## Review routing
+- Franky: fuentes reales, thresholds, allowlists, live-per-request.
+- Chopper: no exposición Docker/Honcho/links/datos host.
+- Usopp: claridad UI/UX responsive mobile-first.

--- a/packages/contracts/src/read-models.ts
+++ b/packages/contracts/src/read-models.ts
@@ -166,6 +166,16 @@ export type HealthcheckModuleCard = {
   summary: string
 }
 
+export type HealthcheckOperationalCheck = {
+  check_id: 'gateways' | 'honcho' | 'docker_runtime' | 'cronjobs' | 'vault_sync' | 'backup'
+  label: string
+  status: HealthcheckStatus
+  severity: OperationalSeverity | 'unknown'
+  updated_at: string | null
+  summary: string
+  freshness: HealthcheckFreshness
+}
+
 export type HealthcheckEvent = {
   event_id: string
   source: string
@@ -187,6 +197,7 @@ export type HealthcheckSummary = {
 
 export type HealthcheckWorkspace = {
   summary_bar: HealthcheckSummaryBar
+  operational_checks: HealthcheckOperationalCheck[]
   modules: HealthcheckModuleCard[]
   events: HealthcheckEvent[]
   principles: string[]

--- a/scripts/check-healthcheck-review-clarity.mjs
+++ b/scripts/check-healthcheck-review-clarity.mjs
@@ -3,46 +3,78 @@ import { readFileSync } from 'node:fs'
 
 const checks = [
   {
-    file: 'apps/api/src/modules/healthcheck/service.py',
+    file: 'apps/api/src/modules/healthcheck/router.py',
     mustInclude: [
-      'HealthcheckCurrentCause',
-      "current_cause = self._current_cause(overall_record) if overall != 'pass' else None",
+      'return HealthcheckService()',
+      'fresh service per request',
+    ],
+    mustNotInclude: [
+      '_service = HealthcheckService()',
     ],
   },
   {
     file: 'apps/api/src/modules/healthcheck/domain.py',
     mustInclude: [
-      "kind: str = 'historical'",
-      'class HealthcheckCurrentCause',
+      'HEALTHCHECK_OPERATIONAL_CHECK_IDS',
+      "'gateways'",
+      "'honcho'",
+      "'docker_runtime'",
+      "'cronjobs'",
+      "'vault_sync'",
+      "'backup'",
+      'class HealthcheckOperationalCheck',
+    ],
+  },
+  {
+    file: 'apps/api/src/modules/healthcheck/service.py',
+    mustInclude: [
+      "'operational_checks'",
+      'def _operational_checks',
+      "'docker_runtime'",
+      'Docker runtime no expone detalles internos',
+      'Honcho no expone datos internos',
     ],
   },
   {
     file: 'apps/web/src/app/healthcheck/page.tsx',
     mustInclude: [
-      'Causa actual',
-      'Bitácora histórica',
-      'Eventos anteriores saneados. No representan necesariamente el estado activo',
-      'Incidencia histórica',
-      'No procede de la bitácora histórica',
+      'Panel operativo',
+      'Estado operativo actual',
+      'Operational check',
+      'Sin datos sensibles',
+      'operational_checks',
     ],
     mustNotInclude: [
+      'Bitácora histórica',
+      'Eventos anteriores saneados',
+      'Incidencia histórica',
+      'No procede de la bitácora histórica',
       'Eventos recientes',
     ],
   },
   {
     file: 'apps/api/tests/test_healthcheck_dashboard_api.py',
     mustInclude: [
-      'test_healthcheck_current_cause_is_derived_from_current_records_not_historical_events',
-      'test_healthcheck_pass_state_has_no_current_cause_even_with_historical_warning',
+      'test_healthcheck_router_builds_live_service_per_request',
+      'operational_checks',
+      'docker_runtime',
     ],
   },
-  {
-    file: 'docs/read-models.md',
-    mustInclude: [
-      'current_cause',
-      'eventos históricos',
-    ],
-  },
+]
+
+const sensitiveNeedles = [
+  'stdout',
+  'stderr',
+  'raw_output',
+  'command',
+  'pid',
+  'container_id',
+  'docker_id',
+  'mount',
+  'remote_url',
+  'prompt_body',
+  'chat_id',
+  'delivery_target',
 ]
 
 let failed = false
@@ -50,15 +82,23 @@ for (const check of checks) {
   const content = readFileSync(check.file, 'utf8')
   for (const needle of check.mustInclude ?? []) {
     if (!content.includes(needle)) {
-      console.error(`[healthcheck-review-clarity] ${check.file} must include: ${needle}`)
+      console.error(`[healthcheck-operational-panel] ${check.file} must include: ${needle}`)
       failed = true
     }
   }
   for (const needle of check.mustNotInclude ?? []) {
     if (content.includes(needle)) {
-      console.error(`[healthcheck-review-clarity] ${check.file} must not include stale copy: ${needle}`)
+      console.error(`[healthcheck-operational-panel] ${check.file} must not include stale copy: ${needle}`)
       failed = true
     }
+  }
+}
+
+const page = readFileSync('apps/web/src/app/healthcheck/page.tsx', 'utf8')
+for (const needle of sensitiveNeedles) {
+  if (page.toLowerCase().includes(needle)) {
+    console.error(`[healthcheck-operational-panel] page must not render sensitive marker: ${needle}`)
+    failed = true
   }
 }
 
@@ -66,4 +106,4 @@ if (failed) {
   process.exit(1)
 }
 
-console.log('Healthcheck review clarity guardrail passed')
+console.log('Healthcheck operational panel guardrail passed')


### PR DESCRIPTION
## Objetivo

Implementa #129: replantea `/healthcheck` como panel operativo vivo, simple y seguro.

## Cambios

- Backend: evita snapshots stale creando `HealthcheckService()` por request en el router.
- Contrato: añade `healthcheck.workspace.operational_checks[]` con 6 checks saneados:
  - `gateways`
  - `honcho`
  - `docker_runtime`
  - `cronjobs`
  - `vault_sync`
  - `backup`
- UI: reescribe `/healthcheck` como 6 cards operativas mobile-first, sin historial ni bitácora.
- Seguridad/no-leakage: endurece tests y guardrail para no exponer logs, rutas internas, comandos, PIDs, IDs Docker, mounts, remotes internos, prompt/chat/delivery data, `.env`, tokens ni secretos.
- Docs/SDD: añade OpenSpec, checklist de verificación y closeout Engram.
- Guardrail server-only: fuerza dynamic rendering también en alias `/dashboard` para que `verify:health-dashboard-server-only` cubra correctamente healthcheck/dashboard.

## Verificación de Zoro

- `npm run verify:health-dashboard-server-only` ✅
- `npm run verify:healthcheck-review-clarity` ✅
- `PYTHONPATH=. pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` ✅ `50 passed`
- `npm --prefix apps/web run typecheck` ✅
- `npm --prefix apps/web run build` ✅
- `git diff --check` ✅
- Smoke API local `/api/v1/healthcheck` ✅
  - status: `ready`
  - checks: `gateways`, `honcho`, `docker_runtime`, `cronjobs`, `vault_sync`, `backup`
  - count: `6`
  - leaks: `[]`
- Smoke web local `/healthcheck` ✅ HTTP 200 y panel renderizado.

## Riesgos y revisión solicitada

No mergear sin review.

- Franky: fuentes reales, thresholds, allowlists, runtime y scripts/guardrails.
- Chopper: exposición segura de Docker/Honcho/links/datos internos.
- Usopp: claridad UI/UX, mobile-first, responsive y ausencia de ruido histórico.

## Notas

- Mantiene campos existentes del workspace además de `operational_checks[]` para compatibilidad.
- No incluye historial/bitácora en la UI.
- No expone datos internos de Docker, Honcho, paths ni comandos.
