### PR TITLE
fix: expose healthcheck operational read model

### DIFF
--- a/apps/api/src/modules/healthcheck/domain.py
+++ b/apps/api/src/modules/healthcheck/domain.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Mapping
 
@@ -218,6 +218,13 @@ class HealthcheckOperationalCheck:
     updated_at: str | None
     summary: str
     freshness: HealthcheckFreshness
+    display_text: str
+    metric_label: str | None = None
+    metric_value: str | None = None
+    failing_items: tuple[Mapping[str, str], ...] = field(default_factory=tuple)
+    items: tuple[Mapping[str, str], ...] = field(default_factory=tuple)
+    links: tuple[Mapping[str, str], ...] = field(default_factory=tuple)
+    facts: tuple[Mapping[str, str], ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)

--- a/apps/api/src/modules/healthcheck/service.py
+++ b/apps/api/src/modules/healthcheck/service.py
@@ -115,7 +115,15 @@ class HealthcheckService:
 
     def _operational_checks(self) -> list[HealthcheckOperationalCheck]:
         records_by_id = {record.module_id: record for record in self._records}
-        gateway_records = [record for record in self._records if record.module_id == 'hermes-gateways' or record.module_id.startswith('gateway.')]
+        default_source_records = getattr(self, '_default_source_records', {})
+        if default_source_records:
+            gateway_records = [
+                record
+                for source_id, record in default_source_records.items()
+                if source_id == 'hermes-gateways' or source_id in MUGIWARA_GATEWAY_SOURCE_IDS
+            ]
+        else:
+            gateway_records = [record for record in self._records if record.module_id == 'hermes-gateways' or record.module_id.startswith('gateway.')]
         return [
             self._gateway_operational_check(gateway_records),
             self._static_operational_check(

--- a/apps/api/src/modules/healthcheck/service.py
+++ b/apps/api/src/modules/healthcheck/service.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from dataclasses import asdict
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+import os
+from typing import TYPE_CHECKING, Mapping
 
 from .domain import (
     HealthcheckCurrentCause,
@@ -13,13 +14,22 @@ from .domain import (
     HealthcheckRecord,
     HealthcheckSummaryBar,
     HealthcheckSummaryItem,
+    MUGIWARA_GATEWAY_SOURCE_IDS,
     resolve_healthcheck_check_id,
     validate_healthcheck_freshness_state,
     validate_healthcheck_severity,
     validate_healthcheck_status,
 )
 
-from .source_adapters import BackupHealthManifestAdapter, CronjobsManifestAdapter, GatewayStatusManifestAdapter, ProjectHealthManifestAdapter, VaultSyncManifestAdapter
+from .source_adapters import (
+    BACKUP_HEALTH_STATUS_MANIFEST,
+    CRONJOBS_STATUS_MANIFEST,
+    BackupHealthManifestAdapter,
+    CronjobsManifestAdapter,
+    GatewayStatusManifestAdapter,
+    ProjectHealthManifestAdapter,
+    VaultSyncManifestAdapter,
+)
 
 if TYPE_CHECKING:
     from .registry import HealthcheckSourceSnapshot
@@ -105,46 +115,202 @@ class HealthcheckService:
 
     def _operational_checks(self) -> list[HealthcheckOperationalCheck]:
         records_by_id = {record.module_id: record for record in self._records}
+        gateway_records = [record for record in self._records if record.module_id == 'hermes-gateways' or record.module_id.startswith('gateway.')]
         return [
-            self._aggregate_operational_check(
-                'gateways',
-                'Gateways',
-                [record for record in self._records if record.module_id == 'hermes-gateways' or record.module_id.startswith('gateway.')],
-                empty_summary='Gateways sin manifiesto operativo agregado.',
-            ),
+            self._gateway_operational_check(gateway_records),
             self._static_operational_check(
                 'honcho',
                 'Honcho',
                 'unknown',
                 'unknown',
-                'Honcho no expone datos internos en Healthcheck; falta manifiesto operativo saneado.',
+                'Honcho sin manifiesto operativo saneado.',
+                display_text='Honcho pendiente de fuente segura · API/DB/Redis sin lectura saneada',
+                facts=(
+                    {'label': 'API', 'value': 'Sin manifiesto'},
+                    {'label': 'DB', 'value': 'Sin manifiesto'},
+                    {'label': 'Redis', 'value': 'Sin manifiesto'},
+                ),
             ),
             self._static_operational_check(
                 'docker_runtime',
                 'Docker runtime',
                 'unknown',
                 'unknown',
-                'Docker runtime no expone detalles internos; falta manifiesto operativo saneado.',
+                'Docker runtime crítico sin manifiesto operativo saneado.',
+                display_text='Docker runtime pendiente de fuente segura · contenedores críticos sin lectura saneada',
+                facts=(
+                    {'label': 'Críticos OK', 'value': 'Sin manifiesto'},
+                ),
             ),
-            self._operational_check_from_record(
-                'cronjobs',
-                'Cronjobs',
-                records_by_id.get('cronjobs'),
-                empty_summary='Cronjobs sin registro operativo allowlisted.',
-            ),
-            self._operational_check_from_record(
-                'vault_sync',
-                'Vault sync',
-                records_by_id.get('vault-sync'),
-                empty_summary='Vault sync sin manifiesto operativo saneado.',
-            ),
-            self._operational_check_from_record(
-                'backup',
-                'Backup',
-                records_by_id.get('backup-health'),
-                empty_summary='Backup sin manifiesto operativo saneado.',
-            ),
+            self._cronjobs_operational_check(records_by_id.get('cronjobs')),
+            self._vault_sync_operational_check(records_by_id.get('vault-sync')),
+            self._backup_operational_check(records_by_id.get('backup-health')),
         ]
+
+    def _gateway_operational_check(self, records: list[HealthcheckRecord]) -> HealthcheckOperationalCheck:
+        aggregate = self._aggregate_operational_check(
+            'gateways',
+            'Gateways',
+            records,
+            empty_summary='Gateways sin manifiesto operativo agregado.',
+        )
+        per_gateway = [record for record in records if record.module_id.startswith('gateway.')]
+        total = len(MUGIWARA_GATEWAY_SOURCE_IDS)
+        active = sum(1 for record in per_gateway if record.status == 'pass')
+        failing = tuple(
+            {
+                'id': record.module_id.removeprefix('gateway.'),
+                'label': record.label.replace(' gateway', ''),
+                'status': record.status,
+            }
+            for record in per_gateway
+            if record.status != 'pass'
+        )
+        display_text = f'{active}/{total} gateways activos'
+        if failing:
+            failed_labels = ', '.join(item['label'] for item in failing[:3])
+            display_text = f'{active}/{total} gateways activos — fallo en: {failed_labels}'
+        return self._copy_operational_check(
+            aggregate,
+            display_text=display_text,
+            metric_label='Gateways activos',
+            metric_value=f'{active}/{total}',
+            failing_items=failing,
+        )
+
+    def _cronjobs_operational_check(self, record: HealthcheckRecord | None) -> HealthcheckOperationalCheck:
+        check = self._operational_check_from_record(
+            'cronjobs',
+            'Cronjobs',
+            record,
+            empty_summary='Cronjobs sin registro operativo allowlisted.',
+        )
+        jobs = self._safe_cronjob_items() if record is not None else ()
+        total = len(jobs)
+        operational = sum(1 for item in jobs if item['status'] == 'pass')
+        failing = tuple(item for item in jobs if item['status'] != 'pass')
+        if total == 0:
+            display_text = 'Cronjobs sin registro operativo saneado'
+            metric_value = '0/0'
+        elif failing:
+            failed_labels = ', '.join(item['label'] for item in failing[:3])
+            display_text = f'{operational}/{total} cronjobs operativos — fallo en: {failed_labels}'
+            metric_value = f'{operational}/{total}'
+        else:
+            display_text = f'{operational}/{total} cronjobs operativos'
+            metric_value = f'{operational}/{total}'
+        return self._copy_operational_check(
+            check,
+            display_text=display_text,
+            metric_label='Cronjobs operativos',
+            metric_value=metric_value,
+            failing_items=failing,
+            items=jobs,
+        )
+
+    def _vault_sync_operational_check(self, record: HealthcheckRecord | None) -> HealthcheckOperationalCheck:
+        check = self._operational_check_from_record(
+            'vault_sync',
+            'Vault sync',
+            record,
+            empty_summary='Vault sync sin manifiesto operativo saneado.',
+        )
+        repo_url = self._safe_url(os.environ.get('MUGIWARA_HEALTHCHECK_VAULT_REPO_URL')) or 'https://github.com/asistentes-mugiwara/vault'
+        links = ({'label': 'Repo vault', 'href': repo_url},)
+        return self._copy_operational_check(
+            check,
+            display_text=f'Último correcto: {check.freshness.updated_at or "sin timestamp"} · repo',
+            metric_label='Último sync correcto',
+            metric_value=check.freshness.updated_at or 'Sin actualización',
+            links=links,
+        )
+
+    def _backup_operational_check(self, record: HealthcheckRecord | None) -> HealthcheckOperationalCheck:
+        check = self._operational_check_from_record(
+            'backup',
+            'Backup',
+            record,
+            empty_summary='Backup sin manifiesto operativo saneado.',
+        )
+        manifest = self._read_safe_manifest(BACKUP_HEALTH_STATUS_MANIFEST)
+        retention = manifest.get('retention_count') if isinstance(manifest, Mapping) else None
+        checksum = manifest.get('checksum_present') if isinstance(manifest, Mapping) else None
+        facts: list[Mapping[str, str]] = []
+        if isinstance(retention, int):
+            facts.append({'label': 'Retención', 'value': f'{retention}/4'})
+        if isinstance(checksum, bool):
+            facts.append({'label': 'Checksum', 'value': 'presente' if checksum else 'ausente'})
+        drive_url = self._safe_url(os.environ.get('MUGIWARA_HEALTHCHECK_BACKUP_DRIVE_URL'))
+        links = ({'label': 'Drive backup', 'href': drive_url},) if drive_url else ()
+        suffix = ' · Drive' if drive_url else ' · Drive no configurado'
+        return self._copy_operational_check(
+            check,
+            display_text=f'Último correcto: {check.freshness.updated_at or "sin timestamp"}{suffix}',
+            metric_label='Último backup válido',
+            metric_value=check.freshness.updated_at or 'Sin actualización',
+            links=links,
+            facts=tuple(facts),
+        )
+
+    def _copy_operational_check(
+        self,
+        check: HealthcheckOperationalCheck,
+        *,
+        display_text: str,
+        metric_label: str | None = None,
+        metric_value: str | None = None,
+        failing_items: tuple[Mapping[str, str], ...] = (),
+        items: tuple[Mapping[str, str], ...] = (),
+        links: tuple[Mapping[str, str], ...] = (),
+        facts: tuple[Mapping[str, str], ...] = (),
+    ) -> HealthcheckOperationalCheck:
+        return HealthcheckOperationalCheck(
+            check_id=check.check_id,
+            label=check.label,
+            status=check.status,
+            severity=check.severity,
+            updated_at=check.updated_at,
+            summary=check.summary,
+            freshness=check.freshness,
+            display_text=display_text,
+            metric_label=metric_label,
+            metric_value=metric_value,
+            failing_items=failing_items,
+            items=items,
+            links=links,
+            facts=facts,
+        )
+
+    def _safe_cronjob_items(self) -> tuple[Mapping[str, str], ...]:
+        manifest = self._read_safe_manifest(CRONJOBS_STATUS_MANIFEST)
+        jobs = manifest.get('jobs') if isinstance(manifest, Mapping) else None
+        if not isinstance(jobs, list):
+            return ()
+        items: list[Mapping[str, str]] = []
+        for index, job in enumerate(jobs, start=1):
+            if not isinstance(job, Mapping):
+                continue
+            raw_status = job.get('last_status') or job.get('status') or job.get('result')
+            status = 'pass' if raw_status in {'success', 'ok', 'pass'} else 'fail' if raw_status in {'error', 'failed', 'fail'} else 'warn'
+            items.append({'id': f'cronjob-{index}', 'label': f'Cronjob {index}', 'status': status})
+        return tuple(items)
+
+    def _read_safe_manifest(self, path) -> Mapping[object, object]:
+        try:
+            import json
+
+            loaded = json.loads(path.read_text(encoding='utf-8'))
+        except Exception:
+            return {}
+        return loaded if isinstance(loaded, Mapping) else {}
+
+    def _safe_url(self, value: str | None) -> str | None:
+        if not value:
+            return None
+        candidate = value.strip()
+        if candidate.startswith('https://github.com/') or candidate.startswith('https://drive.google.com/'):
+            return candidate
+        return None
 
     def _aggregate_operational_check(
         self,
@@ -180,6 +346,7 @@ class HealthcheckService:
             updated_at=record.updated_at or None,
             summary=record.summary,
             freshness=HealthcheckFreshness(updated_at=record.updated_at or None, label=record.freshness_label, state=freshness_state),
+            display_text=record.summary,
         )
 
     def _static_operational_check(
@@ -189,6 +356,9 @@ class HealthcheckService:
         status: str,
         severity: str,
         summary: str,
+        *,
+        display_text: str | None = None,
+        facts: tuple[Mapping[str, str], ...] = (),
     ) -> HealthcheckOperationalCheck:
         validate_healthcheck_status(status)
         validate_healthcheck_severity(severity)
@@ -200,6 +370,8 @@ class HealthcheckService:
             updated_at=None,
             summary=summary,
             freshness=HealthcheckFreshness(updated_at=None, label='Frescura desconocida', state='unknown'),
+            display_text=display_text or summary,
+            facts=facts,
         )
 
 

--- a/apps/api/src/modules/healthcheck/service.py
+++ b/apps/api/src/modules/healthcheck/service.py
@@ -4,6 +4,7 @@ from dataclasses import asdict
 from datetime import datetime, timezone
 import os
 from typing import TYPE_CHECKING, Mapping
+from urllib.parse import urlsplit, urlunsplit
 
 from .domain import (
     HealthcheckCurrentCause,
@@ -316,8 +317,18 @@ class HealthcheckService:
         if not value:
             return None
         candidate = value.strip()
-        if candidate.startswith('https://github.com/') or candidate.startswith('https://drive.google.com/'):
-            return candidate
+        try:
+            parsed = urlsplit(candidate)
+        except ValueError:
+            return None
+        if parsed.scheme != 'https' or parsed.username or parsed.password:
+            return None
+        hostname = parsed.hostname or ''
+        path = parsed.path.rstrip('/')
+        if hostname == 'github.com' and path == '/asistentes-mugiwara/vault':
+            return urlunsplit((parsed.scheme, hostname, path, '', ''))
+        if hostname == 'drive.google.com' and (path.startswith('/drive/folders/') or path.startswith('/file/d/')):
+            return urlunsplit((parsed.scheme, hostname, path, '', ''))
         return None
 
     def _aggregate_operational_check(

--- a/apps/api/tests/test_healthcheck_dashboard_api.py
+++ b/apps/api/tests/test_healthcheck_dashboard_api.py
@@ -771,6 +771,45 @@ def test_healthcheck_returns_sanitized_workspace():
     _assert_no_sensitive_host_output(payload)
 
 
+def test_healthcheck_operational_links_strip_sensitive_url_parts(monkeypatch):
+    monkeypatch.setenv(
+        'MUGIWARA_HEALTHCHECK_VAULT_REPO_URL',
+        'https://github.com/asistentes-mugiwara/vault?access_token=secret-token#private-fragment',
+    )
+    monkeypatch.setenv(
+        'MUGIWARA_HEALTHCHECK_BACKUP_DRIVE_URL',
+        'https://drive.google.com/drive/folders/public-folder?password=secret#internal',
+    )
+
+    workspace = HealthcheckService().get_workspace()
+    vault_sync = next(check for check in workspace['operational_checks'] if check['check_id'] == 'vault_sync')
+    backup = next(check for check in workspace['operational_checks'] if check['check_id'] == 'backup')
+
+    assert list(vault_sync['links']) == [{'label': 'Repo vault', 'href': 'https://github.com/asistentes-mugiwara/vault'}]
+    assert list(backup['links']) == [{'label': 'Drive backup', 'href': 'https://drive.google.com/drive/folders/public-folder'}]
+    assert 'access_token' not in str(workspace)
+    assert 'secret-token' not in str(workspace)
+    assert 'private-fragment' not in str(workspace)
+    assert 'password=secret' not in str(workspace)
+    assert 'internal' not in str(workspace)
+    _assert_no_sensitive_host_output(workspace)
+
+
+def test_healthcheck_operational_links_reject_credentials_and_unexpected_hosts(monkeypatch):
+    monkeypatch.setenv('MUGIWARA_HEALTHCHECK_VAULT_REPO_URL', 'https://user:pass@github.com/asistentes-mugiwara/vault')
+    monkeypatch.setenv('MUGIWARA_HEALTHCHECK_BACKUP_DRIVE_URL', 'https://drive.google.com.evil.test/drive/folders/public-folder')
+
+    workspace = HealthcheckService().get_workspace()
+    vault_sync = next(check for check in workspace['operational_checks'] if check['check_id'] == 'vault_sync')
+    backup = next(check for check in workspace['operational_checks'] if check['check_id'] == 'backup')
+
+    assert list(vault_sync['links']) == [{'label': 'Repo vault', 'href': 'https://github.com/asistentes-mugiwara/vault'}]
+    assert list(backup['links']) == []
+    assert 'github.com.evil.test' not in str(workspace)
+    assert 'user:pass' not in str(workspace)
+    _assert_no_sensitive_host_output(workspace)
+
+
 def test_healthcheck_empty_source_is_not_configured():
     service = HealthcheckService(records=())
 

--- a/apps/api/tests/test_healthcheck_dashboard_api.py
+++ b/apps/api/tests/test_healthcheck_dashboard_api.py
@@ -759,6 +759,13 @@ def test_healthcheck_returns_sanitized_workspace():
     ]
     assert data['events']
     assert isinstance(data['signals'], list)
+    gateways = next(check for check in data['operational_checks'] if check['check_id'] == 'gateways')
+    assert gateways['metric_label'] == 'Gateways activos'
+    assert '/' in gateways['metric_value']
+    assert 'gateways activos' in gateways['display_text']
+    vault_sync = next(check for check in data['operational_checks'] if check['check_id'] == 'vault_sync')
+    assert vault_sync['links'] == [{'label': 'Repo vault', 'href': 'https://github.com/asistentes-mugiwara/vault'}]
+    assert 'Último correcto' in vault_sync['display_text']
     assert {'Repo público', 'Deny by default', 'Sin shell remoto'}.issubset(set(data['principles']))
     _assert_no_sensitive_host_output(payload)
 
@@ -782,6 +789,37 @@ def test_healthcheck_empty_source_is_not_configured():
         'backup',
     ]
     assert all(check['status'] in {'not_configured', 'unknown'} for check in workspace['operational_checks'])
+    assert all(check['display_text'] for check in workspace['operational_checks'])
+    assert next(check for check in workspace['operational_checks'] if check['check_id'] == 'cronjobs')['metric_value'] == '0/0'
+    assert list(next(check for check in workspace['operational_checks'] if check['check_id'] == 'honcho')['facts']) == [
+        {'label': 'API', 'value': 'Sin manifiesto'},
+        {'label': 'DB', 'value': 'Sin manifiesto'},
+        {'label': 'Redis', 'value': 'Sin manifiesto'},
+    ]
+
+
+def test_healthcheck_operational_check_contract_exposes_safe_counters_and_failures():
+    service = HealthcheckService(
+        records=(
+            _record('gateway.luffy', 'Luffy gateway', 'pass', 'low', '2026-04-24T07:45:00Z'),
+            _record('gateway.zoro', 'Zoro gateway', 'fail', 'high', '2026-04-24T07:44:00Z'),
+            _record('cronjobs', 'Cronjobs', 'warn', 'medium', '2026-04-24T07:41:00Z'),
+            _record('vault-sync', 'Vault sync', 'pass', 'low', '2026-04-24T07:40:00Z'),
+            _record('backup-health', 'Backup', 'pass', 'low', '2026-04-24T07:35:00Z'),
+        )
+    )
+
+    workspace = service.get_workspace()
+    gateways = next(check for check in workspace['operational_checks'] if check['check_id'] == 'gateways')
+    assert gateways['metric_value'].endswith('/10')
+    assert 'fallo en: Zoro' in gateways['display_text']
+    assert list(gateways['failing_items']) == [{'id': 'zoro', 'label': 'Zoro', 'status': 'fail'}]
+
+    backup = next(check for check in workspace['operational_checks'] if check['check_id'] == 'backup')
+    assert backup['metric_label'] == 'Último backup válido'
+    assert backup['metric_value'] == '2026-04-24T07:35:00Z'
+    assert 'Drive' in backup['display_text']
+    _assert_no_sensitive_host_output(workspace)
 
 
 def test_healthcheck_router_builds_live_service_per_request():

--- a/apps/api/tests/test_healthcheck_dashboard_api.py
+++ b/apps/api/tests/test_healthcheck_dashboard_api.py
@@ -12,6 +12,7 @@ from apps.api.src.modules.healthcheck.domain import (
     HEALTHCHECK_SOURCE_LABELS,
     HEALTHCHECK_SOURCE_MANIFEST_POLICIES,
     HEALTHCHECK_STATUS_VALUES,
+    MUGIWARA_GATEWAY_SOURCE_IDS,
     HealthcheckEvent,
     HealthcheckRecord,
 )
@@ -820,6 +821,28 @@ def test_healthcheck_operational_check_contract_exposes_safe_counters_and_failur
     assert backup['metric_value'] == '2026-04-24T07:35:00Z'
     assert 'Drive' in backup['display_text']
     _assert_no_sensitive_host_output(workspace)
+
+
+def test_healthcheck_default_gateway_records_use_complete_manifest_snapshot():
+    service = HealthcheckService(
+        records=(
+            _record('hermes-gateways', 'Gateways', 'pass', 'low', '2026-04-24T07:45:00Z'),
+            _record('gateway.zoro', 'Zoro gateway', 'pass', 'low', '2026-04-24T07:45:00Z'),
+        )
+    )
+    service._default_source_records = {
+        'hermes-gateways': _record('hermes-gateways', 'Gateways', 'pass', 'low', '2026-04-24T07:45:00Z'),
+        **{
+            source_id: _record(source_id, f'{source_id.removeprefix("gateway.").title()} gateway', 'pass', 'low', '2026-04-24T07:45:00Z')
+            for source_id in MUGIWARA_GATEWAY_SOURCE_IDS
+        },
+    }
+
+    gateways = next(check for check in service.get_workspace()['operational_checks'] if check['check_id'] == 'gateways')
+
+    assert gateways['metric_value'] == '10/10'
+    assert gateways['display_text'] == '10/10 gateways activos'
+    assert list(gateways['failing_items']) == []
 
 
 def test_healthcheck_router_builds_live_service_per_request():

--- a/apps/web/src/app/healthcheck/page.tsx
+++ b/apps/web/src/app/healthcheck/page.tsx
@@ -161,10 +161,10 @@ function HealthcheckStatusBadges({ status, severity, isSnapshotMode = false }: P
 }
 
 function getOperationalHeadline(workspace: HealthcheckWorkspace, checks: HealthcheckOperationalCheck[]) {
-  const priority = checks[0]
+  const degraded = checks.filter((check) => check.status !== 'pass')
   const isHealthy = workspace.summary_bar.incidents === 0 && workspace.summary_bar.warnings === 0
 
-  if (!priority || isHealthy) {
+  if (isHealthy || degraded.length === 0) {
     return {
       status: 'operativo' as const,
       title: 'Perímetro operativo sin degradación activa',
@@ -173,11 +173,12 @@ function getOperationalHeadline(workspace: HealthcheckWorkspace, checks: Healthc
     }
   }
 
+  const incidents = degraded.filter((check) => check.status === 'fail').length
   return {
-    status: priority.status === 'fail' ? ('incidencia' as const) : priority.status === 'stale' ? ('stale' as const) : ('revision' as const),
-    title: `Prioridad actual: ${priority.label}`,
-    description: priority.summary,
-    detail: `${getHealthcheckStatusLabel(priority.status)} · Severidad ${getHealthcheckSeverityLabel(priority.severity)} · ${priority.freshness.label}`,
+    status: incidents > 0 ? ('incidencia' as const) : ('revision' as const),
+    title: incidents > 0 ? 'Incidencias operativas detectadas' : 'Revisión operativa pendiente',
+    description: `${degraded.length} de ${checks.length} checks requieren atención. Revisa las cards saneadas para ver contadores, fallos y enlaces seguros disponibles.`,
+    detail: `${incidents} incidencias · ${Math.max(degraded.length - incidents, 0)} advertencias/revisiones`,
   }
 }
 
@@ -192,6 +193,7 @@ export default async function HealthcheckPage() {
     updated_at: module.updated_at,
     summary: module.summary,
     freshness: { updated_at: module.updated_at, label: formatTimestamp(module.updated_at), state: module.status === 'stale' ? 'stale' : 'fresh' },
+    display_text: module.summary,
   })))
   const headline = getOperationalHeadline(workspace, operationalChecks)
 
@@ -255,9 +257,9 @@ export default async function HealthcheckPage() {
             title={headline.title}
             description={headline.description}
             detail={headline.detail}
-            eyebrow="Prioridad actual"
+            eyebrow="Resumen operativo"
             ariaRole={headline.status === 'incidencia' ? 'alert' : 'region'}
-            ariaLabel="Prioridad operativa actual de Healthcheck"
+            ariaLabel="Resumen operativo actual de Healthcheck"
           />
         </div>
       </SurfaceCard>
@@ -278,13 +280,54 @@ export default async function HealthcheckPage() {
               <SurfaceCard title={check.label} elevated eyebrow="Check operativo" accent={getHealthcheckAccent(check.status, check.severity)}>
                 <div style={{ display: 'grid', gap: '10px' }}>
                   <HealthcheckStatusBadges status={check.status} severity={check.severity} isSnapshotMode={isSnapshotMode} />
+                  {check.metric_label && check.metric_value ? (
+                    <div style={{ display: 'grid', gap: '4px' }}>
+                      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 700 }}>{check.metric_label}</span>
+                      <strong style={{ color: appTheme.colors.textPrimary, fontSize: '22px' }}>{check.metric_value}</strong>
+                    </div>
+                  ) : null}
                   <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px' }}>
                     Estado: <strong>{getHealthcheckStatusLabel(check.status)}</strong>
                   </span>
                   <span style={{ color: appTheme.colors.textSecondary, fontSize: '13px', fontWeight: 600 }}>
                     Última señal: {formatTimestamp(check.updated_at)} · {check.freshness.label}
                   </span>
-                  <p style={{ margin: 0, color: check.status === 'pass' && check.severity === 'low' ? appTheme.colors.textMuted : appTheme.colors.textSecondary }}>{check.summary}</p>
+                  <p style={{ margin: 0, color: check.status === 'pass' && check.severity === 'low' ? appTheme.colors.textMuted : appTheme.colors.textSecondary }}>{check.display_text ?? check.summary}</p>
+                  {check.failing_items?.length ? (
+                    <div style={{ display: 'grid', gap: '6px' }}>
+                      <span style={{ color: appTheme.colors.textMuted, fontSize: '12px', fontWeight: 700 }}>Fallo en</span>
+                      <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+                        {check.failing_items.map((item) => (
+                          <StatusBadge key={item.id} status={mapHealthcheckStatusToBadgeStatus(item.status)} label={item.label} />
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                  {check.items?.length ? (
+                    <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+                      {check.items.map((item) => (
+                        <StatusBadge key={item.id} status={mapHealthcheckStatusToBadgeStatus(item.status)} label={item.label} />
+                      ))}
+                    </div>
+                  ) : null}
+                  {check.facts?.length ? (
+                    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                      {check.facts.map((fact) => (
+                        <span key={`${fact.label}-${fact.value}`} style={{ color: appTheme.colors.textSecondary, fontSize: '12px', fontWeight: 700 }}>
+                          {fact.label}: {fact.value}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+                  {check.links?.length ? (
+                    <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                      {check.links.map((link) => (
+                        <a key={link.href} href={link.href} rel="noreferrer" target="_blank" style={{ color: appTheme.colors.brandSky500, fontSize: '13px', fontWeight: 700 }}>
+                          {link.label}
+                        </a>
+                      ))}
+                    </div>
+                  ) : null}
                 </div>
               </SurfaceCard>
             </div>

--- a/apps/web/src/modules/healthcheck/view-models/healthcheck-summary.fixture.ts
+++ b/apps/web/src/modules/healthcheck/view-models/healthcheck-summary.fixture.ts
@@ -35,6 +35,17 @@ export type HealthcheckModuleCard = {
   summary: string
 }
 
+export type HealthcheckFact = {
+  label: string
+  value: string
+}
+
+export type HealthcheckOperationalItem = {
+  id: string
+  label: string
+  status: HealthcheckStatus
+}
+
 export type HealthcheckOperationalCheck = {
   check_id: 'gateways' | 'honcho' | 'docker_runtime' | 'cronjobs' | 'vault_sync' | 'backup' | string
   label: string
@@ -43,6 +54,13 @@ export type HealthcheckOperationalCheck = {
   updated_at: string | null
   summary: string
   freshness: HealthcheckFreshness
+  display_text?: string
+  metric_label?: string | null
+  metric_value?: string | null
+  failing_items?: HealthcheckOperationalItem[]
+  items?: HealthcheckOperationalItem[]
+  links?: Array<{ label: string; href: string }>
+  facts?: HealthcheckFact[]
 }
 
 export type HealthcheckEvent = {

--- a/docs/visual-verify-baseline.md
+++ b/docs/visual-verify-baseline.md
@@ -39,7 +39,7 @@ Este comando imprime la checklist canónica por **viewport** y por **ruta**.
 - cards con ritmo visual consistente
 - estados vacíos/error/stale sin colapsar el layout
 - cuando haya fallback visible, las pills `Modo fallback local`, `Snapshot saneado` y/o `No tiempo real` deben aclarar que el contenido no es API real
-- en `/healthcheck`, la causa actual debe verse antes del grid y antes de la bitácora histórica; los checks sanos no deben competir visualmente con incidencias o advertencias
+- en `/healthcheck`, el resumen operativo y los checks operativos deben verse sin recuperar bloques visibles de `Prioridad actual` ni bitácora histórica; los contadores `N/M`, enlaces y facts saneados deben leerse sin parecer raw manifests
 
 ### Responsive fino
 - grids apilan paneles con dignidad

--- a/packages/contracts/src/read-models.ts
+++ b/packages/contracts/src/read-models.ts
@@ -166,6 +166,17 @@ export type HealthcheckModuleCard = {
   summary: string
 }
 
+export type HealthcheckFact = {
+  label: string
+  value: string
+}
+
+export type HealthcheckOperationalItem = {
+  id: string
+  label: string
+  status: HealthcheckStatus
+}
+
 export type HealthcheckOperationalCheck = {
   check_id: 'gateways' | 'honcho' | 'docker_runtime' | 'cronjobs' | 'vault_sync' | 'backup'
   label: string
@@ -174,6 +185,13 @@ export type HealthcheckOperationalCheck = {
   updated_at: string | null
   summary: string
   freshness: HealthcheckFreshness
+  display_text?: string
+  metric_label?: string | null
+  metric_value?: string | null
+  failing_items?: HealthcheckOperationalItem[]
+  items?: HealthcheckOperationalItem[]
+  links?: SafeLink[]
+  facts?: HealthcheckFact[]
 }
 
 export type HealthcheckEvent = {

--- a/scripts/check-healthcheck-review-clarity.mjs
+++ b/scripts/check-healthcheck-review-clarity.mjs
@@ -31,8 +31,11 @@ const checks = [
       "'operational_checks'",
       'def _operational_checks',
       "'docker_runtime'",
-      'Docker runtime no expone detalles internos',
-      'Honcho no expone datos internos',
+      'Docker runtime crítico sin manifiesto operativo saneado',
+      'Honcho sin manifiesto operativo saneado',
+      'display_text',
+      'metric_value',
+      'failing_items',
     ],
   },
   {

--- a/scripts/visual-verify-baseline.mjs
+++ b/scripts/visual-verify-baseline.mjs
@@ -88,9 +88,10 @@ const routes = [
     path: '/healthcheck',
     title: 'Salud del sistema',
     checks: [
-      'resumen actual, causa actual, módulos, bitácora histórica y señales respetan wrap y stacking',
-      'la causa actual aparece antes del grid y antes de la bitácora histórica cuando hay incidencia o advertencia',
+      'resumen operativo, módulos y checks operativos respetan wrap y stacking',
+      'no reaparecen bloques visibles de prioridad actual ni bitácora histórica en la vista principal',
       'badges de estado/severidad no duplican el mismo significado visual',
+      'contadores operativos N/M y enlaces/facts saneados se leen sin parecer raw manifests',
       'checks sanos mantienen menor peso visual que incidencias o advertencias',
       'si la API no está configurada, queda claro que los checks son snapshot local saneado y no tiempo real',
       'principios de seguridad y badges semánticos siguen legibles en móvil',


### PR DESCRIPTION
## Resumen
- Amplía el read-model de `/healthcheck` con campos saneados para `display_text`, métricas, fallos, items, enlaces seguros y facts compactos.
- Añade contadores visibles para gateways y cronjobs, enlace seguro del repo del vault y lectura compacta de backup/retención/checksum cuando el manifiesto lo permite.
- Sustituye la cabecera de “Prioridad actual” por un resumen operativo agregado y mantiene fuera la bitácora/histórico en la experiencia principal.

## Alcance explícito
- Cubre la microfase correctiva de #129 para que la UI deje de depender de copy genérico y lea un contrato operativo backend-owned.
- Honcho y Docker quedan representados como checks saneados con facts explícitos de “sin manifiesto” hasta que existan productores dedicados; no se inventa estado interno ni se filtran detalles del host.

## Verify ejecutado
- `PYTHONPATH=. pytest apps/api/tests/test_healthcheck_dashboard_api.py -q` → 51 passed.
- `python3 -m compileall apps/api/src/modules/healthcheck`.
- `npm --prefix apps/web run typecheck`.
- `npm run verify:healthcheck-review-clarity`.
- `npm run verify:health-dashboard-server-only`.
- `npm run verify:visual-baseline`.
- `npm --prefix apps/web run build`.
- `git diff --check`.
- Smoke local con API nueva en `127.0.0.1:8012` y web prod en `127.0.0.1:3025`: `/healthcheck` renderiza `gateways activos`, `cronjobs operativos`, `Repo vault` y `Drive`; no renderiza `Prioridad actual` ni `Bitácora histórica`.
- Browser console en `/healthcheck`: 0 mensajes, 0 errores.

## Riesgos / notas
- Cambio visible en `/healthcheck`, backend read-model y contrato TS.
- No cierra por completo productores futuros de Honcho/Docker; evita falsear datos y lo deja explícito como fuente pendiente.
- Requiere review de Franky (operación/runtime), Chopper (seguridad/saneado) y Usopp (UI/UX).

Closes #129 si los reviewers aceptan que la representación saneada de Honcho/Docker como “sin manifiesto” es suficiente para esta ronda.