### PR TITLE
fix: polish healthcheck UI labels

### DIFF
--- a/apps/web/src/app/healthcheck/page.tsx
+++ b/apps/web/src/app/healthcheck/page.tsx
@@ -262,7 +262,7 @@ export default async function HealthcheckPage() {
         </div>
       </SurfaceCard>
 
-      <section className="section-block layout-grid layout-grid--cards-240" aria-label="Operational checks">
+      <section className="section-block layout-grid layout-grid--cards-240" aria-label="Checks operativos">
         {operationalChecks.map((check) => {
           const tone = getHealthcheckCardTone(check.status, check.severity)
           return (
@@ -275,13 +275,13 @@ export default async function HealthcheckPage() {
                 opacity: tone.opacity,
               }}
             >
-              <SurfaceCard title={check.label} elevated eyebrow="Operational check" accent={getHealthcheckAccent(check.status, check.severity)}>
+              <SurfaceCard title={check.label} elevated eyebrow="Check operativo" accent={getHealthcheckAccent(check.status, check.severity)}>
                 <div style={{ display: 'grid', gap: '10px' }}>
                   <HealthcheckStatusBadges status={check.status} severity={check.severity} isSnapshotMode={isSnapshotMode} />
                   <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
                     Estado: <strong>{getHealthcheckStatusLabel(check.status)}</strong>
                   </span>
-                  <span style={{ color: appTheme.colors.textMuted, fontSize: '13px' }}>
+                  <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px', fontWeight: 600 }}>
                     Última señal: {formatTimestamp(check.updated_at)} · {check.freshness.label}
                   </span>
                   <p style={{ margin: 0, color: check.status === 'pass' && check.severity === 'low' ? appTheme.colors.textMuted : appTheme.colors.textSecondary }}>{check.summary}</p>

--- a/scripts/check-healthcheck-review-clarity.mjs
+++ b/scripts/check-healthcheck-review-clarity.mjs
@@ -40,7 +40,7 @@ const checks = [
     mustInclude: [
       'Panel operativo',
       'Estado operativo actual',
-      'Operational check',
+      'Check operativo',
       'Sin datos sensibles',
       'operational_checks',
     ],


### PR DESCRIPTION
## Resumen
- Aplica los dos pulidos menores de Usopp en /healthcheck: eyebrow visible en español y metadatos de frescura con más peso/contraste.
- Actualiza el guardrail de claridad para fijar el nuevo copy `Check operativo`.

## Verificación
- `npm run verify:healthcheck-review-clarity`
- `npm run verify:health-dashboard-server-only`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/web run build`
- `npm run verify:visual-baseline`
- `git diff --check`
- Smoke production local /healthcheck: HTTP 200, `Check operativo` presente, `Operational check` ausente, consola browser limpia.

## Riesgo
- Bajo: UI/copy/accesibilidad visual de /healthcheck y guardrail asociado; sin cambios backend, runtime, dependencias ni frontera de datos.